### PR TITLE
fix(line-itin/itinerary-body): Use setActiveLeg from NarrativeItineraries

### DIFF
--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -10,7 +10,6 @@ import { connect } from 'react-redux'
 import styled from 'styled-components'
 
 import { showLegDiagram } from '../../../actions/map'
-import { setActiveLeg } from '../../../actions/narrative'
 import { setViewedTrip } from '../../../actions/ui'
 import TransitLegSubheader from './connected-transit-leg-subheader'
 import TripDetails from '../connected-trip-details'
@@ -82,7 +81,6 @@ const mapStateToProps = (state, ownProps) => {
 }
 
 const mapDispatchToProps = {
-  setActiveLeg,
   setViewedTrip,
   showLegDiagram
 }

--- a/lib/components/narrative/line-itin/line-itinerary.js
+++ b/lib/components/narrative/line-itin/line-itinerary.js
@@ -50,6 +50,7 @@ export default class LineItinerary extends NarrativeItinerary {
       itinerary,
       itineraryFooter,
       LegIcon,
+      setActiveLeg,
       showRealtimeAnnotation,
       onClick,
       timeFormat
@@ -75,7 +76,14 @@ export default class LineItinerary extends NarrativeItinerary {
         />
         {showRealtimeAnnotation && <SimpleRealtimeAnnotation />}
         {active || expanded
-          ? <ItineraryBody itinerary={itinerary} LegIcon={LegIcon} />
+          ? <ItineraryBody
+            itinerary={itinerary}
+            LegIcon={LegIcon}
+            // Don't use setActiveLeg as an import
+            // (will cause error when clicking on itinerary suymmary).
+            // Use the one passed by NarrativeItineraries instead.
+            setActiveLeg={setActiveLeg}
+          />
           : null}
         {itineraryFooter}
       </LineItineraryContainer>

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -102,7 +102,7 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = (dispatch, ownProps) => {
   // FIXME: update signature of these methods,
   // so that only one argument is passed,
-  // e.g. setActiveLeg({ index, leg }) 
+  // e.g. setActiveLeg({ index, leg })
   return {
     setActiveItinerary: index => {
       dispatch(setActiveItinerary({index}))

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -100,6 +100,9 @@ const mapStateToProps = (state, ownProps) => {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => {
+  // FIXME: update signature of these methods,
+  // so that only one argument is passed,
+  // e.g. setActiveLeg({ index, leg }) 
   return {
     setActiveItinerary: index => {
       dispatch(setActiveItinerary({index}))


### PR DESCRIPTION
This PR passes the correct version of `setActiveLeg` to `ConnectedItineraryBody` and addresses an issue involving https://github.com/ibi-group/trimet-mod-otp/pull/265.

To test: clicking on a leg summary (e.g. "Walk 2 miles to ...") in the current dev will cause a blank screen.
With the proposed changes, the map will zoom to the selected leg.
