### PR TITLE
Support OTP endpoints proxied by OTP Middleware

### DIFF
--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -180,10 +180,10 @@ function getJsonAndCheckResponse (res) {
  * - If the OTP server is not the middleware server (standalone OTP server),
  *   an empty object is returned.
  * - If the OTP server is the same as the middleware server,
- *   then an object is returned with the following:
+ *   then an object is returned with the following, so the middleware can link this request to the logged-in user:
  *   - A middleware API key, if it has been set in the configuration (it is most likely required),
  *   - An Auth0 accessToken, when includeToken is true and a user is logged in (userState.loggedInUser is not null).
- * This method assumes JSON request bodies.)
+ * This method assumes JSON request bodies.
  */
 function getOtpFetchOptions (state, includeToken = false) {
   let apiBaseUrl, apiKey, token
@@ -193,7 +193,10 @@ function getOtpFetchOptions (state, includeToken = false) {
     ({ apiBaseUrl, apiKey } = persistence.otp_middleware)
   }
 
-  const isOtpServerSameAsMiddleware = apiBaseUrl === api.host
+  // Detect middleware OTP proxy resource path.
+  const isOtpServerSameAsMiddleware =
+    apiBaseUrl === api.host || `${apiBaseUrl}/otp` === api.host
+
   if (isOtpServerSameAsMiddleware) {
     if (includeToken && state.user) {
       const { accessToken, loggedInUser } = state.user


### PR DESCRIPTION
This PR lets OTP-RR make requests to the OTP endpoints proxied by OTP Middleware,
including authenticated requests to the OTP's /plan endpoint proxied by the middleware after recent middleware changes.

This PR depends on https://github.com/ibi-group/otp-middleware/pull/54.

To test: change your `config.yml` to use a local OTP Middleware instance running https://github.com/ibi-group/otp-middleware/pull/54, then run `yarn start`. On the UI at `localhost:9966`, you should be able to plan a trip, view routes, stops, and trips. If you opt-in for tracking your trip request history (under `My Account`), your trips will be logged as well.

EDIT: Either of the configs below works.

```yml
#preferred
api:
  host: http://localhost:4567
  path: /otp/routers/default
```

```yml
api:
  host: http://localhost:4567/otp
  path: /otp/routers/default
```
