### PR TITLE
Itinerary timeformat

### DIFF
--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -41,7 +41,8 @@ class ConnectedItineraryBody extends Component {
       LegIcon,
       setActiveLeg,
       setViewedTrip,
-      showLegDiagram
+      showLegDiagram,
+      timeOptions
     } = this.props
 
     return (
@@ -62,6 +63,7 @@ class ConnectedItineraryBody extends Component {
           showLegIcon
           showMapButtonColumn={false}
           showViewTripButton
+          timeOptions={timeOptions}
           toRouteAbbreviation={noop}
           TransitLegSubheader={TransitLegSubheader}
           TransitLegSummary={TransitLegSummary}

--- a/lib/components/narrative/line-itin/line-itinerary.js
+++ b/lib/components/narrative/line-itin/line-itinerary.js
@@ -83,6 +83,7 @@ export default class LineItinerary extends NarrativeItinerary {
             // (will cause error when clicking on itinerary suymmary).
             // Use the one passed by NarrativeItineraries instead.
             setActiveLeg={setActiveLeg}
+            timeOptions={timeOptions}
           />
           : null}
         {itineraryFooter}

--- a/lib/components/narrative/line-itin/line-itinerary.js
+++ b/lib/components/narrative/line-itin/line-itinerary.js
@@ -50,9 +50,9 @@ export default class LineItinerary extends NarrativeItinerary {
       itinerary,
       itineraryFooter,
       LegIcon,
+      onClick,
       setActiveLeg,
       showRealtimeAnnotation,
-      onClick,
       timeFormat
     } = this.props
 
@@ -71,8 +71,8 @@ export default class LineItinerary extends NarrativeItinerary {
           companies={companies}
           itinerary={itinerary}
           LegIcon={LegIcon}
-          timeOptions={timeOptions}
           onClick={onClick}
+          timeOptions={timeOptions}
         />
         {showRealtimeAnnotation && <SimpleRealtimeAnnotation />}
         {active || expanded


### PR DESCRIPTION
This PR restores time format support in `line-itinerary#ItineraryBody`.
