### PR TITLE
Geocoding fixes

### DIFF
--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -71,15 +71,8 @@ export function parseUrlQueryString (params = getUrlParams()) {
     })
     const searchId = params.ui_activeSearch || randId()
     // Convert strings to numbers/objects and dispatch
-    dispatch(
-      setQueryParam(
-        planParamsToQuery(
-          planParams,
-          getState().otp.config
-        ),
-        searchId
-      )
-    )
+    planParamsToQuery(planParams, getState().otp.config)
+      .then(query => dispatch(setQueryParam(query, searchId)))
   }
 }
 

--- a/lib/util/geocoder.js
+++ b/lib/util/geocoder.js
@@ -132,6 +132,11 @@ class ArcGISGeocoder extends Geocoder {
    * format.
    */
   getLocationFromGeocodedFeature (feature) {
+    // If feature was returned from 'search' query, it will already be
+    // structured properly.
+    if (feature.geometry) return Geocoder.prototype.getLocationFromGeocodedFeature(feature)
+    // If feature returned from autocomplete, we need to use the magicKey to get
+    // the location's coordinates.
     return this.api.search({ magicKey: feature.magicKey, text: feature.text })
       .then(response => {
         const feature = response.features[0]

--- a/lib/util/query.js
+++ b/lib/util/query.js
@@ -151,7 +151,7 @@ export function getDefaultQuery (config) {
 
 /**
  * Geocode utility for returning the first result for the provided place name text.
- * @param  {String} text - text to search
+ * @param  {string} text - text to search
  * @param  {Object} geocoderConfig
  * @return {Location}
  */
@@ -170,6 +170,24 @@ async function getFirstGeocodeResult (text, geocoderConfig) {
 }
 
 /**
+ * Convert a string query param for a from or to place into a location. If
+ * coordinates not provided and geocoder config is present, use the first
+ * geocoded result.
+ * @param  {string} value                 [description]
+ * @param  {Object} [geocoderConfig=null] [description]
+ * @return {Location}                       [description]
+ */
+async function queryParamToLocation (value, geocoderConfig = null) {
+  let location = parseLocationString(value)
+  if (!location && value && geocoderConfig) {
+    // If a valid location was not found, but the place name text exists,
+    // attempt to geocode the name.
+    location = await getFirstGeocodeResult(value, geocoderConfig)
+  }
+  return location
+}
+
+/**
  * Create a otp query based on a the url params.
  *
  * @param  {Object} params An object representing the parsed querystring of url
@@ -181,20 +199,10 @@ export async function planParamsToQuery (params, config) {
   for (var key in params) {
     switch (key) {
       case 'fromPlace':
-        query.from = parseLocationString(params.fromPlace)
-        // If a valid location was not found, but the place name text exists,
-        // attempt to geocode the name.
-        if (!query.from && params.fromPlace) {
-          query.from = await getFirstGeocodeResult(params.fromPlace, config.geocoder)
-        }
+        query.from = await queryParamToLocation(params.fromPlace, config.geocoder)
         break
       case 'toPlace':
-        query.to = parseLocationString(params.toPlace)
-        // If a valid location was not found, but the place name text exists,
-        // attempt to geocode the name.
-        if (!query.to && params.toPlace) {
-          query.to = await getFirstGeocodeResult(params.toPlace, config.geocoder)
-        }
+        query.to = await queryParamToLocation(params.toPlace, config.geocoder)
         break
       case 'arriveBy':
         query.departArrive = params.arriveBy === 'true'

--- a/lib/util/query.js
+++ b/lib/util/query.js
@@ -1,3 +1,4 @@
+import moment from 'moment'
 import qs from 'qs'
 
 import getGeocoder from './geocoder'
@@ -5,7 +6,7 @@ import { getTransitModes, hasTransit, isAccessMode, toSentenceCase } from './iti
 import { coordsToString, matchLatLon, stringToCoords } from './map'
 import queryParams from './query-params'
 import { getActiveSearch } from './state'
-import { getCurrentTime, getCurrentDate } from './time'
+import { getCurrentTime, getCurrentDate, OTP_API_TIME_FORMAT } from './time'
 
 /* The list of default parameters considered in the settings panel */
 
@@ -21,6 +22,22 @@ export const defaultParams = [
   'optimizeBike',
   'maxEScooterDistance',
   'watts'
+]
+
+/**
+ * List of time formats to parse when reading query params.
+ */
+const TIME_FORMATS = [
+  'HH:mm:ss',
+  'h:mm:ss a',
+  'h:mm:ssa',
+  'h:mm a',
+  'h:mma',
+  'h:mm',
+  'HHmm',
+  'hmm',
+  'ha',
+  OTP_API_TIME_FORMAT // 'HH:mm'
 ]
 
 /* A function to retrieve a property value from an entry in the query-params
@@ -215,7 +232,10 @@ export async function planParamsToQuery (params, config) {
         query.date = params.date || getCurrentDate(config)
         break
       case 'time':
-        query.time = params.time || getCurrentTime(config)
+        const parsedTime = moment(params.time, TIME_FORMATS)
+        query.time = parsedTime.isValid()
+          ? parsedTime.format(OTP_API_TIME_FORMAT)
+          : getCurrentTime(config)
         break
       default:
         if (!isNaN(params[key])) query[key] = parseFloat(params[key])

--- a/lib/util/query.js
+++ b/lib/util/query.js
@@ -1,5 +1,6 @@
 import qs from 'qs'
 
+import getGeocoder from './geocoder'
 import { getTransitModes, hasTransit, isAccessMode, toSentenceCase } from './itinerary'
 import { coordsToString, matchLatLon, stringToCoords } from './map'
 import queryParams from './query-params'
@@ -149,21 +150,51 @@ export function getDefaultQuery (config) {
 }
 
 /**
+ * Geocode utility for returning the first result for the provided place name text.
+ * @param  {String} text - text to search
+ * @param  {Object} geocoderConfig
+ * @return {Location}
+ */
+async function getFirstGeocodeResult (text, geocoderConfig) {
+  const geocoder = getGeocoder(geocoderConfig)
+  // Attempt to geocode search text and return first result if found.
+  // TODO: Import geocoder from @opentripplanner
+  return geocoder
+    .search({ text })
+    .then((result) => {
+      const firstResult = result.features && result.features[0]
+      if (firstResult) {
+        return geocoder.getLocationFromGeocodedFeature(firstResult)
+      }
+    })
+}
+
+/**
  * Create a otp query based on a the url params.
  *
  * @param  {Object} params An object representing the parsed querystring of url
  *    params.
  * @param config the config in the otp-rr store.
  */
-export function planParamsToQuery (params, config) {
+export async function planParamsToQuery (params, config) {
   const query = {}
   for (var key in params) {
     switch (key) {
       case 'fromPlace':
         query.from = parseLocationString(params.fromPlace)
+        // If a valid location was not found, but the place name text exists,
+        // attempt to geocode the name.
+        if (!query.from && params.fromPlace) {
+          query.from = await getFirstGeocodeResult(params.fromPlace, config.geocoder)
+        }
         break
       case 'toPlace':
         query.to = parseLocationString(params.toPlace)
+        // If a valid location was not found, but the place name text exists,
+        // attempt to geocode the name.
+        if (!query.to && params.toPlace) {
+          query.to = await getFirstGeocodeResult(params.toPlace, config.geocoder)
+        }
         break
       case 'arriveBy':
         query.departArrive = params.arriveBy === 'true'


### PR DESCRIPTION
This PR fixes #180 and #181. It is intended for `master` because it contains maintenance changes for an existing implementation, but we should also ensure that the changes make their way into the otp-ui side of things.

To test the geocoding of ungeocoded place names:
1. use the SEPTA config
2. `yarn start`
3. Visit http://localhost:9966/#/?fromPlace=wells%20fargo%20center&toPlace=strawberry%20mansion