### PR TITLE
Properly render eScooter legs occurring after forced walking

### DIFF
--- a/lib/components/narrative/line-itin/place-row.js
+++ b/lib/components/narrative/line-itin/place-row.js
@@ -167,10 +167,10 @@ class RentedVehicleLeg extends PureComponent {
       )
     }
 
-    let pickUpString = 'Pick up'
+    let rentalDescription = 'Pick up'
     if (leg.rentedBike) {
       // TODO: Special case for TriMet may need to be refactored.
-      pickUpString += ` shared bike`
+      rentalDescription += ` shared bike`
     } else {
       // Add company and vehicle labels.
       let vehicleName = ''
@@ -182,14 +182,14 @@ class RentedVehicleLeg extends PureComponent {
           : 'car'
 
       // The networks attribute of the from data will only appear at the very
-      // beggining of the rental. It is possible that there will be some forced
+      // beginning of the rental. It is possible that there will be some forced
       // walking that occurs in the middle of the rental, so once the main mode
       // resumes there won't be any network info. In that case we simply return
       // that the rental is continuing.
       if (leg.from.networks) {
         const companies = leg.from.networks.map(n => getCompanyForNetwork(n, configCompanies))
         const companyLabel = companies.map(co => co.label).join('/')
-        pickUpString += ` ${companyLabel}`
+        rentalDescription += ` ${companyLabel}`
         // Only show vehicle name for car rentals. For bikes and eScooters, these
         // IDs/names tend to be less relevant (or entirely useless) in this context.
         if (leg.rentedCar && leg.from.name) {
@@ -197,17 +197,17 @@ class RentedVehicleLeg extends PureComponent {
         }
         modeString = getModeForPlace(leg.from)
       } else {
-        pickUpString = 'Continue using rental'
+        rentalDescription = 'Continue using rental'
       }
 
-      pickUpString += ` ${modeString}${vehicleName}`
+      rentalDescription += ` ${modeString}${vehicleName}`
     }
     // e.g., Pick up REACHNOW rented car XYZNDB OR
     //       Pick up SPIN eScooter
     //       Pick up shared bike
     return (
       <div className='place-subheader'>
-        {pickUpString}
+        {rentalDescription}
       </div>
     )
   }

--- a/lib/components/narrative/line-itin/place-row.js
+++ b/lib/components/narrative/line-itin/place-row.js
@@ -156,6 +156,9 @@ class RentedVehicleLeg extends PureComponent {
   render () {
     const { config, leg } = this.props
     const configCompanies = config.companies || []
+
+    // Sometimes rented vehicles can be walked over things like stairs or other
+    // ways that forbid the main mode of travel.
     if (leg.mode === 'WALK') {
       return (
         <div className='place-subheader'>
@@ -163,35 +166,48 @@ class RentedVehicleLeg extends PureComponent {
         </div>
       )
     }
-    if (leg.rentedVehicle || leg.rentedBike || leg.rentedCar) {
-      let pickUpString = 'Pick up'
-      if (leg.rentedBike) {
-        // TODO: Special case for TriMet may need to be refactored.
-        pickUpString += ` shared bike`
-      } else {
-        // Add company and vehicle labels.
+
+    let pickUpString = 'Pick up'
+    if (leg.rentedBike) {
+      // TODO: Special case for TriMet may need to be refactored.
+      pickUpString += ` shared bike`
+    } else {
+      // Add company and vehicle labels.
+      let vehicleName = ''
+      // TODO allow more flexibility in customizing these mode strings
+      let modeString = leg.rentedVehicle
+        ? 'eScooter'
+        : leg.rentedBike
+          ? 'bike'
+          : 'car'
+
+      // The networks attribute of the from data will only appear at the very
+      // beggining of the rental. It is possible that there will be some forced
+      // walking that occurs in the middle of the rental, so once the main mode
+      // resumes there won't be any network info. In that case we simply return
+      // that the rental is continuing.
+      if (leg.from.networks) {
         const companies = leg.from.networks.map(n => getCompanyForNetwork(n, configCompanies))
         const companyLabel = companies.map(co => co.label).join('/')
         pickUpString += ` ${companyLabel}`
-        const modeString = getModeForPlace(leg.from)
         // Only show vehicle name for car rentals. For bikes and eScooters, these
         // IDs/names tend to be less relevant (or entirely useless) in this context.
-        const vehicleName = leg.rentedCar ? ` ${leg.from.name}` : ''
-        pickUpString += ` ${modeString}${vehicleName}`
+        if (leg.rentedCar && leg.from.name) {
+          vehicleName = leg.from.name
+        }
+        modeString = getModeForPlace(leg.from)
+      } else {
+        pickUpString = 'Continue using rental'
       }
-      // e.g., Pick up REACHNOW rented car XYZNDB OR
-      //       Pick up SPIN eScooter
-      //       Pick up shared bike
-      return (
-        <div className='place-subheader'>
-          {pickUpString}
-        </div>
-      )
+
+      pickUpString += ` ${modeString}${vehicleName}`
     }
-    // FIXME: Under what conditions would this be returned?
+    // e.g., Pick up REACHNOW rented car XYZNDB OR
+    //       Pick up SPIN eScooter
+    //       Pick up shared bike
     return (
       <div className='place-subheader'>
-        Continue riding from {leg.from.name}
+        {pickUpString}
       </div>
     )
   }

--- a/lib/util/itinerary.js
+++ b/lib/util/itinerary.js
@@ -393,9 +393,9 @@ export function getLegIcon (leg, customIcons) {
     iconStr = leg.from.networks[0]
   } else if (iconStr === 'CAR' && leg.tncData) {
     iconStr = leg.tncData.company
-  } else if (iconStr === 'BICYCLE' && leg.rentedBike) {
+  } else if (iconStr === 'BICYCLE' && leg.rentedBike && leg.from.networks) {
     iconStr = leg.from.networks[0]
-  } else if (iconStr === 'MICROMOBILITY' && leg.rentedVehicle) {
+  } else if (iconStr === 'MICROMOBILITY' && leg.rentedVehicle && leg.from.networks) {
     iconStr = leg.from.networks[0]
   }
 


### PR DESCRIPTION
The latest code changes for eScooter rental didn't properly handle transitions from forced walking back to renting a vehicle. There was always an assumption that the from leg had vehicle rental info when in reality it does not.