### PR TITLE
Fix a bug that occurred when rendering geometry with 0 length

### DIFF
--- a/lib/components/map/base-map.js
+++ b/lib/components/map/base-map.js
@@ -275,6 +275,7 @@ class BaseMap extends Component {
         center={center}
         // onClick={this._onLeftClick}
         zoom={config.map.initZoom || 13}
+        maxZoom={config.map.maxZoom}
         onOverlayAdd={this._onOverlayAdd}
         onOverlayRemove={this._onOverlayRemove}
         onViewportChanged={this._onViewportChanged}

--- a/lib/util/itinerary.js
+++ b/lib/util/itinerary.js
@@ -232,7 +232,7 @@ export function getItineraryBounds (itinerary) {
  * Return a leaflet LatLngBounds object that encloses the given leg's geometry.
  */
 export function getLegBounds (leg) {
-  let coords = polyline
+  const coords = polyline
     .toGeoJSON(leg.legGeometry.points)
     .coordinates.map(c => [c[1], c[0]])
 
@@ -240,10 +240,7 @@ export function getLegBounds (leg) {
   // geometry. In these cases, build us an array of coordinates using the from
   // and to data of the leg.
   if (coords.length === 0) {
-    coords = [
-      [leg.from.lat, leg.from.lon],
-      [leg.to.lat, leg.to.lon]
-    ]
+    coords.push([leg.from.lat, leg.from.lon], [leg.to.lat, leg.to.lon])
   }
   return latLngBounds(coords)
 }

--- a/lib/util/itinerary.js
+++ b/lib/util/itinerary.js
@@ -228,11 +228,24 @@ export function getItineraryBounds (itinerary) {
   return latLngBounds(coords)
 }
 
+/**
+ * Return a leaflet LatLngBounds object that encloses the given leg's geometry.
+ */
 export function getLegBounds (leg) {
-  return latLngBounds(polyline
+  let coords = polyline
     .toGeoJSON(leg.legGeometry.points)
     .coordinates.map(c => [c[1], c[0]])
-  )
+
+  // in certain cases, there might be zero-length coordinates in the leg
+  // geometry. In these cases, build us an array of coordinates using the from
+  // and to data of the leg.
+  if (coords.length === 0) {
+    coords = [
+      [leg.from.lat, leg.from.lon],
+      [leg.to.lat, leg.to.lon]
+    ]
+  }
+  return latLngBounds(coords)
 }
 
 export function routeComparator (a, b) {


### PR DESCRIPTION
This PR:

- fixes a bug that occurs when zooming in to a leg that doesn't have geometry info
- allows the configuration of the max zoom level of the map

Fixes https://github.com/ibi-group/trimet-mod-otp/issues/250