### PR TITLE
Fix css error mobile.css

### DIFF
--- a/lib/components/mobile/mobile.css
+++ b/lib/components/mobile/mobile.css
@@ -129,7 +129,7 @@
 /* Results screen: normal display */
 
 .otp.mobile .mobile-narrative-header {
-  position: fixed,
+  position: fixed;
   height: 40px;
   left: 0;
   right: 0;


### PR DESCRIPTION
There is a css error in this file.
Fix is simple; now show narrative header in mobile version.