### PR TITLE
Revert GraphQL

### DIFF
--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -888,20 +888,24 @@ function createQueryAction (endpoint, responseAction, errorAction, options = {})
   }
 }
 
-function createGraphQLQueryAction (query, variables, responseAction, errorAction, options) {
-  const endpoint = `index/graphql`
-  const fetchOptions = {
-    method: 'POST',
-    body: JSON.stringify({ query, variables }),
-    headers: { 'Content-Type': 'application/json' }
-  }
-  return createQueryAction(
-    endpoint,
-    responseAction,
-    errorAction,
-    { ...options, fetchOptions }
-  )
-}
+// TODO: Determine how we might be able to use GraphQL with the alternative
+// transit index. Currently this is not easily possible because the alternative
+// transit index does not have support for GraphQL and handling both Rest and
+// GraphQL queries could introduce potential difficulties for maintainers.
+// function createGraphQLQueryAction (query, variables, responseAction, errorAction, options) {
+//   const endpoint = `index/graphql`
+//   const fetchOptions = {
+//     method: 'POST',
+//     body: JSON.stringify({ query, variables }),
+//     headers: { 'Content-Type': 'application/json' }
+//   }
+//   return createQueryAction(
+//     endpoint,
+//     responseAction,
+//     errorAction,
+//     { ...options, fetchOptions }
+//   )
+// }
 
 /**
  * Update the browser/URL history with new parameters

--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -295,79 +295,98 @@ const findStopResponse = createAction('FIND_STOP_RESPONSE')
 const findStopError = createAction('FIND_STOP_ERROR')
 
 export function findStop (params) {
-  const query = `
-query stopQuery($stopId: [String]) {
-  stops (ids: $stopId) {
-    id: gtfsId
-    code
-    name
-    url
-    lat
-    lon
-    stoptimesForPatterns {
-      pattern {
-        id: semanticHash
-        route {
-          id: gtfsId
-          longName
-          shortName
-          sortOrder
-        }
-      }
-      stoptimes {
-        scheduledArrival
-        realtimeArrival
-        arrivalDelay
-        scheduledDeparture
-        realtimeDeparture
-        departureDelay
-        timepoint
-        realtime
-        realtimeState
-        serviceDay
-        headsign
-      }
-    }
-  }
-}
-`
-  return createGraphQLQueryAction(
-    query,
-    { stopId: params.stopId },
+  return createQueryAction(
+    `index/stops/${params.stopId}`,
     findStopResponse,
     findStopError,
     {
-      // find stop should not be throttled since it can make quite frequent
-      // updates when fetching stop times for a stop
-      noThrottle: true,
       serviceId: 'stops',
-      rewritePayload: (payload) => {
-        // convert pattern array to ID-mapped object
-        const patterns = []
-        const { stoptimesForPatterns, ...stop } = payload.data.stops[0]
-        stoptimesForPatterns.forEach(obj => {
-          const { pattern, stoptimes: stopTimes } = obj
-          // It's possible that not all stop times for a pattern will share the
-          // same headsign, but this is probably a minor edge case.
-          const headsign = stopTimes[0]
-            ? stopTimes[0].headsign
-            : pattern.route.longName
-          const patternIndex = patterns.findIndex(p =>
-            p.headsign === headsign && pattern.route.id === p.route.id)
-          if (patternIndex === -1) {
-            patterns.push({ ...pattern, headsign, stopTimes })
-          } else {
-            patterns[patternIndex].stopTimes.push(...stopTimes)
-          }
-        })
-        return {
-          ...stop,
-          patterns
-        }
-      }
+      postprocess: (payload, dispatch) => {
+        dispatch(findRoutesAtStop(params.stopId))
+        dispatch(findStopTimesForStop({ stopId: params.stopId }))
+      },
+      noThrottle: true
     }
   )
 }
+
+// TODO: Optionally substitute GraphQL queries? Note: this is not currently
+// possible because gtfsdb (the alternative transit index used by TriMet) does not
+// support GraphQL queries.
+// export function findStop (params) {
+//   const query = `
+// query stopQuery($stopId: [String]) {
+//   stops (ids: $stopId) {
+//     id: gtfsId
+//     code
+//     name
+//     url
+//     lat
+//     lon
+//     stoptimesForPatterns {
+//       pattern {
+//         id: semanticHash
+//         route {
+//           id: gtfsId
+//           longName
+//           shortName
+//           sortOrder
+//         }
+//       }
+//       stoptimes {
+//         scheduledArrival
+//         realtimeArrival
+//         arrivalDelay
+//         scheduledDeparture
+//         realtimeDeparture
+//         departureDelay
+//         timepoint
+//         realtime
+//         realtimeState
+//         serviceDay
+//         headsign
+//       }
+//     }
+//   }
+// }
+// `
+//   return createGraphQLQueryAction(
+//     query,
+//     { stopId: params.stopId },
+//     findStopResponse,
+//     findStopError,
+//     {
+//       // find stop should not be throttled since it can make quite frequent
+//       // updates when fetching stop times for a stop
+//       noThrottle: true,
+//       serviceId: 'stops',
+//       rewritePayload: (payload) => {
+//         // convert pattern array to ID-mapped object
+//         const patterns = []
+//         const { stoptimesForPatterns, ...stop } = payload.data.stops[0]
+//         stoptimesForPatterns.forEach(obj => {
+//           const { pattern, stoptimes: stopTimes } = obj
+//           // It's possible that not all stop times for a pattern will share the
+//           // same headsign, but this is probably a minor edge case.
+//           const headsign = stopTimes[0]
+//             ? stopTimes[0].headsign
+//             : pattern.route.longName
+//           const patternIndex = patterns.findIndex(p =>
+//             p.headsign === headsign && pattern.route.id === p.route.id)
+//           if (patternIndex === -1) {
+//             patterns.push({ ...pattern, headsign, stopTimes })
+//           } else {
+//             patterns[patternIndex].stopTimes.push(...stopTimes)
+//           }
+//         })
+//         return {
+//           ...stop,
+//           patterns
+//         }
+//       }
+//     }
+//   )
+// }
 
 // Single trip lookup query
 
@@ -426,7 +445,8 @@ export function findStopTimesForTrip (params) {
           tripId: params.tripId,
           stopTimes: payload
         }
-      }
+      },
+      noThrottle: true
     }
   )
 }
@@ -448,99 +468,209 @@ export function findGeometryForTrip (params) {
   )
 }
 
+// Stop times for stop query
+// TODO: make timeRange and numberOfDepartures configurable
+
+const findStopTimesForStopResponse = createAction('FIND_STOP_TIMES_FOR_STOP_RESPONSE')
+const findStopTimesForStopError = createAction('FIND_STOP_TIMES_FOR_STOP_ERROR')
+
+export function findStopTimesForStop (params) {
+  return createQueryAction(
+    `index/stops/${params.stopId}/stoptimes?timeRange=345600&numberOfDepartures=5`,
+    findStopTimesForStopResponse,
+    findStopTimesForStopError,
+    {
+      rewritePayload: (payload) => {
+        return {
+          stopId: params.stopId,
+          stopTimes: payload
+        }
+      },
+      noThrottle: true
+    }
+  )
+}
+
 // Routes lookup query
 
 const findRoutesResponse = createAction('FIND_ROUTES_RESPONSE')
 const findRoutesError = createAction('FIND_ROUTES_ERROR')
 
 export function findRoutes (params) {
-  const query = `
-{
-  routes {
-    id: gtfsId
-    color
-    longName
-    shortName
-    mode
-    type
-    desc
-    bikesAllowed
-    sortOrder
-    textColor
-    url
-    agency {
-      id: gtfsId
-      name
-      url
-    }
-  }
-}
-  `
-  return createGraphQLQueryAction(
-    query,
-    {},
+  return createQueryAction(
+    'index/routes',
     findRoutesResponse,
     findRoutesError,
     {
       serviceId: 'routes',
       rewritePayload: (payload) => {
         const routes = {}
-        payload.data.routes.forEach(rte => { routes[rte.id] = rte })
+        payload.forEach(rte => { routes[rte.id] = rte })
         return routes
       }
     }
   )
 }
 
+// export function findRoutes (params) {
+//   const query = `
+// {
+//   routes {
+//     id: gtfsId
+//     color
+//     longName
+//     shortName
+//     mode
+//     type
+//     desc
+//     bikesAllowed
+//     sortOrder
+//     textColor
+//     url
+//     agency {
+//       id: gtfsId
+//       name
+//       url
+//     }
+//   }
+// }
+//   `
+//   return createGraphQLQueryAction(
+//     query,
+//     {},
+//     findRoutesResponse,
+//     findRoutesError,
+//     {
+//       serviceId: 'routes',
+//       rewritePayload: (payload) => {
+//         const routes = {}
+//         payload.data.routes.forEach(rte => { routes[rte.id] = rte })
+//         return routes
+//       }
+//     }
+//   )
+// }
+
 // Patterns for Route lookup query
 // TODO: replace with GraphQL query for route => patterns => geometry
-export const findPatternsForRouteResponse = createAction('FIND_PATTERNS_FOR_ROUTE_RESPONSE')
-export const findPatternsForRouteError = createAction('FIND_PATTERNS_FOR_ROUTE_ERROR')
+const findPatternsForRouteResponse = createAction('FIND_PATTERNS_FOR_ROUTE_RESPONSE')
+const findPatternsForRouteError = createAction('FIND_PATTERNS_FOR_ROUTE_ERROR')
+
+// Single Route lookup query
+
+export const findRouteResponse = createAction('FIND_ROUTE_RESPONSE')
+export const findRouteError = createAction('FIND_ROUTE_ERROR')
 
 export function findRoute (params) {
-  const query = `
-  query routeQuery($routeId: [String]) {
-    routes (ids: $routeId) {
-      id: gtfsId
-      patterns {
-        id: semanticHash
-        directionId
-        headsign
-        name
-        semanticHash
-        geometry {
-          lat
-          lon
-        }
-      }
+  return createQueryAction(
+    `index/routes/${params.routeId}`,
+    findRouteResponse,
+    findRouteError,
+    {
+      postprocess: (payload, dispatch) => {
+        // load patterns
+        dispatch(findPatternsForRoute({ routeId: params.routeId }))
+      },
+      noThrottle: true
     }
-  }
-  `
-  return createGraphQLQueryAction(
-    query,
-    { routeId: params.routeId },
+  )
+}
+
+export function findPatternsForRoute (params) {
+  return createQueryAction(
+    `index/routes/${params.routeId}/patterns`,
     findPatternsForRouteResponse,
     findPatternsForRouteError,
     {
       rewritePayload: (payload) => {
         // convert pattern array to ID-mapped object
         const patterns = {}
-        payload.data.routes[0].patterns.forEach(ptn => {
-          patterns[ptn.id] = {
-            routeId: params.routeId,
-            patternId: ptn.id,
-            geometry: ptn.geometry
-          }
-        })
+        payload.forEach(ptn => { patterns[ptn.id] = ptn })
 
         return {
           routeId: params.routeId,
           patterns
         }
+      },
+      postprocess: (payload, dispatch) => {
+        // load geometry for each pattern
+        payload.forEach(ptn => {
+          dispatch(findGeometryForPattern({
+            routeId: params.routeId,
+            patternId: ptn.id
+          }))
+        })
       }
     }
   )
 }
+
+// Geometry for Pattern lookup query
+
+const findGeometryForPatternResponse = createAction('FIND_GEOMETRY_FOR_PATTERN_RESPONSE')
+const findGeometryForPatternError = createAction('FIND_GEOMETRY_FOR_PATTERN_ERROR')
+
+export function findGeometryForPattern (params) {
+  return createQueryAction(
+    `index/patterns/${params.patternId}/geometry`,
+    findGeometryForPatternResponse,
+    findGeometryForPatternError,
+    {
+      rewritePayload: (payload) => {
+        return {
+          routeId: params.routeId,
+          patternId: params.patternId,
+          geometry: payload
+        }
+      }
+    }
+  )
+}
+
+// export function findRoute (params) {
+//   const query = `
+//   query routeQuery($routeId: [String]) {
+//     routes (ids: $routeId) {
+//       id: gtfsId
+//       patterns {
+//         id: semanticHash
+//         directionId
+//         headsign
+//         name
+//         semanticHash
+//         geometry {
+//           lat
+//           lon
+//         }
+//       }
+//     }
+//   }
+//   `
+//   return createGraphQLQueryAction(
+//     query,
+//     { routeId: params.routeId },
+//     findPatternsForRouteResponse,
+//     findPatternsForRouteError,
+//     {
+//       rewritePayload: (payload) => {
+//         // convert pattern array to ID-mapped object
+//         const patterns = {}
+//         payload.data.routes[0].patterns.forEach(ptn => {
+//           patterns[ptn.id] = {
+//             routeId: params.routeId,
+//             patternId: ptn.id,
+//             geometry: ptn.geometry
+//           }
+//         })
+//
+//         return {
+//           routeId: params.routeId,
+//           patterns
+//         }
+//       }
+//     }
+//   )
+// }
 
 // TNC ETA estimate lookup query
 
@@ -643,7 +773,8 @@ export function findRoutesAtStop (stopId) {
     receivedRoutesAtStopError,
     {
       serviceId: 'stops/routes',
-      rewritePayload: routes => ({stopId, routes})
+      rewritePayload: routes => ({ stopId, routes }),
+      noThrottle: true
     }
   )
 }

--- a/lib/components/map/route-viewer-overlay.js
+++ b/lib/components/map/route-viewer-overlay.js
@@ -2,9 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { FeatureGroup, MapLayer, Polyline } from 'react-leaflet'
 
-function geomToArray (point) {
-  return [point.lat, point.lon]
-}
+import polyline from '@mapbox/polyline'
 
 class RouteViewerOverlay extends MapLayer {
   static propTypes = {}
@@ -15,10 +13,27 @@ class RouteViewerOverlay extends MapLayer {
   componentWillUnmount () {}
 
   componentWillReceiveProps (nextProps) {
+    // helper fn to check if geometry has been populated for all patterns in route
+    const isGeomComplete = routeData => {
+      return (
+        routeData &&
+        routeData.patterns &&
+        Object.values(routeData.patterns).reduce(
+          (acc, ptn) => acc && typeof ptn.geometry !== 'undefined',
+          true
+        )
+      )
+    }
+
     // if pattern geometry just finished populating, update the map points
-    if (nextProps.routeData && nextProps.routeData.patterns && Object.keys(nextProps.routeData.patterns).length > 0) {
+    if (
+      !isGeomComplete(this.props.routeData) &&
+      isGeomComplete(nextProps.routeData)
+    ) {
       const allPoints = Object.values(nextProps.routeData.patterns).reduce(
-        (acc, ptn) => acc.concat(ptn.geometry.map(geomToArray)),
+        (acc, ptn) => {
+          return acc.concat(polyline.decode(ptn.geometry.points))
+        },
         []
       )
       this.context.map.fitBounds(allPoints)
@@ -38,14 +53,14 @@ class RouteViewerOverlay extends MapLayer {
     const segments = []
     Object.values(routeData.patterns).forEach(pattern => {
       if (!pattern.geometry) return
-      const pts = pattern.geometry.map(geomToArray)
+      const pts = polyline.decode(pattern.geometry.points)
       segments.push(
         <Polyline
           positions={pts}
           weight={4}
           color={routeColor}
           opacity={1}
-          key={pattern.patternId}
+          key={pattern.id}
         />
       )
     })

--- a/lib/components/map/route-viewer-overlay.js
+++ b/lib/components/map/route-viewer-overlay.js
@@ -4,6 +4,16 @@ import { FeatureGroup, MapLayer, Polyline } from 'react-leaflet'
 
 import polyline from '@mapbox/polyline'
 
+// helper fn to check if geometry has been populated for all patterns in route
+const isGeomComplete = routeData => {
+  return (
+    routeData &&
+    routeData.patterns &&
+    Object.values(routeData.patterns)
+      .every(ptn => typeof ptn.geometry !== 'undefined')
+  )
+}
+
 class RouteViewerOverlay extends MapLayer {
   static propTypes = {}
 
@@ -13,18 +23,6 @@ class RouteViewerOverlay extends MapLayer {
   componentWillUnmount () {}
 
   componentWillReceiveProps (nextProps) {
-    // helper fn to check if geometry has been populated for all patterns in route
-    const isGeomComplete = routeData => {
-      return (
-        routeData &&
-        routeData.patterns &&
-        Object.values(routeData.patterns).reduce(
-          (acc, ptn) => acc && typeof ptn.geometry !== 'undefined',
-          true
-        )
-      )
-    }
-
     // if pattern geometry just finished populating, update the map points
     if (
       !isGeomComplete(this.props.routeData) &&

--- a/lib/components/viewers/route-viewer.js
+++ b/lib/components/viewers/route-viewer.js
@@ -12,10 +12,11 @@ import { routeComparator } from '../../util/itinerary'
 
 function operatorForRoute (operators, route) {
   return operators.find(o =>
-    o.id.toLowerCase() === route.agency.id.split(':')[0].toLowerCase())
+    route.agency && o.id.toLowerCase() === route.agency.id.split(':')[0].toLowerCase())
 }
 
 function operatorIndexForRoute (operators, route) {
+  if (!route.agency) return 0
   const index = operators.findIndex(o =>
     o.id.toLowerCase() === route.agency.id.split(':')[0].toLowerCase())
   if (index !== -1 && typeof operators[index].order !== 'undefined') return operators[index].order
@@ -114,6 +115,7 @@ class RouteRow extends Component {
     const isActive = this.isActiveRoute()
     const {defaultRouteColor, defaultRouteTextColor, longNameSplitter} = operator
     const activeRouteData = isActive ? routes[viewedRoute.routeId] : null
+    if (isActive) console.log(routes, activeRouteData)
     const color = `#${defaultRouteTextColor || route.textColor || '000000'}`
     const backgroundColor = `#${defaultRouteColor || route.color || 'ffffff'}`
     const longName = (longNameSplitter && route.longName && route.longName.split(longNameSplitter).length > 1)

--- a/lib/components/viewers/route-viewer.js
+++ b/lib/components/viewers/route-viewer.js
@@ -113,13 +113,13 @@ class RouteRow extends Component {
   render () {
     const { operator, route, routes, viewedRoute } = this.props
     const isActive = this.isActiveRoute()
-    const {defaultRouteColor, defaultRouteTextColor, longNameSplitter} = operator
+    const { defaultRouteColor, defaultRouteTextColor, longNameSplitter } = operator
     const activeRouteData = isActive ? routes[viewedRoute.routeId] : null
-    if (isActive) console.log(routes, activeRouteData)
     const color = `#${defaultRouteTextColor || route.textColor || '000000'}`
     const backgroundColor = `#${defaultRouteColor || route.color || 'ffffff'}`
-    const longName = (longNameSplitter && route.longName && route.longName.split(longNameSplitter).length > 1)
-      ? route.longName.split(longNameSplitter)[1]
+    const nameParts = route.longName.split(longNameSplitter)
+    const longName = (longNameSplitter && route.longName && nameParts.length > 1)
+      ? nameParts[1]
       : route.longName
     return (
       <div
@@ -131,7 +131,12 @@ class RouteRow extends Component {
           onClick={this._onClick}
         >
           <div style={{display: 'inline-block'}}>
-            {operator && <img src={operator.logo} style={{marginRight: '5px'}} height={25} />}
+            {// TODO: re-implement multi-agency logos for route viewer.
+              // Currently, the agency object is not nested within the get all
+              // routes endpoint and causing this to only display operators for
+              // the selected route.
+              // operator && <img src={operator.logo} style={{marginRight: '5px'}} height={25} />
+            }
           </div>
           <div style={{display: 'inline-block', marginTop: '2px'}}>
             <Label

--- a/lib/components/viewers/stop-viewer.js
+++ b/lib/components/viewers/stop-viewer.js
@@ -42,9 +42,10 @@ class StopViewer extends Component {
   _onClickPlanFrom = () => this._setLocationFromStop('from')
 
   _refreshStopTimes = () => {
-    const { findStop, viewedStop } = this.props
-    // findStopTimesForStop({ stopId: viewedStop.stopId })
-    findStop({ stopId: viewedStop.stopId })
+    const { findStopTimesForStop, viewedStop } = this.props
+    findStopTimesForStop({ stopId: viewedStop.stopId })
+    // TODO: GraphQL approach would just call findStop again.
+    // findStop({ stopId: viewedStop.stopId })
     this.setState({ spin: true })
     window.setTimeout(this._stopSpin, 1000)
   }
@@ -102,6 +103,7 @@ class StopViewer extends Component {
     ) {
       this.props.findStop({ stopId: nextProps.viewedStop.stopId })
     }
+    // Handle stopping or starting the auto refresh timer.
     if (this.props.autoRefreshStopTimes && !nextProps.autoRefreshStopTimes) this._stopAutoRefresh()
     else if (!this.props.autoRefreshStopTimes && nextProps.autoRefreshStopTimes) this._startAutoRefresh()
   }
@@ -130,9 +132,10 @@ class StopViewer extends Component {
         patternTimes.pattern.headsign = headsign
         const id = `${routeId}-${headsign}`
         if (!(id in stopTimesByPattern)) {
+          const route = stopData.routes.find(r => r.id === routeId)
           stopTimesByPattern[id] = {
             id,
-            route: stopData.routes.find(r => r.id === routeId),
+            route,
             pattern: patternTimes.pattern,
             times: []
           }
@@ -143,7 +146,6 @@ class StopViewer extends Component {
         stopTimesByPattern[id].times = stopTimesByPattern[id].times.concat(filteredTimes)
       })
     }
-    console.log(stopTimesByPattern)
     return (
       <div className='stop-viewer'>
         {/* Header Block */}
