### PR TITLE
Fix alert effective date time string

### DIFF
--- a/lib/components/narrative/line-itin/transit-leg-body.js
+++ b/lib/components/narrative/line-itin/transit-leg-body.js
@@ -202,14 +202,15 @@ class AlertsBody extends Component {
         {this.props.alerts
           .sort((a, b) => b.effectiveStartDate - a.effectiveStartDate)
           .map((alert, i) => {
-            const effectiveStartDate = moment(alert.effectiveStartDate)
-            const daysAway = moment().diff(effectiveStartDate, 'days')
-            // Add time if alert is effective within one day. Otherwise, use
-            // calendar long date format (e.g., July 31, 2019).
-            const dateTimeFormat = Math.abs(daysAway) <= 1
-              ? `${timeFormat}, ${longDateFormat}`
-              : longDateFormat
-            const dateTimeString = effectiveStartDate.format(dateTimeFormat)
+            // If alert is effective as of +/- one day, use today, tomorrow, or
+            // yesterday with time. Otherwise, use long date format.
+            const dateTimeString = moment(alert.effectiveStartDate).calendar({
+              sameDay: `${timeFormat}, [Today]`,
+              nextDay: `${timeFormat}, [Tomorrow]`,
+              lastDay: `${timeFormat}, [Yesterday]`,
+              lastWeek: `${longDateFormat}`,
+              sameElse: `${longDateFormat}`
+            })
             const effectiveDateString = `Effective as of ${dateTimeString}`
             return (
               <div key={i} className='transit-alert'>

--- a/lib/components/narrative/line-itin/transit-leg-body.js
+++ b/lib/components/narrative/line-itin/transit-leg-body.js
@@ -204,13 +204,14 @@ class AlertsBody extends Component {
           .map((alert, i) => {
             // If alert is effective as of +/- one day, use today, tomorrow, or
             // yesterday with time. Otherwise, use long date format.
-            const dateTimeString = moment(alert.effectiveStartDate).calendar({
-              sameDay: `${timeFormat}, [Today]`,
-              nextDay: `${timeFormat}, [Tomorrow]`,
-              lastDay: `${timeFormat}, [Yesterday]`,
-              lastWeek: `${longDateFormat}`,
-              sameElse: `${longDateFormat}`
-            })
+            const dateTimeString = moment(alert.effectiveStartDate)
+              .calendar(null, {
+                sameDay: `${timeFormat}, [Today]`,
+                nextDay: `${timeFormat}, [Tomorrow]`,
+                lastDay: `${timeFormat}, [Yesterday]`,
+                lastWeek: `${longDateFormat}`,
+                sameElse: `${longDateFormat}`
+              })
             const effectiveDateString = `Effective as of ${dateTimeString}`
             return (
               <div key={i} className='transit-alert'>


### PR DESCRIPTION
Somehow #94 did not contain a final commit that I thought it did. I'm not sure what happened there, but this commit should contain the appropriate string rendering to handle all of the cases.

fix ibi-group/trimet-mod-otp#136