### PR TITLE
fix(StopViewerOverlay): Fix prop name for overlay.

### DIFF
--- a/lib/components/map/connected-stop-viewer-overlay.js
+++ b/lib/components/map/connected-stop-viewer-overlay.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux'
 const mapStateToProps = (state, ownProps) => {
   const viewedStop = state.otp.ui.viewedStop
   return {
-    stopData: viewedStop
+    stop: viewedStop
       ? state.otp.transitIndex.stops[viewedStop.stopId]
       : null,
     StopMarker: DefaultStopMarker


### PR DESCRIPTION
This PR fixes the missing teal marker normally displayed on the map when the stop viewer is shown.