### PR TITLE
Fix stop viewer issues

### DIFF
--- a/lib/components/viewers/stop-viewer.js
+++ b/lib/components/viewers/stop-viewer.js
@@ -276,6 +276,7 @@ class PatternRow extends Component {
         return null
       }
     }
+    const routeName = route.shortName ? route.shortName : route.longName
 
     return (
       <div className='route-row'>
@@ -284,7 +285,7 @@ class PatternRow extends Component {
           {/* route name */}
           <div className='route-name'>
             {/* <button className='expansion-button' onClick={this._toggleExpandedView}> */}
-            <b>{route.shortName}</b> To {pattern.headsign}
+            <b>{routeName}</b> To {pattern.headsign}
             {/* </button> */}
           </div>
 

--- a/lib/components/viewers/stop-viewer.js
+++ b/lib/components/viewers/stop-viewer.js
@@ -291,7 +291,7 @@ class PatternRow extends Component {
           {/* next departure preview */}
           {stopTimes && stopTimes.length > 0 && (
             <div className='next-trip-preview'>
-              {getFormattedStopTime(sortedStopTimes[0], homeTimezone, timeFormat, stopViewerArriving)}
+              {getFormattedStopTime(sortedStopTimes[0], homeTimezone, stopViewerArriving, timeFormat)}
             </div>
           )}
 


### PR DESCRIPTION
Fixes:
- route name display (for long name only routes)
- 'Due' text display

Refs ibi-group/trimet-mod-otp#184