### PR TITLE
Add ability to post-process results

### DIFF
--- a/__tests__/reducers/__snapshots__/create-otp-reducer.js.snap
+++ b/__tests__/reducers/__snapshots__/create-otp-reducer.js.snap
@@ -1,0 +1,249 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`reducers > createOtpReducer > default reducer handlers > should handle PLAN_ERROR action 1`] = `
+Object {
+  "activeSearch": 0,
+  "config": Object {
+    "autoPlan": true,
+    "debouncePlanTimeMs": 0,
+  },
+  "currentQuery": Object {
+    "departArrive": "NOW",
+    "from": null,
+    "mode": "TRAM,BUS,GONDOLA,WALK",
+    "to": null,
+    "type": "ITINERARY",
+  },
+  "overlay": Object {
+    "bikeRental": Object {
+      "stations": Array [],
+    },
+  },
+  "searches": Array [
+    Object {
+      "activeItinerary": 0,
+      "activeLeg": null,
+      "activeStep": null,
+      "pending": false,
+      "planResponse": Object {
+        "error": [Error: An error],
+      },
+      "query": Object {
+        "departArrive": "NOW",
+        "from": null,
+        "mode": "TRAM,BUS,GONDOLA,WALK",
+        "to": null,
+        "type": "ITINERARY",
+      },
+    },
+  ],
+  "ui": Object {
+    "showExtendedSettings": false,
+  },
+}
+`;
+
+exports[`reducers > createOtpReducer > default reducer handlers > should handle PLAN_REQUEST action 1`] = `
+Object {
+  "activeSearch": 0,
+  "config": Object {
+    "autoPlan": true,
+    "debouncePlanTimeMs": 0,
+  },
+  "currentQuery": Object {
+    "departArrive": "NOW",
+    "from": null,
+    "mode": "TRAM,BUS,GONDOLA,WALK",
+    "to": null,
+    "type": "ITINERARY",
+  },
+  "overlay": Object {
+    "bikeRental": Object {
+      "stations": Array [],
+    },
+  },
+  "searches": Array [
+    Object {
+      "activeItinerary": 0,
+      "activeLeg": null,
+      "activeStep": null,
+      "pending": true,
+      "planResponse": null,
+      "query": Object {
+        "departArrive": "NOW",
+        "from": null,
+        "mode": "TRAM,BUS,GONDOLA,WALK",
+        "to": null,
+        "type": "ITINERARY",
+      },
+    },
+  ],
+  "ui": Object {
+    "showExtendedSettings": false,
+  },
+}
+`;
+
+exports[`reducers > createOtpReducer > default reducer handlers > should handle PLAN_RESPONSE action 1`] = `
+Object {
+  "activeSearch": 0,
+  "config": Object {
+    "autoPlan": true,
+    "debouncePlanTimeMs": 0,
+  },
+  "currentQuery": Object {
+    "departArrive": "NOW",
+    "from": null,
+    "mode": "TRAM,BUS,GONDOLA,WALK",
+    "to": null,
+    "type": "ITINERARY",
+  },
+  "overlay": Object {
+    "bikeRental": Object {
+      "stations": Array [],
+    },
+  },
+  "searches": Array [
+    Object {
+      "activeItinerary": 0,
+      "activeLeg": null,
+      "activeStep": null,
+      "pending": false,
+      "planResponse": Object {
+        "fakeResponse": true,
+      },
+      "postProcessedResults": null,
+      "query": Object {
+        "departArrive": "NOW",
+        "from": null,
+        "mode": "TRAM,BUS,GONDOLA,WALK",
+        "to": null,
+        "type": "ITINERARY",
+      },
+    },
+  ],
+  "ui": Object {
+    "showExtendedSettings": false,
+  },
+}
+`;
+
+exports[`reducers > createOtpReducer > default reducer handlers > should return default initial state 1`] = `
+Object {
+  "activeSearch": 0,
+  "config": Object {
+    "autoPlan": true,
+    "debouncePlanTimeMs": 0,
+  },
+  "currentQuery": Object {
+    "departArrive": "NOW",
+    "from": null,
+    "mode": "TRAM,BUS,GONDOLA,WALK",
+    "to": null,
+    "type": "ITINERARY",
+  },
+  "overlay": Object {
+    "bikeRental": Object {
+      "stations": Array [],
+    },
+  },
+  "searches": Array [],
+  "ui": Object {
+    "showExtendedSettings": false,
+  },
+}
+`;
+
+exports[`reducers > createOtpReducer > reducer with postProcessor > should post-process results 1`] = `
+Object {
+  "activeSearch": 0,
+  "config": Object {
+    "autoPlan": true,
+    "debouncePlanTimeMs": 0,
+  },
+  "currentQuery": Object {
+    "departArrive": "NOW",
+    "from": null,
+    "mode": "TRAM,BUS,GONDOLA,WALK",
+    "to": null,
+    "type": "ITINERARY",
+  },
+  "overlay": Object {
+    "bikeRental": Object {
+      "stations": Array [],
+    },
+  },
+  "searches": Array [
+    Object {
+      "activeItinerary": 0,
+      "activeLeg": null,
+      "activeStep": null,
+      "pending": false,
+      "planResponse": Object {
+        "fakeResponse": true,
+      },
+      "postProcessedResults": Object {
+        "processed": true,
+      },
+      "query": Object {
+        "departArrive": "NOW",
+        "from": null,
+        "mode": "TRAM,BUS,GONDOLA,WALK",
+        "to": null,
+        "type": "ITINERARY",
+      },
+    },
+  ],
+  "ui": Object {
+    "showExtendedSettings": false,
+  },
+}
+`;
+
+exports[`reducers > createOtpReducer > reducer with postProcessor > should post-process results 2`] = `
+Array [
+  Array [
+    Object {
+      "activeSearch": 0,
+      "config": Object {
+        "autoPlan": true,
+        "debouncePlanTimeMs": 0,
+      },
+      "currentQuery": Object {
+        "departArrive": "NOW",
+        "from": null,
+        "mode": "TRAM,BUS,GONDOLA,WALK",
+        "to": null,
+        "type": "ITINERARY",
+      },
+      "overlay": Object {
+        "bikeRental": Object {
+          "stations": Array [],
+        },
+      },
+      "searches": Array [
+        Object {
+          "activeItinerary": 0,
+          "activeLeg": null,
+          "activeStep": null,
+          "pending": true,
+          "planResponse": null,
+          "query": Object {
+            "departArrive": "NOW",
+            "from": null,
+            "mode": "TRAM,BUS,GONDOLA,WALK",
+            "to": null,
+            "type": "ITINERARY",
+          },
+        },
+      ],
+      "ui": Object {
+        "showExtendedSettings": false,
+      },
+    },
+    Object {
+      "fakeResponse": true,
+    },
+  ],
+]
+`;

