### PR TITLE
fix(actions/user): Remove user fields removed from middleware

### DIFF
--- a/lib/actions/user.js
+++ b/lib/actions/user.js
@@ -11,10 +11,8 @@ function getStateForNewUser (auth0User) {
     auth0UserId: auth0User.sub,
     email: auth0User.email,
     hasConsentedToTerms: false, // User must agree to terms.
-    isEmailVerified: auth0User.email_verified,
     notificationChannel: 'email',
     phoneNumber: '',
-    recentLocations: [],
     savedLocations: [],
     storeTripHistory: false // User must opt in.
   }


### PR DESCRIPTION
This PR removes fields that were removed from OTP middleware by commit https://github.com/ibi-group/otp-middleware/commit/a34bacc.
Not removing these fields causes an error on user signup.
