### PR TITLE
fix(line-itin/itinerary.css): Allow long route short names.

### DIFF
--- a/lib/components/narrative/line-itin/itinerary.css
+++ b/lib/components/narrative/line-itin/itinerary.css
@@ -273,13 +273,13 @@
 .otp .line-itin .leg-body .route-short-name {
   display: inline-block;
   background-color: #0f6aac;
-  padding-top: 1px;
+  padding: 2px;
   color: white;
   font-weight: 500;
   font-size: 14px;
   margin-right: 6px;
   text-align: center;
-  width: 24px;
+  min-width: 24px;
   height: 24px;
   border-radius: 12px;
   border: 1px solid white;

--- a/lib/components/narrative/line-itin/itinerary.css
+++ b/lib/components/narrative/line-itin/itinerary.css
@@ -273,7 +273,7 @@
 .otp .line-itin .leg-body .route-short-name {
   display: inline-block;
   background-color: #0f6aac;
-  padding: 2px;
+  padding: 2px 3px;
   color: white;
   font-weight: 500;
   font-size: 14px;


### PR DESCRIPTION
This PR allows the route short name badge to expand to accommodate long route names.