### PR TITLE
Fix results screen when planning trip

### DIFF
--- a/lib/components/mobile/results-screen.js
+++ b/lib/components/mobile/results-screen.js
@@ -16,7 +16,7 @@ import MobileNavigationBar from './navigation-bar'
 import { MobileScreens, setMobileScreen } from '../../actions/ui'
 import { setUseRealtimeResponse } from '../../actions/narrative'
 import { clearActiveSearch } from '../../actions/form'
-import { getActiveSearch, getRealtimeEffects } from '../../util/state'
+import { getActiveItineraries, getActiveSearch, getRealtimeEffects } from '../../util/state'
 
 const LocationContainer = styled.div`
   font-weight: 300;
@@ -235,7 +235,7 @@ const mapStateToProps = (state, ownProps) => {
     : useRealtime ? activeSearch.response : activeSearch.nonRealtimeResponse
 
   const realtimeEffects = getRealtimeEffects(state.otp)
-
+  const itineraries = getActiveItineraries(state.otp)
   return {
     query: state.otp.currentQuery,
     realtimeEffects,
@@ -243,9 +243,7 @@ const mapStateToProps = (state, ownProps) => {
     resultCount:
       response
         ? activeSearch.query.routingType === 'ITINERARY'
-          ? response.plan
-            ? response.plan.itineraries.length
-            : 0
+          ? itineraries.length
           : response.otp.profile.length
         : null,
     useRealtime,

--- a/lib/components/narrative/itinerary-carousel.js
+++ b/lib/components/narrative/itinerary-carousel.js
@@ -102,9 +102,7 @@ class ItineraryCarousel extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   const activeSearch = getActiveSearch(state.otp)
-  const itineraries = activeSearch && activeSearch.response && activeSearch.response.plan
-    ? getActiveItineraries(state.otp)
-    : null
+  const itineraries = getActiveItineraries(state.otp)
 
   return {
     itineraries,

--- a/lib/components/narrative/itinerary-carousel.js
+++ b/lib/components/narrative/itinerary-carousel.js
@@ -15,7 +15,7 @@ class ItineraryCarousel extends Component {
   state = {}
   static propTypes = {
     itineraries: PropTypes.array,
-    pending: PropTypes.bool,
+    pending: PropTypes.number,
     activeItinerary: PropTypes.number,
     hideHeader: PropTypes.bool,
     itineraryClass: PropTypes.func,

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -38,7 +38,7 @@ class NarrativeItineraries extends Component {
   static propTypes = {
     itineraries: PropTypes.array,
     itineraryClass: PropTypes.func,
-    pending: PropTypes.bool,
+    pending: PropTypes.number,
     activeItinerary: PropTypes.number,
     setActiveItinerary: PropTypes.func,
     setActiveLeg: PropTypes.func,

--- a/lib/components/narrative/tabbed-itineraries.js
+++ b/lib/components/narrative/tabbed-itineraries.js
@@ -15,7 +15,7 @@ class TabbedItineraries extends Component {
   static propTypes = {
     itineraries: PropTypes.array,
     itineraryClass: PropTypes.func,
-    pending: PropTypes.bool,
+    pending: PropTypes.number,
     activeItinerary: PropTypes.number,
     setActiveItinerary: PropTypes.func,
     setActiveLeg: PropTypes.func,


### PR DESCRIPTION
Correctly handle getting itineraries in mobile screens. Fixes #250.

Note: this does not resolve the fact that the expanded mobile screen does not show a full set of results, but that should be a separate PR/issue.