### PR TITLE
Fix undefined error if long name missing

### DIFF
--- a/lib/components/viewers/route-viewer.js
+++ b/lib/components/viewers/route-viewer.js
@@ -112,10 +112,16 @@ class RouteRow extends PureComponent {
     const {defaultRouteColor, defaultRouteTextColor, longNameSplitter} = operator || {}
     const color = `#${defaultRouteTextColor || route.textColor || '000000'}`
     const backgroundColor = `#${defaultRouteColor || route.color || 'ffffff'}`
-    const nameParts = route.longName.split(longNameSplitter)
-    const longName = (longNameSplitter && route.longName && nameParts.length > 1)
-      ? nameParts[1]
-      : route.longName
+    // Default long name is empty string (long name is an optional GTFS value).
+    let longName = ''
+    if (route.longName) {
+      // Attempt to split route name if splitter is defined for operator (to
+      // remove short name value from start of long name value).
+      const nameParts = route.longName.split(longNameSplitter)
+      longName = (longNameSplitter && nameParts.length > 1)
+        ? nameParts[1]
+        : route.longName
+    }
     return (
       <div
         style={{


### PR DESCRIPTION
If a route in a GTFS feed has no long name (a valid scenario), opening the route viewer causes an undefined error when attempting to split the undefined long name value.

https://github.com/opentripplanner/otp-react-redux/blob/master/lib/components/viewers/route-viewer.js#L115-L118

This change fixes that.

Bug is visible in current IBI demo (KCM feed is the culprit): https://otp-mod.ibi-transit.com/#/route

EDIT: I think I actually deployed this fix to the above demo site from my local machine (which is why the bug is no longer visible).