### PR TITLE
Don't send notifications for successful builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ cache:
   yarn: true
 notifications:
   email: false
-  webhooks: https://outlook.office.com/webhook/03fa4a79-572f-4c68-b756-e4e851d0215a@9093f1a3-8771-4fb7-8596-d51eeef18cda/TravisCI/449087910d3647598cf3d7c6387fb8fc/286c079f-6085-4aa0-8f8d-e2a3e8d1f568
+  webhooks:
+    urls:
+      - https://outlook.office.com/webhook/03fa4a79-572f-4c68-b756-e4e851d0215a@9093f1a3-8771-4fb7-8596-d51eeef18cda/TravisCI/449087910d3647598cf3d7c6387fb8fc/286c079f-6085-4aa0-8f8d-e2a3e8d1f568
+    on_success: never
 node_js:
   - '12' # mastarm 5 requires node.js 10 or greater
 # Copy example config for use in build.

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
   webhooks:
     urls:
       - https://outlook.office.com/webhook/03fa4a79-572f-4c68-b756-e4e851d0215a@9093f1a3-8771-4fb7-8596-d51eeef18cda/TravisCI/449087910d3647598cf3d7c6387fb8fc/286c079f-6085-4aa0-8f8d-e2a3e8d1f568
-    on_success: never
+    on_success: change
 node_js:
   - '12' # mastarm 5 requires node.js 10 or greater
 # Copy example config for use in build.


### PR DESCRIPTION
This PR changes the notifications that Travis sends such that only build failures trigger a notification. 

Wait do people think about doing this... for this repo and all others where we get build notifications? I'm pretty sure all of these successful build notifications aren't all that helpful, but it is helpful to know if a build is failing.