### PR TITLE
Log statement to mysteriously fix IE location select onclick

### DIFF
--- a/lib/actions/map.js
+++ b/lib/actions/map.js
@@ -38,21 +38,15 @@ export function clearLocation (payload) {
 export function setLocation (payload) {
   return function (dispatch, getState) {
     const otpState = getState().otp
-
+    const { location, reverseGeocode, type } = payload
     // reverse geocode point location if requested
-    if (payload.reverseGeocode) {
+    if (reverseGeocode) {
       getGeocoder(otpState.config.geocoder)
-        .reverse({ point: payload.location })
-        .then((location) => {
-          dispatch(settingLocation({
-            type: payload.type,
-            location
-          }))
+        .reverse({ point: location })
+        .then((result) => {
+          dispatch(settingLocation({ type, location: result }))
         }).catch(err => {
-          dispatch(settingLocation({
-            type: payload.type,
-            location: payload.location
-          }))
+          dispatch(settingLocation({ type, location }))
           console.warn(err)
         })
     } else {

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -147,7 +147,6 @@ export function setMainPanelContent (payload) {
   return function (dispatch, getState) {
     const { otp, router } = getState()
     if (otp.ui.mainPanelContent === payload) {
-      console.warn(`Attempt to route from ${otp.ui.mainPanelContent} to ${payload}. Doing nothing`)
       // Do nothing if the panel is already set. This will guard against over
       // enthusiastic routing and overwriting current/nested states.
       return

--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -1,3 +1,4 @@
+import bowser from 'bowser'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
@@ -87,6 +88,10 @@ class ResponsiveWebapp extends Component {
   }
 
   componentDidMount () {
+    // For some bizarre reason, logging something to the console somehow improves
+    // the operation of the MenuItem onSelect (for onClick only) for Internet
+    // Explorer.
+    if (bowser.name === 'Internet Explorer') console.log('Loading...')
     // Add on back button press behavior.
     window.addEventListener('popstate', this.props.handleBackButtonPress)
     const { location, title } = this.props

--- a/lib/components/form/location-field.js
+++ b/lib/components/form/location-field.js
@@ -76,6 +76,7 @@ class LocationField extends Component {
       return
     }
     getGeocoder(this.props.config.geocoder)
+
       .autocomplete({ text })
       .then((result) => {
         this.setState({ geocodedFeatures: result.features })
@@ -90,6 +91,7 @@ class LocationField extends Component {
       return
     }
     getGeocoder(this.props.config.geocoder)
+
       .search({ text })
       .then((result) => {
         if (result.features && result.features.length > 0) {
@@ -227,7 +229,7 @@ class LocationField extends Component {
     }
   }
 
-  _setLocation (location) {
+  _setLocation = (location) => {
     const { onLocationSelected, setLocation, type } = this.props
     onLocationSelected && onLocationSelected()
     setLocation({ type, location })

--- a/lib/components/form/location-field.js
+++ b/lib/components/form/location-field.js
@@ -76,7 +76,6 @@ class LocationField extends Component {
       return
     }
     getGeocoder(this.props.config.geocoder)
-
       .autocomplete({ text })
       .then((result) => {
         this.setState({ geocodedFeatures: result.features })
@@ -91,7 +90,6 @@ class LocationField extends Component {
       return
     }
     getGeocoder(this.props.config.geocoder)
-
       .search({ text })
       .then((result) => {
         if (result.features && result.features.length > 0) {

--- a/lib/components/narrative/line-itin/transit-leg-body.js
+++ b/lib/components/narrative/line-itin/transit-leg-body.js
@@ -202,14 +202,17 @@ class AlertsBody extends Component {
         {this.props.alerts
           .sort((a, b) => b.effectiveStartDate - a.effectiveStartDate)
           .map((alert, i) => {
-            const effectiveStartDate = moment(alert.effectiveStartDate)
-            const daysAway = moment().diff(effectiveStartDate, 'days')
-            // Add time if alert is effective within one day. Otherwise, use
-            // calendar long date format (e.g., July 31, 2019).
-            const dateTimeFormat = Math.abs(daysAway) <= 1
-              ? `${timeFormat}, ${longDateFormat}`
-              : longDateFormat
-            const dateTimeString = effectiveStartDate.format(dateTimeFormat)
+            // Add time  (with Today/Yesterday) if alert is effective within one
+            // day. Otherwise, use calendar long date format (e.g., July 31, 2019).
+            // Note: this does not account for the format for future alert
+            // effective start dates.
+            const dateTimeString = moment(alert.effectiveStartDate)
+              .calendar(null, {
+                sameDay: `${timeFormat}, [Today]`,
+                lastDay: `${timeFormat}, [Yesterday]`,
+                lastWeek: longDateFormat,
+                sameElse: longDateFormat
+              })
             const effectiveDateString = `Effective as of ${dateTimeString}`
             return (
               <div key={i} className='transit-alert'>

--- a/lib/components/narrative/trip-tools.js
+++ b/lib/components/narrative/trip-tools.js
@@ -1,7 +1,6 @@
 import React, {Component} from 'react'
 import { connect } from 'react-redux'
 import { Button } from 'react-bootstrap'
-// import { DropdownButton, MenuItem } from 'react-bootstrap'
 import copyToClipboard from 'copy-to-clipboard'
 import bowser from 'bowser'
 


### PR DESCRIPTION
After some amount of debugging I discovered that for some reason on IE, the only way to select a
geocoded result with a click in the location field was to click on the upper part of the MenuItem
(above the text). But by adding a log statement (first I tried to add the statement in the
locationSelected function) anywhere in the app, it seemed to make the entire MenuItem clickable. I
have no idea why this black magic seems to work consistently and had trouble finding info on the
Internet related to this issue.

fix ibi-group/trimet-mod-otp#237

Note: this also contains a tweak that refs ibi-group/trimet-mod-otp#136