### PR TITLE
Don't throttle stop time update requests

### DIFF
--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -337,6 +337,8 @@ query stopQuery($stopId: [String]) {
     findStopResponse,
     findStopError,
     {
+      // find stop should not be throttled since it can make quite frequent
+      // updates when fetching stop times for a stop
       noThrottle: true,
       serviceId: 'stops',
       rewritePayload: (payload) => {

--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -337,6 +337,7 @@ query stopQuery($stopId: [String]) {
     findStopResponse,
     findStopError,
     {
+      noThrottle: true,
       serviceId: 'stops',
       rewritePayload: (payload) => {
         // convert pattern array to ID-mapped object
@@ -715,17 +716,19 @@ function createQueryAction (endpoint, responseAction, errorAction, options = {})
       url = `${api.host}${api.port ? ':' + api.port : ''}${api.path}/${endpoint}`
     }
 
-    // don't make a request to a URL that has already seen the same request
-    // within the last 10 seconds
-    const throttleKey = options.fetchOptions
-      ? `${url}-${hashObject(options.fetchOptions)}`
-      : url
-    if (throttledUrls[throttleKey] && throttledUrls[throttleKey] > now() - TEN_SECONDS) {
-      // URL already had a request within last 10 seconds, warn and exit
-      console.warn(`Request throttled for url: ${url}`)
-      return
-    } else {
-      throttledUrls[throttleKey] = now()
+    if (!options.noThrottle) {
+      // don't make a request to a URL that has already seen the same request
+      // within the last 10 seconds
+      const throttleKey = options.fetchOptions
+        ? `${url}-${hashObject(options.fetchOptions)}`
+        : url
+      if (throttledUrls[throttleKey] && throttledUrls[throttleKey] > now() - TEN_SECONDS) {
+        // URL already had a request within last 10 seconds, warn and exit
+        console.warn(`Request throttled for url: ${url}`)
+        return
+      } else {
+        throttledUrls[throttleKey] = now()
+      }
     }
     let payload
     try {


### PR DESCRIPTION
My latest changes to throttling were causing some stoptime update requests to be throttled when they probably shouldn't have been.