### PR TITLE
Handle any route w webapp + support otp.js legacy start route

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -74,7 +74,6 @@ export function matchContentToUrl (location) {
           // pathname to specify lat, lon, etc.)
           [,, lat, lon, zoom, routerId] = idToParams(location.pathname, '/')
         }
-        console.log('Setting start position/zoom/router', lat, lon, zoom, routerId)
         // Update map location/zoom and optionally override router ID.
         dispatch(setMapCenter({ lat, lon }))
         dispatch(setMapZoom({ zoom }))

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -40,14 +40,13 @@ export function matchContentToUrl (location) {
     // This is a bit of a hack to make up for the fact that react-router does
     // not always provide the match params as expected.
     // https://github.com/ReactTraining/react-router/issues/5870#issuecomment-394194338
-    let root = location.pathname.split('/')[1]
+    const root = location.pathname.split('/')[1]
     const match = matchPath(location.pathname, {
       path: `/${root}/:id`,
       exact: true,
       strict: false
     })
     const id = match && match.params && match.params.id
-    console.log(location, id)
     switch (root) {
       case 'route':
         if (id) {

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -40,13 +40,14 @@ export function matchContentToUrl (location) {
     // This is a bit of a hack to make up for the fact that react-router does
     // not always provide the match params as expected.
     // https://github.com/ReactTraining/react-router/issues/5870#issuecomment-394194338
-    const root = location.pathname.split('/')[1]
+    let root = location.pathname.split('/')[1]
     const match = matchPath(location.pathname, {
       path: `/${root}/:id`,
       exact: true,
       strict: false
     })
     const id = match && match.params && match.params.id
+    console.log(location, id)
     switch (root) {
       case 'route':
         if (id) {
@@ -65,9 +66,16 @@ export function matchContentToUrl (location) {
           dispatch(setMainPanelContent(MainPanelContent.STOP_VIEWER))
         }
         break
+      case 'start':
       case '@':
         // Parse comma separated params (ensuring numbers are parsed correctly).
-        const [lat, lon, zoom, routerId] = id.split(',').map(s => isNaN(s) ? s : +s)
+        let [lat, lon, zoom, routerId] = id ? idToParams(id) : []
+        if (!lat || !lon) {
+          // Attempt to parse path. (Legacy UI otp.js used slashes in the
+          // pathname to specify lat, lon, etc.)
+          [,, lat, lon, zoom, routerId] = idToParams(location.pathname, '/')
+        }
+        console.log('Setting start position/zoom/router', lat, lon, zoom, routerId)
         // Update map location/zoom and optionally override router ID.
         dispatch(setMapCenter({ lat, lon }))
         dispatch(setMapZoom({ zoom }))
@@ -80,6 +88,10 @@ export function matchContentToUrl (location) {
         break
     }
   }
+}
+
+function idToParams (id, delimiter = ',') {
+  return id.split(delimiter).map(s => isNaN(s) ? s : +s)
 }
 
 /**

--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -181,6 +181,7 @@ class RouterWrapper extends Component {
                 // to a quirk with react-router.
                 // https://github.com/ReactTraining/react-router/issues/5870#issuecomment-394194338
                 '/@/:latLonZoomRouter',
+                '/start/:latLonZoomRouter',
                 // Route viewer (and route ID).
                 '/route',
                 '/route/:id',
@@ -193,6 +194,10 @@ class RouterWrapper extends Component {
             <Route
               path='/print'
               component={PrintLayout}
+            />
+            {/* For any other route, simply return the web app. */}
+            <Route
+              render={() => <WebappWithRouter {...this.props} />}
             />
           </Switch>
         </div>


### PR DESCRIPTION
Previously visiting any random route (e.g., https://trimet-mod-dev.ibi-transit.com/#/foo) causes a blank page to be rendered. This fixes that.

It also adds support for the legacy `start` route used in otp.js to specify lat/lon/zoom/router.