### PR TITLE
Add ability to show mapbox wordmark via config

### DIFF
--- a/lib/components/map/default-map.js
+++ b/lib/components/map/default-map.js
@@ -141,6 +141,13 @@ class DefaultMap extends Component {
 
     return (
       <MapContainer>
+        {/* Add the mapbox wordmark if set in config. The implementing
+          application must include CSS that properly displays the wordmark. See
+          mapbox website for example CSS:
+          https://docs.mapbox.com/help/how-mapbox-works/attribution/#other-mapping-frameworks */}
+        {mapConfig.addMapboxWordmark &&
+          <a href='http://mapbox.com/about/maps' class='mapbox-wordmark' target='_blank'>Mapbox</a>
+        }
         <BaseMap
           baseLayers={mapConfig.baseLayers}
           center={center}


### PR DESCRIPTION
This PR adds the ability to add a simple HTML element for displaying the [Mapbox wordmark attribution](https://docs.mapbox.com/help/how-mapbox-works/attribution/#other-mapping-frameworks) on the map.