### PR TITLE
fix(BaseMap): Pass baseLayers from map config to BaseMap.

### DIFF
--- a/lib/components/map/default-map.js
+++ b/lib/components/map/default-map.js
@@ -85,6 +85,7 @@ class DefaultMap extends Component {
     return (
       <MapContainer>
         <BaseMap
+          baseLayers={mapConfig.baseLayers}
           center={center}
           maxZoom={mapConfig.maxZoom}
           onClick={this.onMapClick}


### PR DESCRIPTION
Just occurred to me that `baseLayers` from map configuration were never passed to the refactored map component. 