### PR TITLE
fix(Itineraries): Hide the Save Trip button if no user is logged in.

### DIFF
--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -21,7 +21,8 @@ export default class DefaultItinerary extends NarrativeItinerary {
       itinerary,
       LegIcon,
       setActiveLeg,
-      setActiveStep
+      setActiveStep,
+      user
     } = this.props
     return (
       <div className={`option default-itin${active ? ' active' : ''}`}>
@@ -32,7 +33,10 @@ export default class DefaultItinerary extends NarrativeItinerary {
           <span className='title'>Itinerary {index + 1}</span>{' '}
           <span className='duration pull-right'>{formatDuration(itinerary.duration)}</span>{' '}
           <span className='arrivalTime'>{formatTime(itinerary.startTime)}—{formatTime(itinerary.endTime)}</span>
-          <span className='pull-right'><LinkButton to='/savetrip'>Save</LinkButton></span>{' '}
+          {user && (<>
+            <span className='pull-right'><LinkButton to='/savetrip'>Save</LinkButton></span>{' '}
+            </>
+          )}
           <ItinerarySummary itinerary={itinerary} LegIcon={LegIcon} />
         </button>
         {(active || expanded) &&

--- a/lib/components/narrative/itinerary-carousel.js
+++ b/lib/components/narrative/itinerary-carousel.js
@@ -50,7 +50,7 @@ class ItineraryCarousel extends Component {
   }
 
   render () {
-    const { activeItinerary, itineraries, itineraryClass, hideHeader, pending } = this.props
+    const { activeItinerary, itineraries, itineraryClass, hideHeader, pending, user } = this.props
     if (pending) return <Loading small />
     if (!itineraries) return null
 
@@ -61,6 +61,7 @@ class ItineraryCarousel extends Component {
         key: index,
         expanded: this.props.expanded,
         onClick: this._onItineraryClick,
+        user,
         ...this.props
       })
     })
@@ -112,7 +113,8 @@ const mapStateToProps = (state, ownProps) => {
     activeLeg: activeSearch && activeSearch.activeLeg,
     activeStep: activeSearch && activeSearch.activeStep,
     companies: state.otp.currentQuery.companies,
-    timeFormat: coreUtils.time.getTimeFormat(state.otp.config)
+    timeFormat: coreUtils.time.getTimeFormat(state.otp.config),
+    user: state.user.loggedInUser
   }
 }
 

--- a/lib/components/narrative/line-itin/line-itinerary.js
+++ b/lib/components/narrative/line-itin/line-itinerary.js
@@ -54,7 +54,8 @@ export default class LineItinerary extends NarrativeItinerary {
       onClick,
       setActiveLeg,
       showRealtimeAnnotation,
-      timeFormat
+      timeFormat,
+      user
     } = this.props
 
     if (!itinerary) {
@@ -76,7 +77,9 @@ export default class LineItinerary extends NarrativeItinerary {
           timeOptions={timeOptions}
         />
 
-        <span className='pull-right'><LinkButton to='/savetrip'>Save this option</LinkButton></span>
+        {user &&
+          <span className='pull-right'><LinkButton to='/savetrip'>Save this option</LinkButton></span>
+        }
 
         {showRealtimeAnnotation && <SimpleRealtimeAnnotation />}
         {active || expanded

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -41,7 +41,8 @@ class NarrativeItineraries extends Component {
       itineraries,
       itineraryClass,
       realtimeEffects,
-      useRealtime
+      useRealtime,
+      user
     } = this.props
     if (!itineraries) return null
 
@@ -69,6 +70,7 @@ class NarrativeItineraries extends Component {
             key: index,
             active: index === activeItinerary,
             routingType: 'ITINERARY',
+            user,
             ...this.props
           })
         })}
@@ -95,6 +97,7 @@ const mapStateToProps = (state, ownProps) => {
     activeLeg: activeSearch && activeSearch.activeLeg,
     activeStep: activeSearch && activeSearch.activeStep,
     useRealtime,
+    user: state.user.loggedInUser,
     companies: state.otp.currentQuery.companies
   }
 }

--- a/lib/components/narrative/tabbed-itineraries.js
+++ b/lib/components/narrative/tabbed-itineraries.js
@@ -40,7 +40,8 @@ class TabbedItineraries extends Component {
       itineraryClass,
       realtimeEffects,
       useRealtime,
-      timeFormat
+      timeFormat,
+      user
     } = this.props
     if (!itineraries) return null
 
@@ -123,6 +124,7 @@ class TabbedItineraries extends Component {
           active: true,
           routingType: 'ITINERARY',
           showRealtimeAnnotation,
+          user,
           ...this.props
         })}
 
@@ -149,7 +151,8 @@ const mapStateToProps = (state, ownProps) => {
     useRealtime,
     companies: state.otp.currentQuery.companies,
     tnc: state.otp.tnc,
-    timeFormat: getTimeFormat(state.otp.config)
+    timeFormat: getTimeFormat(state.otp.config),
+    user: state.user.loggedInUser
   }
 }
 


### PR DESCRIPTION
This PR is a quick fix to hide the button to save a trip (for monitoring) if no user is logged in. (The button is currently shown regardless).