### PR TITLE
feat(ItineraryBody): Add fare info in each transit leg body (new config)

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -124,6 +124,12 @@ routingTypes:
   - key: ITINERARY
     text: Exact Time
 
+# Itinerary options
+itinerary:
+  # Show fares for each transit leg (false if omitted).
+  # (Requires using LineItinerary.)
+  showRouteFares: false
+
 ### Use this config for the standard mode selector
 # modeGroups:
 #   - name: Transit

--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -63,6 +63,7 @@ class ConnectedItineraryBody extends Component {
           showElevationProfile
           showLegIcon
           showMapButtonColumn={false}
+          showRouteFares={config.itinerary && config.itinerary.showRouteFares}
           showViewTripButton
           timeOptions={timeOptions}
           toRouteAbbreviation={noop}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@opentripplanner/geocoder": "^1.0.2",
     "@opentripplanner/humanize-distance": "^0.0.22",
     "@opentripplanner/icons": "^1.0.1",
-    "@opentripplanner/itinerary-body": "^1.1.0",
+    "@opentripplanner/itinerary-body": "^1.2.0",
     "@opentripplanner/location-field": "^1.0.2",
     "@opentripplanner/location-icon": "^1.0.0",
     "@opentripplanner/park-and-ride-overlay": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1289,6 +1289,20 @@
     prop-types "^15.7.2"
     qs "^6.9.1"
 
+"@opentripplanner/core-utils@^2.1.1":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-2.1.2.tgz#a19d5d788704f0a6c2aece5206a2c8997c251d16"
+  integrity sha512-i+ADDdHhC+oJNYPrk7o9eu3F/2IMMZ5YAOXR2QGBJbS97kQOYeTAN4pVGfWKTm7ClTTIBG9/NDnVyQMzGuYInw==
+  dependencies:
+    "@mapbox/polyline" "^1.1.0"
+    "@turf/along" "^6.0.1"
+    bowser "^2.7.0"
+    lodash.isequal "^4.5.0"
+    moment "^2.24.0"
+    moment-timezone "^0.5.27"
+    prop-types "^15.7.2"
+    qs "^6.9.1"
+
 "@opentripplanner/endpoints-overlay@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@opentripplanner/endpoints-overlay/-/endpoints-overlay-1.0.1.tgz#d95f0bbfddc9382b593845799b963340eece2742"
@@ -1331,12 +1345,12 @@
     "@opentripplanner/core-utils" "^1.2.0"
     prop-types "^15.7.2"
 
-"@opentripplanner/itinerary-body@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/itinerary-body/-/itinerary-body-1.1.0.tgz#6fabc389ad25f6f14db5a5861603a127530e0d9e"
-  integrity sha512-svu2A0z+CnL5vrkDXuaMjJaDoSC4d52utzdGfgkXdfMaK9prO1D/6SHWiVILXmaDJExdBAoF3mxSuA7xPItTTA==
+"@opentripplanner/itinerary-body@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/itinerary-body/-/itinerary-body-1.2.0.tgz#96d8b832f26c6918ee2c0e122fce6a57a6e5df1a"
+  integrity sha512-LG8SRTTXdYD8M/7+peJPfuqRFbZlbxilqUBRyGw60efZcnWbAenQW/o5aznuucLHiafDUzVUQpy9SEd0gIqRSQ==
   dependencies:
-    "@opentripplanner/core-utils" "^2.1.0"
+    "@opentripplanner/core-utils" "^2.1.1"
     "@opentripplanner/humanize-distance" "^0.0.22"
     "@opentripplanner/icons" "^1.0.0"
     "@opentripplanner/location-icon" "^1.0.0"


### PR DESCRIPTION
This PR add support for displaying fare information introduced by https://github.com/opentripplanner/otp-ui/pull/209.

### New configuration variable

Insert a new configuration variable in `config.yml`:

```yml
# New: itinerary options
itinerary:
  # Show fares for each transit leg (false if omitted).
  # (Requires using LineItinerary.)
  showRouteFares: true
```

### To test
In `tabbed-itineraries`, insert
```js
import LineItinerary from './line-itin/line-itinerary'
```
and change these defaults:
```js
  static defaultProps = {
    itineraryClass: LineItinerary
  }
```

Then `yarn start` and open the URL below, expand the `Ride x mins/n stops` button, and see the fare displayed below the stops list: 
http://localhost:9966/#/?ui_activeSearch=9jwmo0s95&ui_activeItinerary=0&fromPlace=1801%20Atlanta%20Ave%2C%20Orlando%2C%20FL%2C%20USA%3A%3A28.52255017622969%2C-81.38225555419923&toPlace=2506%20N%20Orange%20Ave%2C%20Orlando%2C%20FL%2C%20USA%3A%3A28.57412028580987%2C-81.37281417846681&date=2020-09-08&time=10%3A30&arriveBy=false&mode=WALK%2CBUS%2CRAIL&showIntermediateStops=true&maxWalkDistance=1207&optimize=QUICK&walkSpeed=1.34&ignoreRealtimeUpdates=false&companies=&bannedRoutes=&numItineraries=3&otherThanPreferredRoutesPenalty=900&preferredRoutes=

