### PR TITLE
Persist routerId across page reloads

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -71,13 +71,14 @@ export function matchContentToUrl (location) {
         // Parse comma separated params (ensuring numbers are parsed correctly).
         let [lat, lon, zoom, routerId] = id ? idToParams(id) : []
         if (!lat || !lon) {
-          // Attempt to parse path. (Legacy UI otp.js used slashes in the
-          // pathname to specify lat, lon, etc.)
+          // Attempt to parse path if lat/lon not found. (Legacy UI otp.js used
+          // slashes in the pathname to specify lat, lon, etc.)
           [,, lat, lon, zoom, routerId] = idToParams(location.pathname, '/')
         }
+        console.log(lat, lon, zoom, routerId)
         // Update map location/zoom and optionally override router ID.
-        dispatch(setMapCenter({ lat, lon }))
-        dispatch(setMapZoom({ zoom }))
+        if (+lat && +lon) dispatch(setMapCenter({ lat, lon }))
+        if (+zoom) dispatch(setMapZoom({ zoom }))
         // If router ID is provided, override the default routerId.
         if (routerId) dispatch(setRouterId(routerId))
         dispatch(setMainPanelContent(null))
@@ -90,6 +91,10 @@ export function matchContentToUrl (location) {
   }
 }
 
+/**
+ * Split the path id into its parts (according to specified delimiter). Parse
+ * numbers if detected.
+ */
 function idToParams (id, delimiter = ',') {
   return id.split(delimiter).map(s => isNaN(s) ? s : +s)
 }

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -79,16 +79,7 @@ export function matchContentToUrl (location) {
         dispatch(setMapCenter({ lat, lon }))
         dispatch(setMapZoom({ zoom }))
         // If router ID is provided, override the default routerId.
-        if (routerId) {
-          // This is a somewhat hidden element of the trip planner, so show a
-          // confirmation message to the user to ensure they are aware of what
-          // is happening.
-          const useAltRouterId = window.confirm(
-            `The trip planner's router is set to ${routerId}.\n\nClick OK to confirm or Cancel to use the default router.\n\nNote: new sessions opened with URLs copied from this tab's address bar will not reference the correct router (must contain the #/start/lat/lon/zoom/router prefix).`
-          )
-          if (useAltRouterId) dispatch(setRouterId(routerId))
-          else dispatch(setRouterId(null))
-        }
+        if (routerId) dispatch(setRouterId(routerId))
         dispatch(setMainPanelContent(null))
         break
       // For any other route path, just revert to default panel.

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -78,7 +78,17 @@ export function matchContentToUrl (location) {
         // Update map location/zoom and optionally override router ID.
         dispatch(setMapCenter({ lat, lon }))
         dispatch(setMapZoom({ zoom }))
-        if (routerId) dispatch(setRouterId(routerId))
+        // If router ID is provided, override the default routerId.
+        if (routerId) {
+          // This is a somewhat hidden element of the trip planner, so show a
+          // confirmation message to the user to ensure they are aware of what
+          // is happening.
+          const useAltRouterId = window.confirm(
+            `The trip planner's router is set to ${routerId}.\n\nClick OK to confirm or Cancel to use the default router.\n\nNote: new sessions opened with URLs copied from this tab's address bar will not reference the correct router (must contain the #/start/lat/lon/zoom/router prefix).`
+          )
+          if (useAltRouterId) dispatch(setRouterId(routerId))
+          else dispatch(setRouterId(null))
+        }
         dispatch(setMainPanelContent(null))
         break
       // For any other route path, just revert to default panel.

--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -106,20 +106,20 @@ class ResponsiveWebapp extends Component {
         { enableHighAccuracy: true }
       )
     }
-
+    // Handle routing to a specific part of the app (e.g. stop viewer) on page
+    // load. (This happens prior to routing request in case special routerId is
+    // set from URL.)
+    this.props.matchContentToUrl(this.props.location)
     if (location && location.search) {
       // Set search params and plan trip if routing enabled and a query exists
       // in the URL.
       this.props.parseUrlQueryString()
     }
-    // Handle routing to a specific part of the app (e.g. stop viewer) on page
-    // load.
-    this.props.matchContentToUrl(this.props.location)
   }
 
   componentWillUnmount () {
     // Remove on back button press listener.
-    window.removeEventListener('popstate')
+    window.removeEventListener('popstate', this.props.handleBackButtonPress)
   }
 
   render () {

--- a/lib/components/narrative/trip-tools.js
+++ b/lib/components/narrative/trip-tools.js
@@ -77,10 +77,24 @@ class CopyUrlButton extends Component {
     this.state = { showCopied: false }
   }
 
+  _resetState = () => this.setState({ showCopied: false })
+
   _onClick = () => {
-    copyToClipboard(window.location.href)
+    // If special routerId has been set in session storage, construct copy URL
+    // for itinerary with #/start/ prefix to set routerId on page load.
+    const routerId = window.sessionStorage.getItem('routerId')
+    let url = window.location.href
+    if (routerId) {
+      const parts = url.split('#')
+      if (parts.length === 2) {
+        url = `${parts[0]}#/start/x/x/x/${routerId}${parts[1]}`
+      } else {
+        console.warn('URL not formatted as expected, copied URL will not contain session routerId.', routerId)
+      }
+    }
+    copyToClipboard(url)
     this.setState({ showCopied: true })
-    setTimeout(() => { this.setState({ showCopied: false }) }, 2000)
+    window.setTimeout(this._resetState, 2000)
   }
 
   render () {

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -130,9 +130,9 @@ export function getInitialState (userDefinedConfig, initialQuery) {
   // Note: this mechanism assumes that the OTP API path is otp/routers/default.
   const routerId = window.sessionStorage.getItem('routerId')
   // If routerId is found, update the config.api.path (keep the original config
-  // value at _path in case it needs to be reverted.)
+  // value at originalPath in case it needs to be reverted.)
   if (routerId) {
-    config.api._path = userDefinedConfig.api.path
+    config.api.originalPath = userDefinedConfig.api.path
     config.api.path = `/otp/routers/${routerId}`
   }
   let queryModes = currentQuery.mode.split(',')
@@ -557,13 +557,13 @@ function createOtpReducer (config, initialQuery) {
         })
       case 'SET_ROUTER_ID':
         const routerId = action.payload
-        // Store original path value in _path variable.
-        const _path = config.api._path || config.api.path || '/otp/routers/default'
+        // Store original path value in originalPath variable.
+        const originalPath = config.api.originalPath || config.api.path || '/otp/routers/default'
         const path = routerId
           ? `/otp/routers/${routerId}`
           // If routerId is null, revert to the original config's API path (or
           // the standard path if that is not found).
-          : _path
+          : originalPath
         // Store routerId in session storage (persists through page reloads but
         // not when a new tab/window is opened).
         if (routerId) window.sessionStorage.setItem('routerId', routerId)
@@ -572,7 +572,7 @@ function createOtpReducer (config, initialQuery) {
           config: {
             api: {
               path: { $set: path },
-              _path: { $set: _path }
+              originalPath: { $set: originalPath }
             }
           }
         })

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -121,6 +121,16 @@ export function getInitialState (userDefinedConfig, initialQuery) {
   if (config.locations) {
     locations.push(...config.locations.map(l => ({ ...l, type: 'suggested' })))
   }
+  // Check for alternative routerId in session storage. This is generally used
+  // for testing single GTFS feed OTP graphs that are deployed to feed-specific
+  // routers (e.g., https://otp.server.com/otp/routers/non_default_router).
+  // This routerId session value is initially set by visiting otp-rr
+  // with the path /start/:latLonZoomRouter, which dispatches the SET_ROUTER_ID
+  // action and stores the value in sessionStorage.
+  const routerId = window.sessionStorage.getItem('routerId')
+  if (routerId) {
+    config.api.path = `/otp/routers/${routerId}`
+  }
   let queryModes = currentQuery.mode.split(',')
 
   // If 'TRANSIT' is included in the mode list, replace it with individual modes
@@ -543,6 +553,9 @@ function createOtpReducer (config, initialQuery) {
         })
       case 'SET_ROUTER_ID':
         const routerId = action.payload || 'default'
+        // Store routerId in session storage (persists through page reloads but
+        // not when a new tab/window is opened).
+        window.sessionStorage.setItem('routerId', routerId)
         return update(state, {
           config: {
             api: {

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -127,8 +127,12 @@ export function getInitialState (userDefinedConfig, initialQuery) {
   // This routerId session value is initially set by visiting otp-rr
   // with the path /start/:latLonZoomRouter, which dispatches the SET_ROUTER_ID
   // action and stores the value in sessionStorage.
+  // Note: this mechanism assumes that the OTP API path is otp/routers/default.
   const routerId = window.sessionStorage.getItem('routerId')
+  // If routerId is found, update the config.api.path (keep the original config
+  // value at _path in case it needs to be reverted.)
   if (routerId) {
+    config.api._path = userDefinedConfig.api.path
     config.api.path = `/otp/routers/${routerId}`
   }
   let queryModes = currentQuery.mode.split(',')
@@ -552,14 +556,23 @@ function createOtpReducer (config, initialQuery) {
           }
         })
       case 'SET_ROUTER_ID':
-        const routerId = action.payload || 'default'
+        const routerId = action.payload
+        // Store original path value in _path variable.
+        const _path = config.api._path || config.api.path || '/otp/routers/default'
+        const path = routerId
+          ? `/otp/routers/${routerId}`
+          // If routerId is null, revert to the original config's API path (or
+          // the standard path if that is not found).
+          : _path
         // Store routerId in session storage (persists through page reloads but
         // not when a new tab/window is opened).
-        window.sessionStorage.setItem('routerId', routerId)
+        if (routerId) window.sessionStorage.setItem('routerId', routerId)
+        else window.sessionStorage.removeItem('routerId')
         return update(state, {
           config: {
             api: {
-              path: { $set: `/otp/routers/${routerId}` }
+              path: { $set: path },
+              _path: { $set: _path }
             }
           }
         })


### PR DESCRIPTION
This PR fixes #161. otp-rr already has a provision for overriding the default router (note: this feature will be going away with otp 2.x). This simply adds persistence of this override value for the session (across page reloads, but not new tabs). It also adds a confirm message with the option to revert to the default router.

To test: 
1. `yarn start`
2. Go to `http://localhost:9966/#/start/40.5885995/-73.6394705/11/City_of_Long_Beach_ea05fbd9-bfc6-413a-ab04-e777b95484dd`
3. Open js console
4. Plan trip
5. API request should go to `/otp/routers/City_of_Long_Beach_ea05fbd9-bfc6-413a-ab04-e777b95484dd`
5. 🆕 Click `Copy Link` button to get a URL with the routerId included. Paste into new tab and verify that trip is planned correctly.
6. To remove override, `http://localhost:9966/#/start/40.5885995/-73.6394705/11/SOME_OTHER_VALUE`. And click Cancel.