### PR TITLE
Properly read config about showing elevation profile

### DIFF
--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -42,7 +42,6 @@ class ConnectedItineraryBody extends Component {
       LegIcon,
       setActiveLeg,
       setViewedTrip,
-      showElevationProfile,
       setLegDiagram,
       timeOptions
     } = this.props
@@ -61,7 +60,7 @@ class ConnectedItineraryBody extends Component {
           setLegDiagram={setLegDiagram}
           setViewedTrip={setViewedTrip}
           showAgencyInfo
-          showElevationProfile={showElevationProfile}
+          showElevationProfile={config.elevationProfile}
           showLegIcon
           showMapButtonColumn={false}
           showRouteFares={config.itinerary && config.itinerary.showRouteFares}


### PR DESCRIPTION
This PR makes the elevation profile show up if configured to do so in the ConnectedItinerary component.