### PR TITLE
Bump transitive.js to 0.13.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "redux-actions": "^1.2.1",
     "redux-logger": "^2.7.4",
     "redux-thunk": "^2.3.0",
-    "transitive-js": "^0.13.3",
+    "transitive-js": "^0.13.4",
     "velocity-react": "^1.3.3",
     "yup": "^0.29.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -15841,10 +15841,10 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-transitive-js@^0.13.3:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/transitive-js/-/transitive-js-0.13.3.tgz#4c1671628a65551d7b70b53362300d7017fc0ac9"
-  integrity sha512-vm3v3HuCcmoL+64pew5MHltOabN+ONhs/IonHqf6sRWFUcpVgrUBc9OWLzkJpi1DDPiLjZa6KP27WuoZ1Mk/Fg==
+transitive-js@^0.13.3, transitive-js@^0.13.4:
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/transitive-js/-/transitive-js-0.13.4.tgz#2ef9b57f4c0f4ec594f84664300d91a46dfde820"
+  integrity sha512-26lcurtKYJAZJY0kWo3DelTO2ADIZz6uNxrCRUT0hvAcq/lnTLV3WR/vSmR8vsIWRQ10dokJ80VXK0Y3461Jag==
   dependencies:
     augment "4.3.0"
     component-each "0.2.6"


### PR DESCRIPTION
Bump transitive to get a bug fix for short names.

Copy the Massachusetts config and verify with this trip: http://localhost:9966/#/?ui_activeSearch=kr8ojq35t&ui_activeItinerary=0&fromPlace=Natick%2C%20MA%2C%20USA%3A%3A42.283990000000074%2C-71.34617999999995&toPlace=Boston%2C%20MA%2C%20USA%3A%3A42.35866000000004%2C-71.05673999999993&date=2020-11-03&time=16%3A13&arriveBy=false&mode=WALK%2CBUS%2CFERRY&showIntermediateStops=true&maxWalkDistance=1207&optimize=QUICK&walkSpeed=1.34&ignoreRealtimeUpdates=true&companies=&bannedRoutes=&numItineraries=3&otherThanPreferredRoutesPenalty=900&preferredRoutes=