### PR TITLE
Make navbar border color light color.

### DIFF
--- a/lib/components/app/app.css
+++ b/lib/components/app/app.css
@@ -8,6 +8,10 @@
   padding: 0px 0px;
 }
 
+.navbar-inverse {
+  border-color: #e7e7e7; /* Same as non-inverse style. */
+}
+
 .otp.mobile .app-menu-button {
   padding: 10px 0px 0px 12px;
 }


### PR DESCRIPTION
This PR makes the border of the navbar the same as current (non-middleware) deployments.
This PR should be merged in order to resolve this discussion: https://github.com/ibi-group/trimet-mod-otp/pull/277#pullrequestreview-493506135 and merge https://github.com/ibi-group/trimet-mod-otp/pull/277.