### PR TITLE
improvement(example): Move Auth0Provider plumbing out of example.js a…

### DIFF
--- a/example.js
+++ b/example.js
@@ -16,8 +16,8 @@ import { Grid, Row, Col } from 'react-bootstrap'
 
 // import OTP-RR components
 import {
-  AppNav,
   DefaultMainPanel,
+  DesktopNav,
   Map,
   MobileMain,
   ResponsiveWebapp,
@@ -81,7 +81,7 @@ class OtpRRExample extends Component {
     /** desktop view **/
     const desktopView = (
       <div className='otp'>
-        <AppNav otpConfig={otpConfig} title='OpenTripPlanner' />
+        <DesktopNav />
         <Grid>
           <Row className='main-row'>
             <Col sm={6} md={4} className='sidebar'>

--- a/example.js
+++ b/example.js
@@ -11,21 +11,15 @@ import { Provider } from 'react-redux'
 import thunk from 'redux-thunk'
 import createLogger from 'redux-logger'
 
-// Auth0
-import { Auth0Provider } from 'use-auth0-hooks'
-import { accountLinks, getAuth0Callbacks, getAuth0Config } from './lib/util/auth'
-import { AUTH0_AUDIENCE, AUTH0_SCOPE, URL_ROOT } from './lib/util/constants'
-
 // import Bootstrap Grid components for layout
-import { Nav, Navbar, Grid, Row, Col } from 'react-bootstrap'
+import { Grid, Row, Col } from 'react-bootstrap'
 
 // import OTP-RR components
 import {
-  AppMenu,
+  AppNav,
   DefaultMainPanel,
   Map,
   MobileMain,
-  NavLoginButtonAuth0,
   ResponsiveWebapp,
   createOtpReducer,
   createUserReducer
@@ -81,37 +75,13 @@ const store = createStore(
   compose(applyMiddleware(...middleware))
 )
 
-// Auth0 config and callbacks.
-const auth0Config = getAuth0Config(otpConfig.persistence)
-const auth0Callbacks = getAuth0Callbacks(store)
-
 // define a simple responsive UI using Bootstrap and OTP-RR
 class OtpRRExample extends Component {
   render () {
     /** desktop view **/
     const desktopView = (
       <div className='otp'>
-        <Navbar fluid inverse>
-          <Navbar.Header>
-            <Navbar.Brand>
-              <div style={{ float: 'left', color: 'white', fontSize: 28 }}>
-                <AppMenu />
-              </div>
-              <div className='navbar-title' style={{ marginLeft: 50 }}>OpenTripPlanner</div>
-            </Navbar.Brand>
-          </Navbar.Header>
-
-          {auth0Config && (
-            <Navbar.Collapse>
-              <Nav pullRight>
-                <NavLoginButtonAuth0
-                  id='login-control'
-                  links={accountLinks}
-                />
-              </Nav>
-            </Navbar.Collapse>
-          )}
-        </Navbar>
+        <AppNav otpConfig={otpConfig} title='OpenTripPlanner' />
         <Grid>
           <Row className='main-row'>
             <Col sm={6} md={4} className='sidebar'>
@@ -146,34 +116,20 @@ class OtpRRExample extends Component {
   }
 }
 
-const innerProvider = (
-  <Provider store={store}>
-    { /**
+// render the app
+render(
+  (
+    <Provider store={store}>
+      { /**
      * If not using router history, simply include OtpRRExample here:
      * e.g.
      * <OtpRRExample />
      */
-    }
-    <OtpRRExample />
-  </Provider>
-)
-
-// render the app
-render(auth0Config
-  ? (
-    <Auth0Provider
-      audience={AUTH0_AUDIENCE}
-      scope={AUTH0_SCOPE}
-      domain={auth0Config.domain}
-      clientId={auth0Config.clientId}
-      redirectUri={URL_ROOT}
-      {...auth0Callbacks}
-    >
-      {innerProvider}
-    </Auth0Provider>
+      }
+      <OtpRRExample />
+    </Provider>
   )
-  : innerProvider
-,
+  ,
 
-document.getElementById('root')
+  document.getElementById('root')
 )

--- a/lib/actions/auth.js
+++ b/lib/actions/auth.js
@@ -30,7 +30,7 @@ export function showLoginError (err) {
 /**
  * This function is called by the Auth0Provider component, with the described parameter(s),
  * after the user signs in.
- * @param {Error} err
+ * @param {Object} appState The state that was stored when calling useAuth().login().
  */
 export function processSignIn (appState) {
   return function (dispatch, getState) {
@@ -41,7 +41,10 @@ export function processSignIn (appState) {
       // Here, we save the URL hash prior to login (contains a combination of itinerary search, stop/trip view, etc.),
       // so that the AfterLoginScreen can redirect back there when logged-in user info is fetched.
       // (For routing, it is easier to deal with the path without the hash sign.)
-      const urlHashWithoutHash = (appState.urlHash.split('#')[1] || '/')
+      const hashIndex = appState.urlHash.indexOf('#')
+      const urlHashWithoutHash = hashIndex >= 0
+        ? appState.urlHash.substr(hashIndex + 1)
+        : '/'
       dispatch(setPathBeforeSignIn(urlHashWithoutHash))
     } else if (appState && appState.returnTo) {
       // TODO: Handle other after-login situations.

--- a/lib/actions/auth.js
+++ b/lib/actions/auth.js
@@ -1,0 +1,56 @@
+import { push } from 'connected-react-router'
+
+import { setPathBeforeSignIn } from '../actions/user'
+
+/**
+ * This function is called by the Auth0Provider component, with the described parameter(s),
+ * when a new access token could not be retrieved.
+ * @param {Error} err
+ * @param {AccessTokenRequestOptions} options
+ */
+export function showAccessTokenError (err, options) {
+  return function (dispatch, getState) {
+    // TODO: improve this.
+    console.error('Failed to retrieve access token: ', err)
+  }
+}
+
+/**
+ * This function is called by the Auth0Provider component, with the described parameter(s),
+ * when signing-in fails for some reason.
+ * @param {Error} err
+ */
+export function showLoginError (err) {
+  return function (dispatch, getState) {
+    // TODO: improve this.
+    if (err) dispatch(push('/oops'))
+  }
+}
+
+/**
+ * This function is called by the Auth0Provider component, with the described parameter(s),
+ * after the user signs in.
+ * @param {Error} err
+ */
+export function processSignIn (appState) {
+  return function (dispatch, getState) {
+    if (appState && appState.urlHash) {
+      // At this stage after login, Auth0 has already redirected to /signedin (Auth0-whitelisted)
+      // which shows the AfterLoginScreen.
+      //
+      // Here, we save the URL hash prior to login (contains a combination of itinerary search, stop/trip view, etc.),
+      // so that the AfterLoginScreen can redirect back there when logged-in user info is fetched.
+      // (For routing, it is easier to deal with the path without the hash sign.)
+      const urlHashWithoutHash = (appState.urlHash.split('#')[1] || '/')
+      dispatch(setPathBeforeSignIn(urlHashWithoutHash))
+    } else if (appState && appState.returnTo) {
+      // TODO: Handle other after-login situations.
+      // Note that when redirecting from a login-protected (e.g. account) page while logged out,
+      //     then returnTo is set by Auth0 to this object format:
+      //     {
+      //       pathname: "/"
+      //       query: { ... }
+      //     }
+    }
+  }
+}

--- a/lib/components/app/app-nav.js
+++ b/lib/components/app/app-nav.js
@@ -4,10 +4,9 @@ import { connect } from 'react-redux'
 
 import NavLoginButtonAuth0 from '../user/nav-login-button-auth0.js'
 import { accountLinks, getAuth0Config } from '../../util/auth'
-
 import AppMenu from './app-menu'
 
-const AppNav = ({ otpConfig }) => {
+const AppNav = ({ otpConfig, title }) => {
   const { branding, persistence } = otpConfig
   const showLogin = Boolean(getAuth0Config(persistence))
 
@@ -15,15 +14,23 @@ const AppNav = ({ otpConfig }) => {
     <Navbar fluid inverse>
       <Navbar.Header>
         <Navbar.Brand>
-          <div className='app-menu-container'>
+          {/* TODO: Reconcile CSS class and inline style. */}
+          <div className='app-menu-container' style={{ float: 'left', color: 'white', fontSize: 28 }}>
             <AppMenu />
           </div>
-          <div
-            className={`icon-${branding}`}
-            // This style is applied here because it is only intended for
-            // desktop view.
-            style={{ marginLeft: 50 }}
-          />
+
+          {branding && (
+            <div
+              className={`icon-${branding}`}
+              // This style is applied here because it is only intended for
+              // desktop view.
+              style={{ marginLeft: 50 }}
+            />
+          )}
+
+          {title && (
+            <div className='navbar-title' style={{ marginLeft: 50 }}>OpenTripPlanner</div>
+          )}
         </Navbar.Brand>
       </Navbar.Header>
 

--- a/lib/components/app/desktop-nav.js
+++ b/lib/components/app/desktop-nav.js
@@ -1,19 +1,43 @@
-import PropTypes from 'prop-types'
 import React from 'react'
 import { Nav, Navbar } from 'react-bootstrap'
 import { connect } from 'react-redux'
 
 import NavLoginButtonAuth0 from '../user/nav-login-button-auth0.js'
 import { accountLinks, getAuth0Config } from '../../util/auth'
+import { DEFAULT_APP_TITLE } from '../../util/constants'
 import AppMenu from './app-menu'
 
 /**
- * The desktop navigation bar, featuring a sign-in button/menu.
+ * The desktop navigation bar, featuring a `branding` logo or a `title` text
+ * defined in config.yml, and a sign-in button/menu with account links.
+ *
+ * The `branding` and `title` parameters in config.yml are handled
+ * and shown in this order in the navigation bar:
+ * 1. If `branding` is defined, it is shown, and no title is displayed.
+ * 2. If `branding` is not defined but if `title` is, then `title` is shown.
+ * 3. If neither is defined, just show 'OpenTripPlanner' (DEFAULT_APP_TITLE).
+ *
  * TODO: merge with the mobile navigation bar.
  */
-const DesktopNav = ({ otpConfig, title }) => {
-  const { branding, persistence } = otpConfig
+const DesktopNav = ({ otpConfig }) => {
+  const { branding, persistence, title = DEFAULT_APP_TITLE } = otpConfig
   const showLogin = Boolean(getAuth0Config(persistence))
+
+  // Display branding and title in the order as described in the class summary.
+  let brandingOrTitle
+  if (branding) {
+    brandingOrTitle = (
+      <div
+        className={`icon-${branding}`}
+        // FIXME: Style hack for desktop view.
+        style={{ marginLeft: 50 }}
+      />
+    )
+  } else {
+    brandingOrTitle = (
+      <div className='navbar-title' style={{ marginLeft: 50 }}>{title}</div>
+    )
+  }
 
   return (
     <Navbar fluid inverse>
@@ -24,17 +48,8 @@ const DesktopNav = ({ otpConfig, title }) => {
             <AppMenu />
           </div>
 
-          {branding && (
-            <div
-              className={`icon-${branding}`}
-              // Style hack for desktop view.
-              style={{ marginLeft: 50 }}
-            />
-          )}
+          {brandingOrTitle}
 
-          {title && (
-            <div className='navbar-title' style={{ marginLeft: 50 }}>{title}</div>
-          )}
         </Navbar.Brand>
       </Navbar.Header>
 
@@ -50,14 +65,6 @@ const DesktopNav = ({ otpConfig, title }) => {
       )}
     </Navbar>
   )
-}
-
-DesktopNav.propTypes = {
-  title: PropTypes.string
-}
-
-DesktopNav.defaultProps = {
-  title: 'OpenTripPlanner'
 }
 
 // connect to the redux store

--- a/lib/components/app/desktop-nav.js
+++ b/lib/components/app/desktop-nav.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Nav, Navbar } from 'react-bootstrap'
 import { connect } from 'react-redux'
@@ -6,7 +7,11 @@ import NavLoginButtonAuth0 from '../user/nav-login-button-auth0.js'
 import { accountLinks, getAuth0Config } from '../../util/auth'
 import AppMenu from './app-menu'
 
-const AppNav = ({ otpConfig, title }) => {
+/**
+ * The desktop navigation bar, featuring a sign-in button/menu.
+ * TODO: merge with the mobile navigation bar.
+ */
+const DesktopNav = ({ otpConfig, title }) => {
   const { branding, persistence } = otpConfig
   const showLogin = Boolean(getAuth0Config(persistence))
 
@@ -22,14 +27,13 @@ const AppNav = ({ otpConfig, title }) => {
           {branding && (
             <div
               className={`icon-${branding}`}
-              // This style is applied here because it is only intended for
-              // desktop view.
+              // Style hack for desktop view.
               style={{ marginLeft: 50 }}
             />
           )}
 
           {title && (
-            <div className='navbar-title' style={{ marginLeft: 50 }}>OpenTripPlanner</div>
+            <div className='navbar-title' style={{ marginLeft: 50 }}>{title}</div>
           )}
         </Navbar.Brand>
       </Navbar.Header>
@@ -48,6 +52,14 @@ const AppNav = ({ otpConfig, title }) => {
   )
 }
 
+DesktopNav.propTypes = {
+  title: PropTypes.string
+}
+
+DesktopNav.defaultProps = {
+  title: 'OpenTripPlanner'
+}
+
 // connect to the redux store
 
 const mapStateToProps = (state, ownProps) => {
@@ -59,4 +71,4 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = {
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(AppNav)
+export default connect(mapStateToProps, mapDispatchToProps)(DesktopNav)

--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { Route, Switch, withRouter } from 'react-router'
+import { Auth0Provider } from 'use-auth0-hooks'
 
 import PrintLayout from './print-layout'
 import { setMapCenter, setMapZoom } from '../../actions/config'
@@ -13,6 +14,8 @@ import { formChanged, parseUrlQueryString } from '../../actions/form'
 import { getCurrentPosition, receivedPositionResponse } from '../../actions/location'
 import { setLocationToCurrent } from '../../actions/map'
 import { handleBackButtonPress, matchContentToUrl } from '../../actions/ui'
+import { getAuth0Callbacks, getAuth0Config } from '../../util/auth'
+import { AUTH0_AUDIENCE, AUTH0_SCOPE, URL_ROOT } from '../../util/constants'
 import { getActiveItinerary, getTitle } from '../../util/state'
 import AfterSignInScreen from '../user/after-signin-screen'
 import UserAccountScreen from '../user/user-account-screen'
@@ -180,8 +183,12 @@ class RouterWrapper extends Component {
   }
 
   render () {
-    const { routerConfig } = this.props
-    return (
+    const { dispatch, persistence, routerConfig } = this.props
+    // Initialize Auth0Provider in this component so it is available everywhere.
+    const auth0Config = getAuth0Config(persistence)
+    const auth0Callbacks = getAuth0Callbacks(dispatch)
+
+    const router = (
       <ConnectedRouter
         basename={routerConfig && routerConfig.basename}
         history={history}>
@@ -241,7 +248,27 @@ class RouterWrapper extends Component {
         </div>
       </ConnectedRouter>
     )
+
+    return (
+      auth0Config
+        ? (
+          <Auth0Provider
+            audience={AUTH0_AUDIENCE}
+            scope={AUTH0_SCOPE}
+            domain={auth0Config.domain}
+            clientId={auth0Config.clientId}
+            redirectUri={URL_ROOT}
+            {...auth0Callbacks}
+          >
+            {router}
+          </Auth0Provider>
+        )
+        : router
+    )
   }
 }
-const mapStateToWrapperProps = (state, ownProps) => ({ routerConfig: state.otp.config.reactRouter })
+const mapStateToWrapperProps = (state, ownProps) => ({
+  persistence: state.otp.config.persistence,
+  routerConfig: state.otp.config.reactRouter
+})
 export default connect(mapStateToWrapperProps)(RouterWrapper)

--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -9,15 +9,17 @@ import { Route, Switch, withRouter } from 'react-router'
 import { Auth0Provider } from 'use-auth0-hooks'
 
 import PrintLayout from './print-layout'
+import * as authActions from '../../actions/auth'
 import { setMapCenter, setMapZoom } from '../../actions/config'
 import { formChanged, parseUrlQueryString } from '../../actions/form'
 import { getCurrentPosition, receivedPositionResponse } from '../../actions/location'
 import { setLocationToCurrent } from '../../actions/map'
 import { handleBackButtonPress, matchContentToUrl } from '../../actions/ui'
-import { getAuth0Callbacks, getAuth0Config } from '../../util/auth'
+import { getAuth0Config } from '../../util/auth'
 import { AUTH0_AUDIENCE, AUTH0_SCOPE, URL_ROOT } from '../../util/constants'
 import { getActiveItinerary, getTitle } from '../../util/state'
 import AfterSignInScreen from '../user/after-signin-screen'
+import BeforeSignInScreen from '../user/before-signin-screen'
 import UserAccountScreen from '../user/user-account-screen'
 import withLoggedInUserSupport from '../user/with-logged-in-user-support'
 
@@ -171,7 +173,13 @@ const WebappWithRouter = withRouter(
   )
 )
 
-class RouterWrapper extends Component {
+/**
+ * The routing component for the application.
+ * This is the top-most "standard" component,
+ * and we initialize the Auth0Provider here
+ * so that Auth0 services are available everywhere.
+ */
+class RouterWrapperWithAuth0 extends Component {
   /**
    * Combine the router props with the other props that get
    * passed to the exported component. This way, it is possible for
@@ -183,10 +191,13 @@ class RouterWrapper extends Component {
   }
 
   render () {
-    const { dispatch, persistence, routerConfig } = this.props
-    // Initialize Auth0Provider in this component so it is available everywhere.
-    const auth0Config = getAuth0Config(persistence)
-    const auth0Callbacks = getAuth0Callbacks(dispatch)
+    const {
+      auth0Config,
+      processSignIn,
+      routerConfig,
+      showAccessTokenError,
+      showLoginError
+    } = this.props
 
     const router = (
       <ConnectedRouter
@@ -254,11 +265,14 @@ class RouterWrapper extends Component {
         ? (
           <Auth0Provider
             audience={AUTH0_AUDIENCE}
-            scope={AUTH0_SCOPE}
-            domain={auth0Config.domain}
             clientId={auth0Config.clientId}
+            domain={auth0Config.domain}
+            onAccessTokenError={showAccessTokenError}
+            onLoginError={showLoginError}
+            onRedirectCallback={processSignIn}
+            onRedirecting={BeforeSignInScreen}
             redirectUri={URL_ROOT}
-            {...auth0Callbacks}
+            scope={AUTH0_SCOPE}
           >
             {router}
           </Auth0Provider>
@@ -267,8 +281,16 @@ class RouterWrapper extends Component {
     )
   }
 }
+
 const mapStateToWrapperProps = (state, ownProps) => ({
-  persistence: state.otp.config.persistence,
+  auth0Config: getAuth0Config(state.otp.config.persistence),
   routerConfig: state.otp.config.reactRouter
 })
-export default connect(mapStateToWrapperProps)(RouterWrapper)
+
+const mapWrapperDispatchToProps = {
+  processSignIn: authActions.processSignIn,
+  showAccessTokenError: authActions.showAccessTokenError,
+  showLoginError: authActions.showLoginError
+}
+
+export default connect(mapStateToWrapperProps, mapWrapperDispatchToProps)(RouterWrapperWithAuth0)

--- a/lib/components/mobile/navigation-bar.js
+++ b/lib/components/mobile/navigation-bar.js
@@ -26,8 +26,13 @@ class MobileNavigationBar extends Component {
   }
 
   render () {
-    const { headerAction, headerText, persistence, showBackButton, title } = this.props
-    const auth0Config = getAuth0Config(persistence)
+    const {
+      auth0Config,
+      headerAction,
+      headerText,
+      showBackButton,
+      title
+    } = this.props
 
     return (
       <Navbar fluid fixedTop>
@@ -75,7 +80,7 @@ class MobileNavigationBar extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    persistence: state.otp.config.persistence
+    auth0Config: getAuth0Config(state.otp.config.persistence)
   }
 }
 

--- a/lib/components/user/before-signin-screen.js
+++ b/lib/components/user/before-signin-screen.js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+/**
+ * This screen is flashed just before the Auth0 login page is shown.
+ * TODO: improve this screen.
+ */
+const BeforeSignInScreen = () => (
+  <div>
+    <h1>Signing you in</h1>
+    <p>
+      In order to access this page you will need to sign in.
+      Please wait while we redirect you to the login page...
+    </p>
+  </div>
+)
+
+export default BeforeSignInScreen

--- a/lib/components/user/user-account-screen.js
+++ b/lib/components/user/user-account-screen.js
@@ -6,7 +6,7 @@ import { withLoginRequired } from 'use-auth0-hooks'
 import { routeTo } from '../../actions/ui'
 import { createOrUpdateUser } from '../../actions/user'
 import { isNewUser } from '../../util/user'
-import AppNav from '../app/app-nav'
+import DesktopNav from '../app/desktop-nav'
 import AccountSetupFinishPane from './account-setup-finish-pane'
 import ExistingAccountDisplay from './existing-account-display'
 import FavoriteLocationsPane from './favorite-locations-pane'
@@ -121,7 +121,7 @@ class UserAccountScreen extends Component {
     return (
       <div className='otp'>
         {/* TODO: Do mobile view. */}
-        <AppNav />
+        <DesktopNav />
         <form className='container'>
           {formContents}
         </form>

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ import ViewerContainer from './components/viewers/viewer-container'
 
 import ResponsiveWebapp from './components/app/responsive-webapp'
 import AppMenu from './components/app/app-menu'
-import AppNav from './components/app/app-nav'
+import DesktopNav from './components/app/desktop-nav'
 import DefaultMainPanel from './components/app/default-main-panel'
 
 import { setAutoPlan, setMapCenter } from './actions/config'
@@ -98,7 +98,7 @@ export {
   // app components,
   ResponsiveWebapp,
   AppMenu,
-  AppNav,
+  DesktopNav,
   DefaultMainPanel,
 
   // actions

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,7 @@ import ViewerContainer from './components/viewers/viewer-container'
 
 import ResponsiveWebapp from './components/app/responsive-webapp'
 import AppMenu from './components/app/app-menu'
+import AppNav from './components/app/app-nav'
 import DefaultMainPanel from './components/app/default-main-panel'
 
 import { setAutoPlan, setMapCenter } from './actions/config'
@@ -97,6 +98,7 @@ export {
   // app components,
   ResponsiveWebapp,
   AppMenu,
+  AppNav,
   DefaultMainPanel,
 
   // actions

--- a/lib/util/auth.js
+++ b/lib/util/auth.js
@@ -42,9 +42,9 @@ export function getAuth0Config (persistence) {
  * Gets the callback methods for Auth0.
  * Note: Methods inside are originally copied from https://github.com/sandrinodimattia/use-auth0-hooks#readme
  * and some methods from that example may still be untouched.
- * @param reduxStore The redux store to carry out the navigation action.
+ * @param dispatch The dispatch method to carry out the actions.
  */
-export function getAuth0Callbacks (reduxStore) {
+export function getAuth0Callbacks (dispatch) {
   return {
     /**
      * When it hasn't been possible to retrieve a new access token.
@@ -60,7 +60,7 @@ export function getAuth0Callbacks (reduxStore) {
      * @param {Error} err
      */
     onLoginError: err => {
-      if (err) reduxStore.dispatch(push(`/oops`))
+      if (err) dispatch(push(`/oops`))
     },
     /**
      * Where to send the user after they have signed in.
@@ -74,7 +74,7 @@ export function getAuth0Callbacks (reduxStore) {
         // so that the AfterLoginScreen can redirect back there when logged-in user info is fetched.
         // (For routing, it is easier to deal with the path without the hash sign.)
         const urlHashWithoutHash = (appState.urlHash.split('#')[1] || '/')
-        reduxStore.dispatch(setPathBeforeSignIn(urlHashWithoutHash))
+        dispatch(setPathBeforeSignIn(urlHashWithoutHash))
       } else if (appState && appState.returnTo) {
         // TODO: Handle other after-login situations.
         // Careful!

--- a/lib/util/auth.js
+++ b/lib/util/auth.js
@@ -1,6 +1,3 @@
-import { push } from 'connected-react-router'
-
-import { setPathBeforeSignIn } from '../actions/user'
 import { PERSISTENCE_STRATEGY_OTP_MIDDLEWARE } from './constants'
 
 /**
@@ -36,70 +33,4 @@ export function getAuth0Config (persistence) {
     return (enabled && strategy === PERSISTENCE_STRATEGY_OTP_MIDDLEWARE) ? auth0 : null
   }
   return null
-}
-
-/**
- * Gets the callback methods for Auth0.
- * Note: Methods inside are originally copied from https://github.com/sandrinodimattia/use-auth0-hooks#readme
- * and some methods from that example may still be untouched.
- * @param dispatch The dispatch method to carry out the actions.
- */
-export function getAuth0Callbacks (dispatch) {
-  return {
-    /**
-     * When it hasn't been possible to retrieve a new access token.
-     * @param {Error} err
-     * @param {AccessTokenRequestOptions} options
-     */
-    onAccessTokenError: (err, options) => {
-      console.error('Failed to retrieve access token: ', err)
-    },
-    /**
-     * When signing in fails for some reason, we want to show it here.
-     * TODO: Implement the error URL.
-     * @param {Error} err
-     */
-    onLoginError: err => {
-      if (err) dispatch(push(`/oops`))
-    },
-    /**
-     * Where to send the user after they have signed in.
-     */
-    onRedirectCallback: appState => {
-      if (appState && appState.urlHash) {
-        // At this stage after login, Auth0 has already redirected to /signedin (Auth0-whitelisted)
-        // which shows the AfterLoginScreen.
-        //
-        // Here, we save the URL hash prior to login (contains a combination of itinerary search, stop/trip view, etc.),
-        // so that the AfterLoginScreen can redirect back there when logged-in user info is fetched.
-        // (For routing, it is easier to deal with the path without the hash sign.)
-        const urlHashWithoutHash = (appState.urlHash.split('#')[1] || '/')
-        dispatch(setPathBeforeSignIn(urlHashWithoutHash))
-      } else if (appState && appState.returnTo) {
-        // TODO: Handle other after-login situations.
-        // Careful!
-        // - When redirecting from a login-protected (e.g. account) page while logged out,
-        //     then returnTo is set by Auth0 to this object format:
-        //     {
-        //       pathname: "/"
-        //       query: { ... }
-        //     }
-      }
-    },
-    /**
-     * When redirecting to the login page you'll end up in this state where the login page is still loading.
-     * You can render a message to show that the user is being redirected.
-     */
-    onRedirecting: () => {
-      return (
-        <div>
-          <h1>Signing you in</h1>
-          <p>
-            In order to access this page you will need to sign in.
-            Please wait while we redirect you to the login page...
-          </p>
-        </div>
-      )
-    }
-  }
 }

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -1,5 +1,6 @@
 export const AUTH0_AUDIENCE = 'https://otp-middleware'
 export const AUTH0_SCOPE = ''
+export const DEFAULT_APP_TITLE = 'OpenTripPlanner'
 export const PERSISTENCE_STRATEGY_OTP_MIDDLEWARE = 'otp_middleware'
 
 // Gets the root URL, e.g. https://otp-instance.example.com:8080, computed once for all.


### PR DESCRIPTION
This pull request addresses this comment: https://github.com/opentripplanner/otp-react-redux/pull/167#discussion_r439492550 and moves the plumbing to set up `Auth0Provider` to the `ConnectedRouter` component.