### PR TITLE
Fix vehicle marker color

### DIFF
--- a/lib/components/form/settings-selector-panel.js
+++ b/lib/components/form/settings-selector-panel.js
@@ -263,20 +263,21 @@ class SettingsSelectorPanel extends Component {
     const {config, mode, icons} = this.props
     const {exclusiveModes} = config.modes
     const modeHasTransit = hasTransit(mode)
-
+    // Use int for array element keys
+    let key = 0
     if (!exclusiveModes) return null
 
     // create an array of children to display within a mode-group-row
     // at most 2 exclusive modes will be displayed side-by-side
     const children = []
-    const spacer = (
-      <Col xs={2} style={{ height: 44 }}>&nbsp;</Col>
+    const spacer = () => (
+      <Col xs={2} key={key++} style={{ height: 44 }}>&nbsp;</Col>
     )
 
     exclusiveModes.forEach((exclusiveMode, idx) => {
       // add left padding for every evenly indexed exclusiveMode
       if (idx % 2 === 0) {
-        children.push(spacer)
+        children.push(spacer())
       }
 
       switch (exclusiveMode) {
@@ -285,6 +286,7 @@ class SettingsSelectorPanel extends Component {
             <Col xs={4}>
               <ModeButton
                 enabled
+                key={key++}
                 active={mode === 'WALK'}
                 icons={icons}
                 mode={'WALK'}
@@ -301,6 +303,7 @@ class SettingsSelectorPanel extends Component {
             <Col xs={4}>
               <ModeButton
                 enabled
+                key={key++}
                 active={!modeHasTransit && hasBike(mode)}
                 icons={icons}
                 mode={'BICYCLE'}
@@ -317,6 +320,7 @@ class SettingsSelectorPanel extends Component {
             <Col xs={4}>
               <ModeButton
                 enabled
+                key={key++}
                 active={!modeHasTransit && hasMicromobility(mode)}
                 icons={icons}
                 mode={'MICROMOBILITY'}
@@ -334,7 +338,7 @@ class SettingsSelectorPanel extends Component {
 
       // add right padding for every odd indexed exclusiveMode
       if (idx % 2 !== 0) {
-        children.push(spacer)
+        children.push(spacer())
       }
     })
 

--- a/lib/components/map/map.css
+++ b/lib/components/map/map.css
@@ -67,7 +67,6 @@
 /*** Car Rental Map Icons ***/
 
 .otp .car-rental-icon {
-  color: gray;
   font-size: 18px;
   text-align: center;
 }
@@ -75,7 +74,6 @@
 /*** Micromobility Rental Map Icons ***/
 
 .otp .micromobility-rental-icon {
-  color: gray;
   font-size: 18px;
   text-align: center;
 }

--- a/lib/components/map/vehicle-rental-overlay.js
+++ b/lib/components/map/vehicle-rental-overlay.js
@@ -159,16 +159,19 @@ class VehicleRentalOverlay extends MapLayer {
 
   _renderStationAsMarker = (station, symbolDef) => {
     const {baseIconClass} = this.props
-    let className = `fa fa-map-marker ${baseIconClass}`
+    let classes = `fa fa-map-marker ${baseIconClass}`
     // If this station is exclusive to a single network, apply the the class for that network
     if (station.networks.length === 1) {
-      className += ` ${baseIconClass}-${station.networks[0].toLowerCase()}`
+      classes += ` ${baseIconClass}-${station.networks[0].toLowerCase()}`
     }
+    const color = symbolDef && symbolDef.fillColor
+      ? symbolDef.fillColor
+      : 'gray'
     const markerIcon = divIcon({
+      className: '',
       iconSize: [11, 16],
       popupAnchor: [0, -6],
-      html: '<i />',
-      className
+      html: `<i class="${classes}" style="color: ${color}"/>`
     })
 
     return (
@@ -211,8 +214,8 @@ class VehicleRentalOverlay extends MapLayer {
   }
 
   render () {
-    const { stations, companies } = this.props
-
+    const { mapSymbols, stations, companies } = this.props
+    if (!mapSymbols) console.warn(`No map symbols provided for layer ${this.props.name}`, companies)
     let filteredStations = stations
     if (companies) {
       filteredStations = stations.filter(


### PR DESCRIPTION
Use config-defined values for vehicle marker color. Previously these were hard coded in css class selectors (update required for trimet-mod-otp#styles.scss as well).

Fixes ibi-group/trimet-mod-otp#218