### PR TITLE
Bump transitive for label fixes (master branch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "redux-logger": "^2.7.4",
     "redux-thunk": "^2.3.0",
     "throttle-debounce": "^2.0.1",
-    "transitive-js": "^0.13.2",
+    "transitive-js": "^0.13.3",
     "turf-along": "^3.0.12",
     "velocity-react": "^1.3.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14784,10 +14784,10 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-transitive-js@^0.13.2:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/transitive-js/-/transitive-js-0.13.2.tgz#ca8adde4ccf5c1fb02623df287ac3c91499c566a"
-  integrity sha512-2r6uoA7pCOyMeecTOWgT+MJMa+gVmLlBR2+s1YKYxBYmusS5Lx24ICqc3RVA2+yE36k9fe+ReMBOcBCoK2mY6w==
+transitive-js@^0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/transitive-js/-/transitive-js-0.13.3.tgz#4c1671628a65551d7b70b53362300d7017fc0ac9"
+  integrity sha512-vm3v3HuCcmoL+64pew5MHltOabN+ONhs/IonHqf6sRWFUcpVgrUBc9OWLzkJpi1DDPiLjZa6KP27WuoZ1Mk/Fg==
   dependencies:
     augment "4.3.0"
     component-each "0.2.6"


### PR DESCRIPTION
This bumps transitive.js to [0.13.3](https://github.com/conveyal/transitive.js/releases/tag/v0.13.3) for some label rendering fixes.