### PR TITLE
Fix duplicate bike rental label

### DIFF
--- a/lib/util/map.js
+++ b/lib/util/map.js
@@ -78,7 +78,11 @@ export function itineraryToTransitive (itin, includeGeometry) {
       })
       tdata.places.push({
         place_id: fromPlaceId,
-        place_name: leg.from.name,
+        // Do not label the from place in addition to the to place. Otherwise,
+        // in some cases (bike rental station) the label for a single place will
+        // appear twice on the rendered transitive view.
+        // See https://github.com/conveyal/trimet-mod-otp/issues/152
+        // place_name: leg.from.name,
         place_lat: leg.from.lat,
         place_lon: leg.from.lon
       })


### PR DESCRIPTION
Fixes conveyal/trimet-mod-otp#152, by not providing a label for the "from place" in addition to the "to place." Not providing a from place will prevent transitive from rendering properly, but omitting the label seems to cause no issues for any of the modes rendered (bike rental, transit, etc.).

This feels a bit hacky, but I'm hoping @demory can provide some insight here.