@@ -217,6 +219,14 @@ class StopViewer extends Component {
                 {Object.values(stopTimesByPattern)
                   .sort((a, b) => routeComparator(a.route, b.route))
                   .map(patternTimes => {
+                    // Only add pattern row if route is found.
+                    // FIXME: there is currently a bug with the alernative transit index
+                    // where routes are not associated with the stop if the only stoptimes
+                    // for the stop are drop off only. See https://github.com/ibi-group/trimet-mod-otp/issues/217
+                    if (!patternTimes.route) {
+                      console.warn(`Cannot render stop times for missing route ID: ${getRouteIdForPattern(patternTimes.pattern)}`)
+                      return null
+                    }
                     return (
                       <PatternRow
                         pattern={patternTimes.pattern}

--- a/lib/components/viewers/stop-viewer.js
+++ b/lib/components/viewers/stop-viewer.js
@@ -121,20 +121,29 @@ class StopViewer extends Component {
     if (stopData && stopData.id) {
       stopId = stopData.id.includes(':') ? stopData.id.split(':')[1] : stopData.id
     }
-    // construct a lookup table mapping routeId (e.g. 'MyAgency:10') to an array of stoptimes
-    const stopTimesByRoute = {}
+    // construct a lookup table mapping pattern (e.g. 'ROUTE_ID-HEADSIGN') to an array of stoptimes
+    const stopTimesByPattern = {}
     if (stopData && stopData.routes && stopData.stopTimes) {
       stopData.stopTimes.forEach(patternTimes => {
-        const patternIdParts = patternTimes.pattern.id.split(':')
-        const routeId = patternIdParts[0] + ':' + patternIdParts[1]
-        if (!(routeId in stopTimesByRoute)) stopTimesByRoute[routeId] = []
+        const routeId = getRouteIdForPattern(patternTimes.pattern)
+        const headsign = patternTimes.times[0] && patternTimes.times[0].headsign
+        patternTimes.pattern.headsign = headsign
+        const id = `${routeId}-${headsign}`
+        if (!(id in stopTimesByPattern)) {
+          stopTimesByPattern[id] = {
+            id,
+            route: stopData.routes.find(r => r.id === routeId),
+            pattern: patternTimes.pattern,
+            times: []
+          }
+        }
         const filteredTimes = patternTimes.times.filter(stopTime => {
           return stopTime.stopIndex < stopTime.stopCount - 1 // ensure that this isn't the last stop
         })
-        stopTimesByRoute[routeId] = stopTimesByRoute[routeId].concat(filteredTimes)
+        stopTimesByPattern[id].times = stopTimesByPattern[id].times.concat(filteredTimes)
       })
     }
-
+    console.log(stopTimesByPattern)
     return (
       <div className='stop-viewer'>
         {/* Header Block */}
@@ -203,16 +212,17 @@ class StopViewer extends Component {
             </div>
 
             {/* pattern listing */}
-            {stopData.patterns && (
+            {stopData.stopTimes && stopData.routes && (
               <div style={{ marginTop: 20 }}>
-                {stopData.patterns
+                {Object.values(stopTimesByPattern)
                   .sort((a, b) => routeComparator(a.route, b.route))
-                  .map(pattern => {
+                  .map(patternTimes => {
                     return (
                       <PatternRow
-                        pattern={pattern}
-                        stopTimes={pattern.stopTimes}
-                        key={pattern.id}
+                        pattern={patternTimes.pattern}
+                        route={patternTimes.route}
+                        stopTimes={patternTimes.times}
+                        key={patternTimes.id}
                         stopViewerArriving={stopViewerArriving}
                         homeTimezone={homeTimezone}
                         timeFormat={timeFormat}
@@ -253,13 +263,12 @@ class PatternRow extends Component {
   render () {
     const {
       pattern,
+      route,
       stopTimes,
       homeTimezone,
       stopViewerArriving,
       timeFormat
     } = this.props
-    const { route } = pattern
-
     // sort stop times by next departure
     let sortedStopTimes = null
     if (stopTimes) {
@@ -417,6 +426,12 @@ function getFormattedStopTime (stopTime, homeTimezone, soonText = 'Due', timeFor
       </div>
     </div>
   )
+}
+
+function getRouteIdForPattern (pattern) {
+  const patternIdParts = pattern.id.split(':')
+  const routeId = patternIdParts[0] + ':' + patternIdParts[1]
+  return routeId
 }
 
 // helper method to generate status label

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -663,6 +663,19 @@ function createOtpReducer (config, initialQuery) {
         return update(state, {
           transitIndex: { routes: { $merge: newRoutes } }
         })
+      case 'FIND_ROUTE_RESPONSE':
+        // If routes is undefined, initialize it w/ this route only
+        if (!state.transitIndex.routes) {
+          return update(state, {
+            transitIndex: { routes: { $set: { [action.payload.id]: action.payload } } }
+          })
+        }
+        // Otherwise, overwrite only this route
+        return update(state, {
+          transitIndex: {
+            routes: { [action.payload.id]: { $set: action.payload } }
+          }
+        })
       case 'FIND_PATTERNS_FOR_ROUTE_RESPONSE':
         const { patterns, routeId } = action.payload
         // If routes is undefined, initialize it w/ this route only


### PR DESCRIPTION
This PR reverts the GraphQL queries employed to fetch routes and stops. After these queries were implemented to assist with the enhancements related to multi-agency implementations, it was later realized that the alternative transit index used by TriMet (backed by gtfsdb) would not support these queries.