### PR TITLE
Change directories for cp scripts

### DIFF
--- a/cpbuild.sh
+++ b/cpbuild.sh
@@ -1,5 +1,5 @@
 echo 'rebuilding..'
 yarn prepublish
 echo 'copying built js..'
-cp -r ./build ~/dev/otp/trimet-mod-otp/node_modules/otp-react-redux
+cp -r ./build ~/git/trimet-mod-otp/node_modules/otp-react-redux
 echo 'done'

--- a/cpcss.sh
+++ b/cpcss.sh
@@ -1,5 +1,4 @@
 echo "building and copying css.."
 mastarm build
-cp ~/dev/otp/otp-react-redux/dist/index.css* ~/dev/otp/trimet-mod-otp/node_modules/otp-react-redux/dist/
+cp ~/git/otp-react-redux/dist/index.css* ~/git/trimet-mod-otp/node_modules/otp-react-redux/dist/
 echo "done"
-


### PR DESCRIPTION
This PR changes the location of the cp scripts to use `~/git/...` instead of `~dev/otp/...`.