### PR TITLE
Fix reverse locations and clear location actions

### DIFF
--- a/lib/actions/map.js
+++ b/lib/actions/map.js
@@ -1,5 +1,7 @@
 import { createAction } from 'redux-actions'
 
+import { routingQuery } from './api'
+import { clearActiveSearch } from './form'
 import { reverse } from '../util/geocoder'
 
 /* SET_LOCATION action creator. Updates a from or to location in the store
@@ -13,10 +15,11 @@ import { reverse } from '../util/geocoder'
  *   }
  */
 
-export const clearingLocation = createAction('CLEAR_LOCATION')
-export const settingLocation = createAction('SET_LOCATION')
-export const switchingLocations = createAction('SWITCH_LOCATIONS')
+// Private actions
+const clearingLocation = createAction('CLEAR_LOCATION')
+const settingLocation = createAction('SET_LOCATION')
 
+// Public actions
 export const forgetPlace = createAction('FORGET_PLACE')
 export const rememberPlace = createAction('REMEMBER_PLACE')
 export const forgetStop = createAction('FORGET_STOP')
@@ -24,7 +27,11 @@ export const rememberStop = createAction('REMEMBER_STOP')
 
 export function clearLocation (payload) {
   return function (dispatch, getState) {
+    // Dispatch the clear location action and then clear the active search (so
+    // that the map and narrative are not showing a search when one or both
+    // locations are not defined).
     dispatch(clearingLocation(payload))
+    dispatch(clearActiveSearch())
   }
 }
 
@@ -72,6 +79,7 @@ export function setLocationToCurrent (payload) {
 export function switchLocations () {
   return function (dispatch, getState) {
     const { from, to } = getState().otp.currentQuery
+    // First, reverse the locations.
     dispatch(settingLocation({
       type: 'from',
       location: to
@@ -80,6 +88,8 @@ export function switchLocations () {
       type: 'to',
       location: from
     }))
+    // Then kick off a routing query (if the query is invalid, search will abort).
+    dispatch(routingQuery())
   }
 }
 


### PR DESCRIPTION
Previous changes caused reverse locations to not fire a search when the locations were switched.
Similar changes caused the clear location action to keep the current search visible after a location
was cleared. This commit fixes both issues.

fix ibi-group/trimet-mod-otp#215