### PR TITLE
Pass timeFormat to rendered itin

### DIFF
--- a/lib/components/narrative/line-itin/realtime-time-column.js
+++ b/lib/components/narrative/line-itin/realtime-time-column.js
@@ -3,10 +3,9 @@ import {
   legType,
   timeOptionsType
 } from '@opentripplanner/core-utils/lib/types'
-import { formatTime, getTimeFormat } from '@opentripplanner/core-utils/lib/time'
+import { formatTime } from '@opentripplanner/core-utils/lib/time'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { connect } from 'react-redux'
 import styled from 'styled-components'
 
 const TimeText = styled.div``
@@ -129,16 +128,7 @@ function RealtimeTimeColumn ({
   )
 }
 
-// Connect to redux store for timeOptions.
-const mapStateToProps = (state, ownProps) => {
-  return {
-    timeOptions: {
-      format: getTimeFormat(state.otp.config)
-    }
-  }
-}
-
-export default connect(mapStateToProps)(RealtimeTimeColumn)
+export default RealtimeTimeColumn
 
 RealtimeTimeColumn.propTypes = {
   isDestination: PropTypes.bool.isRequired,

--- a/lib/components/narrative/tabbed-itineraries.js
+++ b/lib/components/narrative/tabbed-itineraries.js
@@ -162,12 +162,9 @@ class TabButton extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   const activeSearch = getActiveSearch(state.otp)
-  // const { activeItinerary, activeLeg, activeStep } = activeSearch ? activeSearch.activeItinerary : {}
   const pending = activeSearch ? Boolean(activeSearch.pending) : false
   const realtimeEffects = getRealtimeEffects(state.otp)
   const useRealtime = state.otp.useRealtime
-  const timeFormat = getTimeFormat(state.otp.config)
-  console.log(timeFormat)
   return {
     // swap out realtime itineraries with non-realtime depending on boolean
     pending,

--- a/lib/components/narrative/tabbed-itineraries.js
+++ b/lib/components/narrative/tabbed-itineraries.js
@@ -15,7 +15,7 @@ class TabbedItineraries extends Component {
   static propTypes = {
     itineraries: PropTypes.array,
     itineraryClass: PropTypes.func,
-    pending: PropTypes.number,
+    pending: PropTypes.bool,
     activeItinerary: PropTypes.number,
     setActiveItinerary: PropTypes.func,
     setActiveLeg: PropTypes.func,
@@ -85,6 +85,7 @@ class TabbedItineraries extends Component {
             expanded: true,
             routingType: 'ITINERARY',
             showRealtimeAnnotation,
+            timeFormat,
             ...itineraryClassProps
           })
           : null
@@ -92,29 +93,6 @@ class TabbedItineraries extends Component {
 
       </div>
     )
-  }
-}
-
-// connect to the redux store
-
-const mapStateToProps = (state, ownProps) => {
-  const activeSearch = getActiveSearch(state.otp)
-  // const { activeItinerary, activeLeg, activeStep } = activeSearch ? activeSearch.activeItinerary : {}
-  const pending = activeSearch ? activeSearch.pending : false
-  const realtimeEffects = getRealtimeEffects(state.otp)
-  const useRealtime = state.otp.useRealtime
-  return {
-    // swap out realtime itineraries with non-realtime depending on boolean
-    pending,
-    realtimeEffects,
-    activeItinerary: activeSearch && activeSearch.activeItinerary,
-    activeLeg: activeSearch && activeSearch.activeLeg,
-    activeStep: activeSearch && activeSearch.activeStep,
-    useRealtime,
-    companies: state.otp.currentQuery.companies,
-    tnc: state.otp.tnc,
-    timeFormat: getTimeFormat(state.otp.config),
-    user: state.user.loggedInUser
   }
 }
 
@@ -177,6 +155,31 @@ class TabButton extends Component {
         </div>
       </Button>
     )
+  }
+}
+
+// connect to the redux store
+
+const mapStateToProps = (state, ownProps) => {
+  const activeSearch = getActiveSearch(state.otp)
+  // const { activeItinerary, activeLeg, activeStep } = activeSearch ? activeSearch.activeItinerary : {}
+  const pending = activeSearch ? Boolean(activeSearch.pending) : false
+  const realtimeEffects = getRealtimeEffects(state.otp)
+  const useRealtime = state.otp.useRealtime
+  const timeFormat = getTimeFormat(state.otp.config)
+  console.log(timeFormat)
+  return {
+    // swap out realtime itineraries with non-realtime depending on boolean
+    pending,
+    realtimeEffects,
+    activeItinerary: activeSearch && activeSearch.activeItinerary,
+    activeLeg: activeSearch && activeSearch.activeLeg,
+    activeStep: activeSearch && activeSearch.activeStep,
+    useRealtime,
+    companies: state.otp.currentQuery.companies,
+    tnc: state.otp.tnc,
+    timeFormat: getTimeFormat(state.otp.config),
+    user: state.user.loggedInUser
   }
 }
 


### PR DESCRIPTION
Fixes #268. A previous attempt had tried to fix this by connecting the RealtimeTimeColumn to the redux store, but the true underlying issue was a bad destructuring of props in `TabbedItineraries`.

To test, use a config.yml for a timezone different than your local computer's. Plan a trip and verify that the times in the narrative itinerary match what is shown in the tabbed-itin summary.