--- a/__tests__/reducers/create-otp-reducer.js
+++ b/__tests__/reducers/create-otp-reducer.js
@@ -1,0 +1,93 @@
+/* globals describe, expect, it */
+
+import createOtpReducer from '../../lib/reducers/create-otp-reducer'
+
+describe('reducers > createOtpReducer >', () => {
+  describe('default reducer handlers >', () => {
+    it('should return default initial state', () => {
+      const defaultReducer = createOtpReducer({}, {})
+      expect(
+        stripDateAndTimeFromReducerState(
+          defaultReducer(undefined, {type: 'init'})
+        )
+      ).toMatchSnapshot()
+    })
+
+    it('should handle PLAN_REQUEST action', () => {
+      const defaultReducer = createOtpReducer({}, {})
+      const defaultReducerState = defaultReducer(undefined, {type: 'init'})
+      expect(
+        stripDateAndTimeFromReducerState(
+          defaultReducer(defaultReducerState, {type: 'PLAN_REQUEST'})
+        )
+      ).toMatchSnapshot()
+    })
+
+    it('should handle PLAN_ERROR action', () => {
+      const defaultReducer = createOtpReducer({}, {})
+      const defaultReducerState = defaultReducer(undefined, {type: 'init'})
+      const pendingReducerState = defaultReducer(defaultReducerState, {type: 'PLAN_REQUEST'})
+      expect(
+        stripDateAndTimeFromReducerState(
+          defaultReducer(pendingReducerState, {
+            type: 'PLAN_ERROR',
+            payload: new Error('An error')
+          })
+        )
+      ).toMatchSnapshot()
+    })
+
+    it('should handle PLAN_RESPONSE action', () => {
+      const defaultReducer = createOtpReducer({}, {})
+      const defaultReducerState = defaultReducer(undefined, {type: 'init'})
+      const pendingReducerState = defaultReducer(defaultReducerState, {type: 'PLAN_REQUEST'})
+      expect(
+        stripDateAndTimeFromReducerState(
+          defaultReducer(pendingReducerState, {
+            type: 'PLAN_RESPONSE',
+            payload: { fakeResponse: true }
+          })
+        )
+      ).toMatchSnapshot()
+    })
+  })
+
+  describe('reducer with postProcessor >', () => {
+    it('should post-process results', () => {
+      const postProcessor = jest.fn((state, results) => ({ processed: true }))
+      const defaultReducer = createOtpReducer({}, {}, postProcessor)
+      const defaultReducerState = defaultReducer(undefined, {type: 'init'})
+      const pendingReducerState = defaultReducer(defaultReducerState, {type: 'PLAN_REQUEST'})
+      expect(
+        stripDateAndTimeFromReducerState(
+          defaultReducer(pendingReducerState, {
+            type: 'PLAN_RESPONSE',
+            payload: { fakeResponse: true }
+          })
+        )
+      ).toMatchSnapshot()
+      expect(postProcessor.mock.calls).toMatchSnapshot()
+    })
+  })
+})
+
+function stripDateAndTimeFromQuery (query) {
+  // assert that date and time exist and then remove them
+  expect(query.date).toEqual(expect.stringMatching(/\d{4}-\d{2}-\d{2}/))
+  delete query.date
+  expect(query.time).toEqual(expect.stringMatching(/\d{2}:\d{2}/))
+  delete query.time
+}
+
+function stripDateAndTimeFromReducerState (reducerState) {
+  stripDateAndTimeFromQuery(reducerState.currentQuery)
+
+  // also remove from searches
+  if (reducerState.searches) {
+    reducerState.searches.forEach(search => {
+      stripDateAndTimeFromQuery(search.query)
+    })
+  }
+
+  return reducerState
+}

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -23,12 +23,12 @@ const defaultQuery = {
 
 // TODO: fire planTrip action if default query is complete/error-free
 
-function createOtpReducer (config, initialQuery) {
+function createOtpReducer (config, initialQuery, resultPostProcessor) {
   defaultQuery.mode = defaultQuery.mode || config.modes[0] || 'TRANSIT,WALK'
   // populate query by merging any provided query params w/ the default params
-  const currentQuery = Object.assign(defaultQuery, initialQuery)
+  const currentQuery = Object.assign({}, defaultQuery, initialQuery)
   const initialState = {
-    config: Object.assign(defaultConfig, config),
+    config: Object.assign({}, defaultConfig, config),
     currentQuery,
     searches: [],
     activeSearch: 0,
@@ -72,6 +72,12 @@ function createOtpReducer (config, initialQuery) {
         return update(state, {
           searches: {[latestSearchIndex]: {
             planResponse: {$set: action.payload},
+            postProcessedResults: {$set: (
+              typeof resultPostProcessor === 'function'
+                ? resultPostProcessor(state, action.payload)
+                : null
+              )
+            },
             pending: {$set: false}
           }},
           activeSearch: { $set: latestSearchIndex }

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -67,7 +67,6 @@ export function getDefaultQuery () {
   if (typeof (window) !== 'undefined') {
     params = qs.parse(window.location.hash.split('#plan?')[1])
   }
-  console.log(params)
   const from = (params.fromPlace && params.fromPlace.split(',')) || []
   const to = (params.toPlace && params.toPlace.split(',')) || []
   return {


### PR DESCRIPTION
Extend the create-otp-reducer function to allow it to accept a function that will post-process the results and save to the reducer state.