### PR TITLE
Be able to handle clicking a geocoded location in IE11

### DIFF
--- a/lib/components/form/location-field.js
+++ b/lib/components/form/location-field.js
@@ -19,6 +19,7 @@ import { distanceStringImperial } from '../../util/distance'
 import getGeocoder from '../../util/geocoder'
 import { formatStoredPlaceName } from '../../util/map'
 import { getActiveSearch, getShowUserSettings } from '../../util/state'
+import { isIE } from '../../util/ui'
 
 class LocationField extends Component {
   static propTypes = {
@@ -518,10 +519,27 @@ function createOption (icon, title, onSelect, isActive, isLast) {
     // style={{ borderBottom: '1px solid lightgrey' }}
     key={itemKey++}
     active={isActive}>
-    <div style={{ paddingTop: '5px', paddingBottom: '3px' }}>
-      <div style={{ float: 'left' }}><i className={`fa fa-${icon}`} /></div>
-      <div style={{ marginLeft: '30px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{title}</div>
-    </div>
+    {isIE()
+      // In internet explorer 11, some really weird stuff is happening where it
+      // is not possible to click the text of the title, but if you click just
+      // above it, then it works. So, if using IE 11, just return the title text
+      // and avoid all the extra fancy stuff.
+      // See https://github.com/ibi-group/trimet-mod-otp/issues/237
+      ? title
+      : (
+        <div style={{ paddingTop: '5px', paddingBottom: '3px' }}>
+          <div style={{ float: 'left' }}><i className={`fa fa-${icon}`} /></div>
+          <div style={{
+            marginLeft: '30px',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap'
+          }}>
+            {title}
+          </div>
+        </div>
+      )
+    }
   </MenuItem>
 }
 

--- a/lib/util/ui.js
+++ b/lib/util/ui.js
@@ -1,3 +1,5 @@
+import bowser from 'bowser'
+
 import { MainPanelContent } from '../actions/ui'
 import { summarizeQuery } from './query'
 import { getActiveSearch } from './state'
@@ -8,6 +10,13 @@ const DEFAULT_TITLE = document.title
 export function isMobile () {
   // TODO: consider using 3rd-party library?
   return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+}
+
+/**
+ * Returns true if the user is using a [redacted] browser
+ */
+export function isIE () {
+  return bowser.name === 'Internet Explorer'
 }
 
 /**


### PR DESCRIPTION
A counter-proposal to #95. It appears that there is some funkiness going on when clicking a geocode result in IE 11. If the top part of a result is clicked, then it works, but click on the text and you're out of luck. That made me wonder if it's some weird styling issue, so I removed all the fancy styling and merely display the text alone if the user is using IE and it appears to work now.

Fixes ibi-group/trimet-mod-otp#237