### PR TITLE
fix(actions/api): Send routing requests to middleware

### DIFF
--- a/__tests__/actions/__snapshots__/api.js.snap
+++ b/__tests__/actions/__snapshots__/api.js.snap
@@ -18,6 +18,15 @@ Array [
   Array [
     Object {
       "payload": Object {
+        "error": [Error: only http(s) protocols are supported],
+        "searchId": "abcd1234",
+      },
+      "type": "ROUTING_ERROR",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
         "activeItinerary": 0,
         "routingType": "ITINERARY",
         "searchId": "abcd1235",
@@ -48,5 +57,3 @@ Array [
   ],
 ]
 `;
-
-exports[`actions > api routingQuery should make a query to OTP: OTP Query Path 1`] = `"/api/plan?fromPlace=Origin%20%2812%2C34%29%3A%3A12%2C34&toPlace=Destination%20%2834%2C12%29%3A%3A34%2C12&mode=WALK%2CTRANSIT"`;

--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -376,7 +376,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                     From Location Icon
                                   </title>
                                   <path
-                                    d="M256 8C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm80 248c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80z"
+                                    d="M256 56c110.532 0 200 89.451 200 200 0 110.532-89.451 200-200 200-110.532 0-200-89.451-200-200 0-110.532 89.451-200 200-200m0-48C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 168c-44.183 0-80 35.817-80 80s35.817 80 80 80 80-35.817 80-80-35.817-80-80-80z"
                                     fill="currentColor"
                                     key="k0"
                                   />
@@ -390,7 +390,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 XBKVp"
+                          className="styled__Button-p56b41-2 bjZNPA"
                           onClick={[Function]}
                         >
                           From here
@@ -471,7 +471,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 XBKVp"
+                          className="styled__Button-p56b41-2 bjZNPA"
                           onClick={[Function]}
                         >
                           To here
@@ -1076,7 +1076,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                     From Location Icon
                                   </title>
                                   <path
-                                    d="M256 8C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm80 248c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80z"
+                                    d="M256 56c110.532 0 200 89.451 200 200 0 110.532-89.451 200-200 200-110.532 0-200-89.451-200-200 0-110.532 89.451-200 200-200m0-48C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 168c-44.183 0-80 35.817-80 80s35.817 80 80 80 80-35.817 80-80-35.817-80-80-80z"
                                     fill="currentColor"
                                     key="k0"
                                   />
@@ -1090,7 +1090,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 XBKVp"
+                          className="styled__Button-p56b41-2 bjZNPA"
                           onClick={[Function]}
                         >
                           From here
@@ -1171,7 +1171,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 XBKVp"
+                          className="styled__Button-p56b41-2 bjZNPA"
                           onClick={[Function]}
                         >
                           To here
@@ -1785,7 +1785,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                     From Location Icon
                                   </title>
                                   <path
-                                    d="M256 8C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm80 248c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80z"
+                                    d="M256 56c110.532 0 200 89.451 200 200 0 110.532-89.451 200-200 200-110.532 0-200-89.451-200-200 0-110.532 89.451-200 200-200m0-48C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 168c-44.183 0-80 35.817-80 80s35.817 80 80 80 80-35.817 80-80-35.817-80-80-80z"
                                     fill="currentColor"
                                     key="k0"
                                   />
@@ -1799,7 +1799,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 XBKVp"
+                          className="styled__Button-p56b41-2 bjZNPA"
                           onClick={[Function]}
                         >
                           From here
@@ -1880,7 +1880,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 XBKVp"
+                          className="styled__Button-p56b41-2 bjZNPA"
                           onClick={[Function]}
                         >
                           To here
@@ -2851,7 +2851,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     From Location Icon
                                   </title>
                                   <path
-                                    d="M256 8C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm80 248c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80z"
+                                    d="M256 56c110.532 0 200 89.451 200 200 0 110.532-89.451 200-200 200-110.532 0-200-89.451-200-200 0-110.532 89.451-200 200-200m0-48C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 168c-44.183 0-80 35.817-80 80s35.817 80 80 80 80-35.817 80-80-35.817-80-80-80z"
                                     fill="currentColor"
                                     key="k0"
                                   />
@@ -2865,7 +2865,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 XBKVp"
+                          className="styled__Button-p56b41-2 bjZNPA"
                           onClick={[Function]}
                         >
                           From here
@@ -2946,7 +2946,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 XBKVp"
+                          className="styled__Button-p56b41-2 bjZNPA"
                           onClick={[Function]}
                         >
                           To here
@@ -4651,7 +4651,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                     From Location Icon
                                   </title>
                                   <path
-                                    d="M256 8C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm80 248c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80z"
+                                    d="M256 56c110.532 0 200 89.451 200 200 0 110.532-89.451 200-200 200-110.532 0-200-89.451-200-200 0-110.532 89.451-200 200-200m0-48C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 168c-44.183 0-80 35.817-80 80s35.817 80 80 80 80-35.817 80-80-35.817-80-80-80z"
                                     fill="currentColor"
                                     key="k0"
                                   />
@@ -4665,7 +4665,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 XBKVp"
+                          className="styled__Button-p56b41-2 bjZNPA"
                           onClick={[Function]}
                         >
                           From here
@@ -4746,7 +4746,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 XBKVp"
+                          className="styled__Button-p56b41-2 bjZNPA"
                           onClick={[Function]}
                         >
                           To here

--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -376,7 +376,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                     From Location Icon
                                   </title>
                                   <path
-                                    d="M256 56c110.532 0 200 89.451 200 200 0 110.532-89.451 200-200 200-110.532 0-200-89.451-200-200 0-110.532 89.451-200 200-200m0-48C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 168c-44.183 0-80 35.817-80 80s35.817 80 80 80 80-35.817 80-80-35.817-80-80-80z"
+                                    d="M256 8C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm80 248c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80z"
                                     fill="currentColor"
                                     key="k0"
                                   />
@@ -390,7 +390,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 bjZNPA"
+                          className="styled__Button-p56b41-2 XBKVp"
                           onClick={[Function]}
                         >
                           From here
@@ -471,7 +471,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 bjZNPA"
+                          className="styled__Button-p56b41-2 XBKVp"
                           onClick={[Function]}
                         >
                           To here
@@ -1076,7 +1076,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                     From Location Icon
                                   </title>
                                   <path
-                                    d="M256 56c110.532 0 200 89.451 200 200 0 110.532-89.451 200-200 200-110.532 0-200-89.451-200-200 0-110.532 89.451-200 200-200m0-48C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 168c-44.183 0-80 35.817-80 80s35.817 80 80 80 80-35.817 80-80-35.817-80-80-80z"
+                                    d="M256 8C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm80 248c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80z"
                                     fill="currentColor"
                                     key="k0"
                                   />
@@ -1090,7 +1090,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 bjZNPA"
+                          className="styled__Button-p56b41-2 XBKVp"
                           onClick={[Function]}
                         >
                           From here
@@ -1171,7 +1171,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 bjZNPA"
+                          className="styled__Button-p56b41-2 XBKVp"
                           onClick={[Function]}
                         >
                           To here
@@ -1785,7 +1785,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                     From Location Icon
                                   </title>
                                   <path
-                                    d="M256 56c110.532 0 200 89.451 200 200 0 110.532-89.451 200-200 200-110.532 0-200-89.451-200-200 0-110.532 89.451-200 200-200m0-48C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 168c-44.183 0-80 35.817-80 80s35.817 80 80 80 80-35.817 80-80-35.817-80-80-80z"
+                                    d="M256 8C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm80 248c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80z"
                                     fill="currentColor"
                                     key="k0"
                                   />
@@ -1799,7 +1799,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 bjZNPA"
+                          className="styled__Button-p56b41-2 XBKVp"
                           onClick={[Function]}
                         >
                           From here
@@ -1880,7 +1880,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 bjZNPA"
+                          className="styled__Button-p56b41-2 XBKVp"
                           onClick={[Function]}
                         >
                           To here
@@ -2851,7 +2851,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     From Location Icon
                                   </title>
                                   <path
-                                    d="M256 56c110.532 0 200 89.451 200 200 0 110.532-89.451 200-200 200-110.532 0-200-89.451-200-200 0-110.532 89.451-200 200-200m0-48C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 168c-44.183 0-80 35.817-80 80s35.817 80 80 80 80-35.817 80-80-35.817-80-80-80z"
+                                    d="M256 8C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm80 248c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80z"
                                     fill="currentColor"
                                     key="k0"
                                   />
@@ -2865,7 +2865,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 bjZNPA"
+                          className="styled__Button-p56b41-2 XBKVp"
                           onClick={[Function]}
                         >
                           From here
@@ -2946,7 +2946,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 bjZNPA"
+                          className="styled__Button-p56b41-2 XBKVp"
                           onClick={[Function]}
                         >
                           To here
@@ -4651,7 +4651,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                     From Location Icon
                                   </title>
                                   <path
-                                    d="M256 56c110.532 0 200 89.451 200 200 0 110.532-89.451 200-200 200-110.532 0-200-89.451-200-200 0-110.532 89.451-200 200-200m0-48C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 168c-44.183 0-80 35.817-80 80s35.817 80 80 80 80-35.817 80-80-35.817-80-80-80z"
+                                    d="M256 8C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm80 248c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80z"
                                     fill="currentColor"
                                     key="k0"
                                   />
@@ -4665,7 +4665,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 bjZNPA"
+                          className="styled__Button-p56b41-2 XBKVp"
                           onClick={[Function]}
                         >
                           From here
@@ -4746,7 +4746,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                         onClick={[Function]}
                       >
                         <button
-                          className="styled__Button-p56b41-2 bjZNPA"
+                          className="styled__Button-p56b41-2 XBKVp"
                           onClick={[Function]}
                         >
                           To here

--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -195,7 +195,7 @@ function getOtpFetchOptions (state, includeToken = false) {
   }
 
   // FIXME: Reinstate the commented if condition below
-  // (and remove the other one) once there is a fix
+  // (and remove the other one, and update the snapshots) once there is a fix
   // for https://github.com/ibi-group/otp-middleware/issues/26.
   //
   // const isOtpServerSameAsMiddleware = apiBaseUrl === api.host

--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -188,13 +188,19 @@ function getJsonAndCheckResponse (res) {
 function getOtpFetchOptions (state, includeToken = false) {
   let apiBaseUrl, apiKey, token
 
-  const { api, persistence } = state.otp.config
+  // const { api, persistence } = state.otp.config
+  const { persistence } = state.otp.config
   if (persistence && persistence.otp_middleware) {
     ({ apiBaseUrl, apiKey } = persistence.otp_middleware)
   }
 
-  const isOtpServerSameAsMiddleware = apiBaseUrl === api.host
-  if (isOtpServerSameAsMiddleware) {
+  // FIXME: Reinstate the commented if condition below
+  // (and remove the other one) once there is a fix
+  // for https://github.com/ibi-group/otp-middleware/issues/26.
+  //
+  // const isOtpServerSameAsMiddleware = apiBaseUrl === api.host
+  // if (isOtpServerSameAsMiddleware) {
+  if (apiBaseUrl) { // FIXME: remove per above.
     if (includeToken && state.user) {
       const { accessToken, loggedInUser } = state.user
       if (accessToken && loggedInUser) {
@@ -214,6 +220,26 @@ function constructRoutingQuery (otpState, ignoreRealtimeUpdates) {
   // Check for routingType-specific API config; if none, use default API
   const rt = config.routingTypes && config.routingTypes.find(rt => rt.key === routingType)
   const api = (rt && rt.api) || config.api
+
+  // FIXME: Remove this block below once there is a fix
+  // for https://github.com/ibi-group/otp-middleware/issues/26.
+  let apiBaseUrl
+  const { persistence } = config
+  if (persistence && persistence.otp_middleware) {
+    ({ apiBaseUrl } = persistence.otp_middleware)
+  }
+
+  const isOtpServerSameAsMiddleware = apiBaseUrl === api.host
+  if (!isOtpServerSameAsMiddleware) {
+    // Send the plan request to middleware at /plan (no path) if middleware is available but api.host is regular OTP.
+    const planEndpoint = `${apiBaseUrl}${api.port
+      ? ':' + api.port
+      : ''}/plan`
+    const params = getRoutingParams(otpState, ignoreRealtimeUpdates)
+    return `${planEndpoint}?${qs.stringify(params)}`
+  }
+  // END FIXME.
+
   const planEndpoint = `${api.host}${api.port
     ? ':' + api.port
     : ''}${api.path}/plan`


### PR DESCRIPTION
This PR is a temporary remedy until https://github.com/ibi-group/otp-middleware/issues/26 is addressed in the middleware.

To use, set the middleware configuration as normal,
but change your OTP API host in `config.yml` to be a regular OTP server (not the middleware):
```yml
# Default OTP API
api:
  host: https://regular-otp-server.example.com
  path: /otp/routers/default
```
