### PR TITLE
Use dynamic contents via React context

### DIFF
--- a/example.js
+++ b/example.js
@@ -19,6 +19,7 @@ import {
   CallTakerControls,
   CallTakerPanel,
   CallTakerWindows,
+  DefaultItinerary,
   DefaultMainPanel,
   DesktopNav,
   BatchRoutingPanel,
@@ -49,6 +50,7 @@ if (useCustomIcons) {
 // define some application-wide components that should be used in
 // various places
 const components = {
+  ItineraryBody: DefaultItinerary,
   LegIcon: MyLegIcon,
   ModeIcon: MyModeIcon
 }

--- a/example.js
+++ b/example.js
@@ -48,7 +48,11 @@ if (useCustomIcons) {
 }
 
 // define some application-wide components that should be used in
-// various places
+// various places. The following components can be provided here:
+// - ItineraryBody (required)
+// - ItineraryFooter (optional)
+// - LegIcon (required)
+// - ModeIcon (required)
 const components = {
   ItineraryBody: DefaultItinerary,
   LegIcon: MyLegIcon,
@@ -125,7 +129,32 @@ class OtpRRExample extends Component {
       </main>
     )
 
-    /** the main webapp **/
+    /**
+     * The main webapp.
+     *
+     * Note: the ResponsiveWebapp creates a React context provider
+     * (./util/contexts#ComponentContext to be specific) to supply custom
+     * components to various other subcomponents throughout otp-react-redux. If
+     * the ResponsiveWebapp is not used and instead some subcomponents that use
+     * the components in the `components` variable are imported and rendered
+     * outside of the ResponsiveWebapp component, then the ComponentContext will
+     * need to wrap that component in order for the subcomponents to be able to
+     * access the component context. For example:
+     *
+     * ```js
+     * import RouteViewer from 'otp-react-redux/build/components/viewers/route-viewer'
+     * import { ComponentContext } from 'otp-react-redux/build/util/contexts'
+     *
+     * const components = {
+     *   ModeIcon: MyCustomModeIconComponent
+     * }
+     * const ContextAwareRouteViewer = () => (
+     *   <ComponentContext.Provider value={components}>
+     *     <RouteViewer />
+     *   <ComponentContext.Provider/>
+     * )
+     * ```
+     */
     return (
       <ResponsiveWebapp
         components={components}

--- a/example.js
+++ b/example.js
@@ -46,6 +46,13 @@ if (useCustomIcons) {
   MyModeIcon = CustomIcons.CustomModeIcon
 }
 
+// define some application-wide components that should be used in
+// various places
+const components = {
+  LegIcon: MyLegIcon,
+  ModeIcon: MyModeIcon
+}
+
 // Get the initial query from config (for demo/testing purposes).
 const {initialQuery} = otpConfig
 const history = createHashHistory()
@@ -69,6 +76,7 @@ const store = createStore(
   }),
   compose(applyMiddleware(...middleware))
 )
+
 // define a simple responsive UI using Bootstrap and OTP-RR
 class OtpRRExample extends Component {
   render () {
@@ -87,10 +95,10 @@ class OtpRRExample extends Component {
               <main>
                 {/* TODO: extract the BATCH elements out of CallTakerPanel. */}
                 {otpConfig.datastoreUrl
-                  ? <CallTakerPanel LegIcon={MyLegIcon} ModeIcon={MyModeIcon} />
+                  ? <CallTakerPanel />
                   : otpConfig.routingTypes.find(t => t.key === 'BATCH')
-                    ? <BatchRoutingPanel LegIcon={MyLegIcon} ModeIcon={MyModeIcon} />
-                    : <DefaultMainPanel LegIcon={MyLegIcon} ModeIcon={MyModeIcon} />
+                    ? <BatchRoutingPanel />
+                    : <DefaultMainPanel />
                 }
               </main>
             </Col>
@@ -109,8 +117,6 @@ class OtpRRExample extends Component {
       // <main> Needed for accessibility checks. TODO: Find a better place.
       <main>
         <MobileMain
-          LegIcon={MyLegIcon}
-          ModeIcon={MyModeIcon}
           map={<Map />}
           title={<div className='navbar-title'>OpenTripPlanner</div>}
         />
@@ -120,9 +126,9 @@ class OtpRRExample extends Component {
     /** the main webapp **/
     return (
       <ResponsiveWebapp
+        components={components}
         desktopView={desktopView}
         mobileView={mobileView}
-        LegIcon={MyLegIcon}
       />
     )
   }

--- a/lib/components/app/batch-routing-panel.js
+++ b/lib/components/app/batch-routing-panel.js
@@ -31,7 +31,6 @@ class BatchRoutingPanel extends Component {
   render () {
     const {
       activeSearch,
-      itineraryFooter,
       mobile,
       showUserSettings
     } = this.props
@@ -104,7 +103,6 @@ class BatchRoutingPanel extends Component {
               left: '0',
               bottom: '0'
             }}
-            itineraryFooter={itineraryFooter}
           />
         </div>
       </ViewerContainer>

--- a/lib/components/app/batch-routing-panel.js
+++ b/lib/components/app/batch-routing-panel.js
@@ -32,14 +32,12 @@ class BatchRoutingPanel extends Component {
     const {
       activeSearch,
       itineraryFooter,
-      LegIcon,
-      ModeIcon,
       mobile,
       showUserSettings
     } = this.props
     const actionText = mobile ? 'tap' : 'click'
     return (
-      <ViewerContainer ModeIcon={ModeIcon}>
+      <ViewerContainer>
         <LocationField
           inputPlaceholder={`Enter start location or ${actionText} on map...`}
           locationType='from'
@@ -107,7 +105,6 @@ class BatchRoutingPanel extends Component {
               bottom: '0'
             }}
             itineraryFooter={itineraryFooter}
-            LegIcon={LegIcon}
           />
         </div>
       </ViewerContainer>

--- a/lib/components/app/call-taker-panel.js
+++ b/lib/components/app/call-taker-panel.js
@@ -21,6 +21,7 @@ import { modeButtonButtonCss } from '../form/styled'
 import SwitchButton from '../form/switch-button'
 import UserSettings from '../form/user-settings'
 import NarrativeItineraries from '../narrative/narrative-itineraries'
+import { ComponentContext } from '../../util/contexts'
 import { hasValidLocation, getActiveSearch, getShowUserSettings } from '../../util/state'
 import ViewerContainer from '../viewers/viewer-container'
 
@@ -202,11 +203,9 @@ class CallTakerPanel extends Component {
       activeSearch,
       currentQuery,
       itineraryFooter,
-      LegIcon,
       mainPanelContent,
       mobile,
       modes,
-      ModeIcon,
       routes,
       setQueryParam,
       showUserSettings
@@ -240,7 +239,7 @@ class CallTakerPanel extends Component {
     const maxPlacesDefined = intermediatePlaces.length >= 3
     const addIntermediateDisabled = !from || !to || maxPlacesDefined
     return (
-      <ViewerContainer ModeIcon={ModeIcon}>
+      <ViewerContainer>
         {/* FIXME: should this be a styled component */}
         <div className='main-panel' style={{
           position: 'absolute',
@@ -337,7 +336,6 @@ class CallTakerPanel extends Component {
               <div className='advanced-search-options' style={advancedSearchStyle}>
                 <CallTakerAdvancedOptions
                   modes={modes}
-                  ModeIcon={ModeIcon}
                   routes={routes}
                   findRoutes={this.props.findRoutes}
                   setQueryParam={setQueryParam}
@@ -362,7 +360,6 @@ class CallTakerPanel extends Component {
                 bottom: '0'
               }}
               itineraryFooter={itineraryFooter}
-              LegIcon={LegIcon}
             />
           </div>
         </div>
@@ -380,6 +377,8 @@ class CallTakerAdvancedOptions extends Component {
       transitModes: props.modes.transitModes.map(m => m.mode)
     }
   }
+
+  static contextType = ComponentContext
 
   componentWillMount () {
     // Fetch routes for banned/preferred routes selectors.
@@ -477,7 +476,9 @@ class CallTakerAdvancedOptions extends Component {
   }
 
   render () {
-    const {currentQuery, modes, ModeIcon} = this.props
+    const { currentQuery, modes } = this.props
+    const { ModeIcon } = this.context
+
     const {maxBikeDistance, maxWalkDistance, mode} = currentQuery
     const bannedRoutes = this.getRouteList('bannedRoutes')
     const preferredRoutes = this.getRouteList('preferredRoutes')

--- a/lib/components/app/call-taker-panel.js
+++ b/lib/components/app/call-taker-panel.js
@@ -202,7 +202,6 @@ class CallTakerPanel extends Component {
     const {
       activeSearch,
       currentQuery,
-      itineraryFooter,
       mainPanelContent,
       mobile,
       modes,
@@ -359,7 +358,6 @@ class CallTakerPanel extends Component {
                 left: '0',
                 bottom: '0'
               }}
-              itineraryFooter={itineraryFooter}
             />
           </div>
         </div>

--- a/lib/components/app/default-main-panel.js
+++ b/lib/components/app/default-main-panel.js
@@ -16,9 +16,7 @@ class DefaultMainPanel extends Component {
       currentQuery,
       itineraryClass,
       itineraryFooter,
-      LegIcon,
       mainPanelContent,
-      ModeIcon,
       showUserSettings
     } = this.props
     const showPlanTripButton = mainPanelContent === 'EDIT_DATETIME' ||
@@ -26,7 +24,7 @@ class DefaultMainPanel extends Component {
     const mostRecentQuery = activeSearch ? activeSearch.query : null
     const planDisabled = isEqual(currentQuery, mostRecentQuery)
     return (
-      <ViewerContainer ModeIcon={ModeIcon}>
+      <ViewerContainer>
         <div style={{
           position: 'absolute',
           top: 0,
@@ -36,7 +34,7 @@ class DefaultMainPanel extends Component {
           paddingBottom: 15,
           overflow: 'auto'
         }}>
-          <DefaultSearchForm ModeIcon={ModeIcon} />
+          <DefaultSearchForm />
           {!activeSearch && !showPlanTripButton && showUserSettings &&
             <UserSettings />
           }
@@ -44,7 +42,6 @@ class DefaultMainPanel extends Component {
             <NarrativeRoutingResults
               itineraryClass={itineraryClass}
               itineraryFooter={itineraryFooter}
-              LegIcon={LegIcon}
             />
           </div>
         </div>

--- a/lib/components/app/default-main-panel.js
+++ b/lib/components/app/default-main-panel.js
@@ -14,8 +14,6 @@ class DefaultMainPanel extends Component {
     const {
       activeSearch,
       currentQuery,
-      itineraryClass,
-      itineraryFooter,
       mainPanelContent,
       showUserSettings
     } = this.props
@@ -39,10 +37,7 @@ class DefaultMainPanel extends Component {
             <UserSettings />
           }
           <div className='desktop-narrative-container'>
-            <NarrativeRoutingResults
-              itineraryClass={itineraryClass}
-              itineraryFooter={itineraryFooter}
-            />
+            <NarrativeRoutingResults />
           </div>
         </div>
         {showPlanTripButton &&

--- a/lib/components/app/print-layout.js
+++ b/lib/components/app/print-layout.js
@@ -8,14 +8,16 @@ import { parseUrlQueryString } from '../../actions/form'
 import { routingQuery } from '../../actions/api'
 import DefaultMap from '../map/default-map'
 import TripDetails from '../narrative/connected-trip-details'
+import { ComponentContext } from '../../util/contexts'
 import { getActiveItinerary } from '../../util/state'
 
 class PrintLayout extends Component {
   static propTypes = {
     itinerary: PropTypes.object,
-    LegIcon: PropTypes.elementType.isRequired,
     parseUrlQueryString: PropTypes.func
   }
+
+  static contextType = ComponentContext
 
   constructor (props) {
     super(props)
@@ -53,7 +55,9 @@ class PrintLayout extends Component {
   }
 
   render () {
-    const { config, itinerary, LegIcon } = this.props
+    const { config, itinerary } = this.props
+    const { LegIcon } = this.context
+
     return (
       <div className='otp print-layout'>
         {/* The header bar, including the Toggle Map and Print buttons */}

--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -18,6 +18,7 @@ import * as mapActions from '../../actions/map'
 import * as uiActions from '../../actions/ui'
 import { getAuth0Config } from '../../util/auth'
 import { AUTH0_AUDIENCE, AUTH0_SCOPE, URL_ROOT } from '../../util/constants'
+import { ComponentContext } from '../../util/contexts'
 import { getActiveItinerary, getTitle } from '../../util/state'
 import AfterSignInScreen from '../user/after-signin-screen'
 import BeforeSignInScreen from '../user/before-signin-screen'
@@ -136,8 +137,12 @@ class ResponsiveWebapp extends Component {
   }
 
   render () {
-    const { desktopView, mobileView } = this.props
-    return isMobile() ? mobileView : desktopView
+    const { components, desktopView, mobileView } = this.props
+    return (
+      <ComponentContext.Provider value={components}>
+        {isMobile() ? mobileView : desktopView}
+      </ComponentContext.Provider>
+    )
   }
 }
 

--- a/lib/components/form/connected-settings-selector-panel.js
+++ b/lib/components/form/connected-settings-selector-panel.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
 import { setQueryParam } from '../../actions/form'
+import { ComponentContext } from '../../util/contexts'
 import { getShowUserSettings } from '../../util/state'
 
 import { StyledSettingsSelectorPanel } from './styled'
@@ -11,18 +11,17 @@ import UserTripSettings from './user-trip-settings'
 // TODO: Button title should be bold when button is selected.
 
 class ConnectedSettingsSelectorPanel extends Component {
-  static propTypes = {
-    ModeIcon: PropTypes.elementType.isRequired
-  }
+  static contextType = ComponentContext
 
   render () {
     const {
       config,
-      ModeIcon,
       query,
       setQueryParam,
       showUserSettings
     } = this.props
+    const { ModeIcon } = this.context
+
     return (
       <div className='settings-selector-panel'>
         <div className='modes-panel'>

--- a/lib/components/form/default-search-form.js
+++ b/lib/components/form/default-search-form.js
@@ -7,8 +7,7 @@ import SwitchButton from './switch-button'
 
 export default class DefaultSearchForm extends Component {
   static propTypes = {
-    mobile: PropTypes.bool,
-    ModeIcon: PropTypes.elementType.isRequired
+    mobile: PropTypes.bool
   }
 
   static defaultProps = {
@@ -25,7 +24,7 @@ export default class DefaultSearchForm extends Component {
   }
 
   render () {
-    const { mobile, ModeIcon } = this.props
+    const { mobile } = this.props
     const actionText = mobile ? 'tap' : 'click'
 
     return (
@@ -48,7 +47,7 @@ export default class DefaultSearchForm extends Component {
           </div>
         </div>
 
-        <TabbedFormPanel ModeIcon={ModeIcon} />
+        <TabbedFormPanel />
       </div>
     )
   }

--- a/lib/components/form/tabbed-form-panel.js
+++ b/lib/components/form/tabbed-form-panel.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types'
 import { Button } from 'react-bootstrap'
 import { connect } from 'react-redux'
 
@@ -11,10 +10,6 @@ import ConnectedSettingsSelectorPanel from './connected-settings-selector-panel'
 import { setMainPanelContent } from '../../actions/ui'
 
 class TabbedFormPanel extends Component {
-  static propTypes = {
-    ModeIcon: PropTypes.elementType.isRequired
-  }
-
   _onEditDateTimeClick = () => {
     const { mainPanelContent, setMainPanelContent } = this.props
     setMainPanelContent(mainPanelContent === 'EDIT_DATETIME' ? null : 'EDIT_DATETIME')
@@ -28,7 +23,7 @@ class TabbedFormPanel extends Component {
   _onHideClick = () => this.props.setMainPanelContent(null)
 
   render () {
-    const { ModeIcon, mainPanelContent } = this.props
+    const { mainPanelContent } = this.props
 
     return (
       <div className='tabbed-form-panel'>
@@ -49,7 +44,7 @@ class TabbedFormPanel extends Component {
         {(mainPanelContent === 'EDIT_DATETIME' || mainPanelContent === 'EDIT_SETTINGS') && (
           <div className='active-panel'>
             {mainPanelContent === 'EDIT_DATETIME' && (<DateTimeModal />)}
-            {mainPanelContent === 'EDIT_SETTINGS' && (<ConnectedSettingsSelectorPanel ModeIcon={ModeIcon} />)}
+            {mainPanelContent === 'EDIT_SETTINGS' && (<ConnectedSettingsSelectorPanel />)}
             <div className='hide-button-row'>
               <Button className='hide-button clear-button-formatting' onClick={this._onHideClick}>
                 <i className='fa fa-caret-up' /> Hide Settings

--- a/lib/components/mobile/main.js
+++ b/lib/components/mobile/main.js
@@ -18,7 +18,6 @@ import { getActiveItinerary } from '../../util/state'
 class MobileMain extends Component {
   static propTypes = {
     currentQuery: PropTypes.object,
-    itineraryClass: PropTypes.func,
     map: PropTypes.element,
     setMobileScreen: PropTypes.func,
     title: PropTypes.element,
@@ -44,7 +43,7 @@ class MobileMain extends Component {
   }
 
   render () {
-    const { itineraryClass, itineraryFooter, map, title, uiState } = this.props
+    const { map, title, uiState } = this.props
 
     // check for route viewer
     if (uiState.mainPanelContent === MainPanelContent.ROUTE_VIEWER) {
@@ -101,11 +100,7 @@ class MobileMain extends Component {
 
       case MobileScreens.RESULTS_SUMMARY:
         return (
-          <MobileResultsScreen
-            itineraryClass={itineraryClass}
-            itineraryFooter={itineraryFooter}
-            map={map}
-          />
+          <MobileResultsScreen map={map} />
         )
       default:
         return <p>Invalid mobile screen</p>

--- a/lib/components/mobile/main.js
+++ b/lib/components/mobile/main.js
@@ -19,8 +19,6 @@ class MobileMain extends Component {
   static propTypes = {
     currentQuery: PropTypes.object,
     itineraryClass: PropTypes.func,
-    LegIcon: PropTypes.elementType.isRequired,
-    ModeIcon: PropTypes.elementType.isRequired,
     map: PropTypes.element,
     setMobileScreen: PropTypes.func,
     title: PropTypes.element,
@@ -46,11 +44,11 @@ class MobileMain extends Component {
   }
 
   render () {
-    const { itineraryClass, itineraryFooter, LegIcon, map, ModeIcon, title, uiState } = this.props
+    const { itineraryClass, itineraryFooter, map, title, uiState } = this.props
 
     // check for route viewer
     if (uiState.mainPanelContent === MainPanelContent.ROUTE_VIEWER) {
-      return <MobileRouteViewer ModeIcon={ModeIcon} />
+      return <MobileRouteViewer />
     }
 
     // check for viewed stop
@@ -99,14 +97,13 @@ class MobileMain extends Component {
         return <MobileDateTimeScreen />
 
       case MobileScreens.SET_OPTIONS:
-        return <MobileOptionsScreen ModeIcon={ModeIcon} />
+        return <MobileOptionsScreen />
 
       case MobileScreens.RESULTS_SUMMARY:
         return (
           <MobileResultsScreen
             itineraryClass={itineraryClass}
             itineraryFooter={itineraryFooter}
-            LegIcon={LegIcon}
             map={map}
           />
         )

--- a/lib/components/mobile/options-screen.js
+++ b/lib/components/mobile/options-screen.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
 import MobileContainer from './container'
@@ -10,17 +9,11 @@ import PlanTripButton from '../form/plan-trip-button'
 import { MobileScreens, setMobileScreen } from '../../actions/ui'
 
 class MobileOptionsScreen extends Component {
-  static propTypes = {
-    ModeIcon: PropTypes.elementType.isRequired
-  }
-
   _planTripClicked = () => {
     this.props.setMobileScreen(MobileScreens.RESULTS_SUMMARY)
   }
 
   render () {
-    const { ModeIcon } = this.props
-
     return (
       <MobileContainer>
         <MobileNavigationBar
@@ -30,7 +23,7 @@ class MobileOptionsScreen extends Component {
         />
 
         <div className='options-main-content mobile-padding'>
-          <ConnectedSettingsSelectorPanel ModeIcon={ModeIcon} />
+          <ConnectedSettingsSelectorPanel />
         </div>
 
         <div className='options-lower-tray mobile-padding'>

--- a/lib/components/mobile/results-screen.js
+++ b/lib/components/mobile/results-screen.js
@@ -103,8 +103,6 @@ class MobileResultsScreen extends Component {
     const {
       activeItineraryIndex,
       error,
-      itineraryClass,
-      itineraryFooter,
       query,
       realtimeEffects,
       resultCount,
@@ -213,8 +211,6 @@ class MobileResultsScreen extends Component {
           style={narrativeContainerStyle}
         >
           <ItineraryCarousel
-            itineraryClass={itineraryClass}
-            itineraryFooter={itineraryFooter}
             hideHeader
             expanded={this.state.expanded}
             onClick={this._optionClicked}

--- a/lib/components/mobile/results-screen.js
+++ b/lib/components/mobile/results-screen.js
@@ -105,7 +105,6 @@ class MobileResultsScreen extends Component {
       error,
       itineraryClass,
       itineraryFooter,
-      LegIcon,
       query,
       realtimeEffects,
       resultCount,
@@ -220,7 +219,6 @@ class MobileResultsScreen extends Component {
             expanded={this.state.expanded}
             onClick={this._optionClicked}
             showRealtimeAnnotation={showRealtimeAnnotation}
-            LegIcon={LegIcon}
           />
         </div>
 

--- a/lib/components/mobile/route-viewer.js
+++ b/lib/components/mobile/route-viewer.js
@@ -9,13 +9,15 @@ import RouteViewer from '../viewers/route-viewer'
 import DefaultMap from '../map/default-map'
 
 import { setViewedRoute, setMainPanelContent } from '../../actions/ui'
+import { ComponentContext } from '../../util/contexts'
 
 class MobileRouteViewer extends Component {
   static propTypes = {
-    ModeIcon: PropTypes.element.isRequired,
     setViewedRoute: PropTypes.func,
     setMainPanelContent: PropTypes.func
   }
+
+  static contextType = ComponentContext
 
   _backClicked = () => {
     this.props.setViewedRoute(null)
@@ -23,7 +25,7 @@ class MobileRouteViewer extends Component {
   }
 
   render () {
-    const { ModeIcon } = this.props
+    const { ModeIcon } = this.context
     return (
       <MobileContainer>
         <MobileNavigationBar

--- a/lib/components/narrative/itinerary-carousel.js
+++ b/lib/components/narrative/itinerary-carousel.js
@@ -9,6 +9,7 @@ import { setActiveItinerary, setActiveLeg, setActiveStep } from '../../actions/n
 import Icon from './icon'
 import DefaultItinerary from './default/default-itinerary'
 import Loading from './loading'
+import { ComponentContext } from '../../util/contexts'
 import { getActiveItineraries, getActiveSearch } from '../../util/state'
 
 class ItineraryCarousel extends Component {
@@ -26,6 +27,8 @@ class ItineraryCarousel extends Component {
     expanded: PropTypes.bool,
     companies: PropTypes.string
   }
+
+  static contextType = ComponentContext
 
   static defaultProps = {
     itineraryClass: DefaultItinerary
@@ -50,16 +53,26 @@ class ItineraryCarousel extends Component {
   }
 
   render () {
-    const { activeItinerary, itineraries, itineraryClass, hideHeader, pending, user } = this.props
+    const {
+      activeItinerary,
+      itineraries,
+      itineraryClass,
+      hideHeader,
+      pending,
+      user
+    } = this.props
+    const { LegIcon } = this.context
+
     if (pending) return <Loading small />
     if (!itineraries) return null
 
     const views = itineraries.map((itinerary, index) => {
       return React.createElement(itineraryClass, {
-        itinerary,
-        index,
-        key: index,
         expanded: this.props.expanded,
+        index,
+        itinerary,
+        key: index,
+        LegIcon,
         onClick: this._onItineraryClick,
         user,
         ...this.props

--- a/lib/components/narrative/itinerary-carousel.js
+++ b/lib/components/narrative/itinerary-carousel.js
@@ -7,7 +7,6 @@ import SwipeableViews from 'react-swipeable-views'
 
 import { setActiveItinerary, setActiveLeg, setActiveStep } from '../../actions/narrative'
 import Icon from './icon'
-import DefaultItinerary from './default/default-itinerary'
 import Loading from './loading'
 import { ComponentContext } from '../../util/contexts'
 import { getActiveItineraries, getActiveSearch } from '../../util/state'
@@ -19,7 +18,6 @@ class ItineraryCarousel extends Component {
     pending: PropTypes.number,
     activeItinerary: PropTypes.number,
     hideHeader: PropTypes.bool,
-    itineraryClass: PropTypes.func,
     onClick: PropTypes.func,
     setActiveItinerary: PropTypes.func,
     setActiveLeg: PropTypes.func,
@@ -29,10 +27,6 @@ class ItineraryCarousel extends Component {
   }
 
   static contextType = ComponentContext
-
-  static defaultProps = {
-    itineraryClass: DefaultItinerary
-  }
 
   _onItineraryClick = () => {
     if (typeof this.props.onClick === 'function') this.props.onClick()
@@ -55,27 +49,15 @@ class ItineraryCarousel extends Component {
   render () {
     const {
       activeItinerary,
+      expanded,
       itineraries,
-      itineraryClass,
       hideHeader,
       pending
     } = this.props
-    const { LegIcon } = this.context
+    const { ItineraryBody, LegIcon } = this.context
 
     if (pending) return <Loading small />
     if (!itineraries) return null
-
-    const views = itineraries.map((itinerary, index) => {
-      return React.createElement(itineraryClass, {
-        expanded: this.props.expanded,
-        index,
-        itinerary,
-        key: index,
-        LegIcon,
-        onClick: this._onItineraryClick,
-        ...this.props
-      })
-    })
 
     return (
       <div className='options itinerary'>
@@ -103,7 +85,19 @@ class ItineraryCarousel extends Component {
         <SwipeableViews
           index={activeItinerary}
           onChangeIndex={this._onSwipe}
-        >{views}</SwipeableViews>
+        >
+          {itineraries.map((itinerary, index) => (
+            <ItineraryBody
+              expanded={expanded}
+              index={index}
+              itinerary={itinerary}
+              key={index}
+              LegIcon={LegIcon}
+              onClick={this._onItineraryClick}
+              {...this.props}
+            />
+          ))}
+        </SwipeableViews>
       </div>
     )
   }

--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -15,7 +15,7 @@ import TransitLegSubheader from './connected-transit-leg-subheader'
 import RealtimeTimeColumn from './realtime-time-column'
 import TripDetails from '../connected-trip-details'
 import TripTools from '../trip-tools'
-import { ComponentContext } from '../../util/contexts'
+import { ComponentContext } from '../../../util/contexts'
 
 const noop = () => {}
 

--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -15,6 +15,7 @@ import TransitLegSubheader from './connected-transit-leg-subheader'
 import RealtimeTimeColumn from './realtime-time-column'
 import TripDetails from '../connected-trip-details'
 import TripTools from '../trip-tools'
+import { ComponentContext } from '../../util/contexts'
 
 const noop = () => {}
 
@@ -29,6 +30,8 @@ const StyledItineraryBody = styled(ItineraryBody)`
 `
 
 class ConnectedItineraryBody extends Component {
+  static contextType = ComponentContext
+
   /** avoid rerendering if the itinerary to display hasn't changed */
   shouldComponentUpdate (nextProps, nextState) {
     return !isEqual(this.props.itinerary, nextProps.itinerary)
@@ -39,12 +42,12 @@ class ConnectedItineraryBody extends Component {
       config,
       diagramVisible,
       itinerary,
-      LegIcon,
       setActiveLeg,
       setViewedTrip,
       setLegDiagram,
       timeOptions
     } = this.props
+    const { LegIcon } = this.context
 
     return (
       <ItineraryBodyContainer>

--- a/lib/components/narrative/line-itin/itin-summary.js
+++ b/lib/components/narrative/line-itin/itin-summary.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import styled from 'styled-components'
 
+import { ComponentContext } from '../../../util/contexts'
+
 // TODO: make this a prop
 const defaultRouteColor = '#008'
 
@@ -71,16 +73,17 @@ const ShortName = styled.div`
 
 export default class ItinerarySummary extends Component {
   static propTypes = {
-    itinerary: PropTypes.object,
-    LegIcon: PropTypes.elementType.isRequired
+    itinerary: PropTypes.object
   }
+
+  static contextType = ComponentContext
 
   _onSummaryClicked = () => {
     if (typeof this.props.onClick === 'function') this.props.onClick()
   }
 
   render () {
-    const { itinerary, LegIcon, timeOptions } = this.props
+    const { itinerary, timeOptions } = this.props
     const {
       centsToString,
       maxTNCFare,

--- a/lib/components/narrative/line-itin/itin-summary.js
+++ b/lib/components/narrative/line-itin/itin-summary.js
@@ -84,6 +84,8 @@ export default class ItinerarySummary extends Component {
 
   render () {
     const { itinerary, timeOptions } = this.props
+    const { LegIcon } = this.context
+
     const {
       centsToString,
       maxTNCFare,
@@ -131,7 +133,9 @@ export default class ItinerarySummary extends Component {
           }).map((leg, k) => {
             return (
               <RoutePreview key={k}>
-                <LegIconContainer><LegIcon leg={leg} /></LegIconContainer>
+                <LegIconContainer>
+                  <LegIcon leg={leg} />
+                </LegIconContainer>
                 {coreUtils.itinerary.isTransit(leg.mode)
                   ? (
                     <ShortName leg={leg} >

--- a/lib/components/narrative/line-itin/line-itinerary.js
+++ b/lib/components/narrative/line-itin/line-itinerary.js
@@ -50,7 +50,6 @@ export default class LineItinerary extends NarrativeItinerary {
       expanded,
       itinerary,
       itineraryFooter,
-      LegIcon,
       onClick,
       setActiveLeg,
       showRealtimeAnnotation,
@@ -72,7 +71,6 @@ export default class LineItinerary extends NarrativeItinerary {
         <ItinerarySummary
           companies={companies}
           itinerary={itinerary}
-          LegIcon={LegIcon}
           onClick={onClick}
           timeOptions={timeOptions}
         />
@@ -85,7 +83,6 @@ export default class LineItinerary extends NarrativeItinerary {
         {active || expanded
           ? <ItineraryBody
             itinerary={itinerary}
-            LegIcon={LegIcon}
             // timeOptions={timeOptions}
             // Don't use setActiveLeg as an import
             // (will cause error when clicking on itinerary suymmary).

--- a/lib/components/narrative/line-itin/line-itinerary.js
+++ b/lib/components/narrative/line-itin/line-itinerary.js
@@ -7,6 +7,7 @@ import ItinerarySummary from './itin-summary'
 import NarrativeItinerary from '../narrative-itinerary'
 import SaveTripButton from '../save-trip-button'
 import SimpleRealtimeAnnotation from '../simple-realtime-annotation'
+import { ComponentContext } from '../../../util/contexts'
 
 const { getLegModeLabel, getTimeZoneOffset, isTransit } = coreUtils.itinerary
 
@@ -15,6 +16,8 @@ export const LineItineraryContainer = styled.div`
 `
 
 export default class LineItinerary extends NarrativeItinerary {
+  static contextType = ComponentContext
+
   _headerText () {
     const { itinerary } = this.props
     return itinerary.summary || this._getSummary(itinerary)
@@ -49,12 +52,12 @@ export default class LineItinerary extends NarrativeItinerary {
       companies,
       expanded,
       itinerary,
-      itineraryFooter,
       onClick,
       setActiveLeg,
       showRealtimeAnnotation,
       timeFormat
     } = this.props
+    const { ItineraryFooter } = this.context
 
     if (!itinerary) {
       return <div>No Itinerary!</div>
@@ -87,7 +90,7 @@ export default class LineItinerary extends NarrativeItinerary {
             timeOptions={timeOptions}
           />
           : null}
-        {itineraryFooter}
+        {ItineraryFooter && <ItineraryFooter />}
       </LineItineraryContainer>
     )
   }

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -14,6 +14,7 @@ import {
 } from '../../actions/narrative'
 import DefaultItinerary from './default/default-itinerary'
 import Icon from '../narrative/icon'
+import { ComponentContext } from '../../util/contexts'
 import LinkButton from '../user/link-button'
 import {
   getResponsesWithErrors,
@@ -46,6 +47,8 @@ class NarrativeItineraries extends Component {
     setUseRealtimeResponse: PropTypes.func,
     useRealtime: PropTypes.bool
   }
+
+  static contextType = ComponentContext
 
   static defaultProps = {
     itineraryClass: DefaultItinerary
@@ -118,6 +121,8 @@ class NarrativeItineraries extends Component {
       sort,
       useRealtime
     } = this.props
+    const { LegIcon } = this.context
+
     if (!activeSearch) return null
     const itineraryIsExpanded = activeItinerary !== undefined && activeItinerary !== null && this.state.showDetails
     const showRealtimeAnnotation = realtimeEffects.isAffectedByRealtimeData && (
@@ -209,15 +214,16 @@ class NarrativeItineraries extends Component {
             // Hide non-active itineraries.
             if (!active && itineraryIsExpanded) return null
             return React.createElement(itineraryClass, {
-              itinerary,
-              index,
-              key: index,
               active,
-              routingType: 'ITINERARY',
-              sort,
               expanded: this.state.showDetails,
+              index,
+              itinerary,
+              key: index,
+              LegIcon,
               onClick: active ? this._toggleDetailedItinerary : undefined,
+              routingType: 'ITINERARY',
               showRealtimeAnnotation,
+              sort,
               ...this.props
             })
           })}

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -12,7 +12,6 @@ import {
   setVisibleItinerary,
   updateItineraryFilter
 } from '../../actions/narrative'
-import DefaultItinerary from './default/default-itinerary'
 import Icon from '../narrative/icon'
 import { ComponentContext } from '../../util/contexts'
 import {
@@ -38,7 +37,6 @@ function humanReadableMode (modeStr) {
 class NarrativeItineraries extends Component {
   static propTypes = {
     itineraries: PropTypes.array,
-    itineraryClass: PropTypes.func,
     pending: PropTypes.bool,
     activeItinerary: PropTypes.number,
     setActiveItinerary: PropTypes.func,
@@ -49,10 +47,6 @@ class NarrativeItineraries extends Component {
   }
 
   static contextType = ComponentContext
-
-  static defaultProps = {
-    itineraryClass: DefaultItinerary
-  }
 
   state = {}
 
@@ -109,13 +103,12 @@ class NarrativeItineraries extends Component {
       errors,
       filter,
       itineraries,
-      itineraryClass,
       pending,
       realtimeEffects,
       sort,
       useRealtime
     } = this.props
-    const { LegIcon } = this.context
+    const { ItineraryBody, LegIcon } = this.context
 
     if (!activeSearch) return null
     const itineraryIsExpanded = activeItinerary !== undefined && activeItinerary !== null && this.state.showDetails
@@ -199,19 +192,21 @@ class NarrativeItineraries extends Component {
             const active = index === activeItinerary
             // Hide non-active itineraries.
             if (!active && itineraryIsExpanded) return null
-            return React.createElement(itineraryClass, {
-              active,
-              expanded: this.state.showDetails,
-              index,
-              itinerary,
-              key: index,
-              LegIcon,
-              onClick: active ? this._toggleDetailedItinerary : undefined,
-              routingType: 'ITINERARY',
-              showRealtimeAnnotation,
-              sort,
-              ...this.props
-            })
+            return (
+              <ItineraryBody
+                active={active}
+                expanded={this.state.showDetails}
+                index={index}
+                itinerary={itinerary}
+                key={index}
+                LegIcon={LegIcon}
+                onClick={active ? this._toggleDetailedItinerary : undefined}
+                routingType='ITINERARY'
+                showRealtimeAnnotation={showRealtimeAnnotation}
+                sort={sort}
+                {...this.props}
+              />
+            )
           })}
           {/* FIXME: Flesh out error design/move to component? */}
           {errors.map((e, i) => {

--- a/lib/components/narrative/narrative-routing-results.js
+++ b/lib/components/narrative/narrative-routing-results.js
@@ -16,7 +16,6 @@ import { setMainPanelContent } from '../../actions/ui'
 class NarrativeRoutingResults extends Component {
   static propTypes = {
     itineraryClass: PropTypes.func,
-    LegIcon: PropTypes.elementType.isRequired,
     routingType: PropTypes.string
   }
 
@@ -29,7 +28,14 @@ class NarrativeRoutingResults extends Component {
   }
 
   render () {
-    const { error, itineraryClass, itineraryFooter, LegIcon, pending, itineraries, mainPanelContent } = this.props
+    const {
+      error,
+      itineraryClass,
+      itineraryFooter,
+      pending,
+      itineraries,
+      mainPanelContent
+    } = this.props
     if (pending) return <Loading />
     if (error) return <ErrorMessage />
     if (mainPanelContent) return null
@@ -40,7 +46,6 @@ class NarrativeRoutingResults extends Component {
         itineraryClass={itineraryClass}
         itineraryFooter={itineraryFooter}
         itineraries={itineraries}
-        LegIcon={LegIcon}
       />
     )
   }

--- a/lib/components/narrative/narrative-routing-results.js
+++ b/lib/components/narrative/narrative-routing-results.js
@@ -15,7 +15,6 @@ import { setMainPanelContent } from '../../actions/ui'
 
 class NarrativeRoutingResults extends Component {
   static propTypes = {
-    itineraryClass: PropTypes.func,
     routingType: PropTypes.string
   }
 
@@ -30,23 +29,18 @@ class NarrativeRoutingResults extends Component {
   render () {
     const {
       error,
-      itineraryClass,
-      itineraryFooter,
       pending,
       itineraries,
       mainPanelContent
     } = this.props
+
     if (pending) return <Loading />
     if (error) return <ErrorMessage />
     if (mainPanelContent) return null
 
     return (
       // TODO: If multiple routing types exist, do the check here.
-      <TabbedItineraries
-        itineraryClass={itineraryClass}
-        itineraryFooter={itineraryFooter}
-        itineraries={itineraries}
-      />
+      <TabbedItineraries itineraries={itineraries} />
     )
   }
 }

--- a/lib/components/narrative/tabbed-itineraries.js
+++ b/lib/components/narrative/tabbed-itineraries.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux'
 
 import * as narrativeActions from '../../actions/narrative'
 import DefaultItinerary from './default/default-itinerary'
+import { ComponentContext } from '../../util/contexts'
 import { getActiveSearch, getRealtimeEffects } from '../../util/state'
 
 const { calculateFares, calculatePhysicalActivity, getTimeZoneOffset } = coreUtils.itinerary
@@ -23,6 +24,8 @@ class TabbedItineraries extends Component {
     setUseRealtimeResponse: PropTypes.func,
     useRealtime: PropTypes.bool
   }
+
+  static contextType = ComponentContext
 
   static defaultProps = {
     itineraryClass: DefaultItinerary
@@ -44,6 +47,8 @@ class TabbedItineraries extends Component {
       useRealtime,
       ...itineraryClassProps
     } = this.props
+    const { LegIcon } = this.context
+
     if (!itineraries) return null
 
     /* TODO: should this be moved? */
@@ -78,11 +83,12 @@ class TabbedItineraries extends Component {
         {/* Show active itin if itineraries exist and active itin is defined. */}
         {(itineraries.length > 0 && activeItinerary >= 0)
           ? React.createElement(itineraryClass, {
-            itinerary: itineraries[activeItinerary],
-            index: activeItinerary,
-            key: activeItinerary,
             active: true,
             expanded: true,
+            index: activeItinerary,
+            itinerary: itineraries[activeItinerary],
+            key: activeItinerary,
+            LegIcon,
             routingType: 'ITINERARY',
             showRealtimeAnnotation,
             timeFormat,

--- a/lib/components/narrative/tabbed-itineraries.js
+++ b/lib/components/narrative/tabbed-itineraries.js
@@ -5,7 +5,6 @@ import { Button } from 'react-bootstrap'
 import { connect } from 'react-redux'
 
 import * as narrativeActions from '../../actions/narrative'
-import DefaultItinerary from './default/default-itinerary'
 import { ComponentContext } from '../../util/contexts'
 import { getActiveSearch, getRealtimeEffects } from '../../util/state'
 
@@ -15,7 +14,6 @@ const { formatDuration, formatTime, getTimeFormat } = coreUtils.time
 class TabbedItineraries extends Component {
   static propTypes = {
     itineraries: PropTypes.array,
-    itineraryClass: PropTypes.func,
     pending: PropTypes.bool,
     activeItinerary: PropTypes.number,
     setActiveItinerary: PropTypes.func,
@@ -27,10 +25,6 @@ class TabbedItineraries extends Component {
 
   static contextType = ComponentContext
 
-  static defaultProps = {
-    itineraryClass: DefaultItinerary
-  }
-
   _toggleRealtimeItineraryClick = (e) => {
     const { setUseRealtimeResponse, useRealtime } = this.props
     setUseRealtimeResponse({ useRealtime: !useRealtime })
@@ -40,14 +34,13 @@ class TabbedItineraries extends Component {
     const {
       activeItinerary,
       itineraries,
-      itineraryClass,
       realtimeEffects,
       setActiveItinerary,
       timeFormat,
       useRealtime,
-      ...itineraryClassProps
+      ...itineraryBodyProps
     } = this.props
-    const { LegIcon } = this.context
+    const { ItineraryBody, LegIcon } = this.context
 
     if (!itineraries) return null
 
@@ -82,18 +75,20 @@ class TabbedItineraries extends Component {
 
         {/* Show active itin if itineraries exist and active itin is defined. */}
         {(itineraries.length > 0 && activeItinerary >= 0)
-          ? React.createElement(itineraryClass, {
-            active: true,
-            expanded: true,
-            index: activeItinerary,
-            itinerary: itineraries[activeItinerary],
-            key: activeItinerary,
-            LegIcon,
-            routingType: 'ITINERARY',
-            showRealtimeAnnotation,
-            timeFormat,
-            ...itineraryClassProps
-          })
+          ? (
+            <ItineraryBody
+              active
+              expanded
+              index={activeItinerary}
+              itinerary={itineraries[activeItinerary]}
+              key={activeItinerary}
+              LegIcon={LegIcon}
+              routingType='ITINERARY'
+              showRealtimeAnnotation={showRealtimeAnnotation}
+              timeFormat={timeFormat}
+              {...itineraryBodyProps}
+            />
+          )
           : null
         }
 

--- a/lib/components/viewers/route-viewer.js
+++ b/lib/components/viewers/route-viewer.js
@@ -187,7 +187,7 @@ class RouteRow extends PureComponent {
   }
 
   render () {
-    const {isActive, route, operator} = this.props
+    const { isActive, route, operator } = this.props
     const { ModeIcon } = this.context
 
     const {defaultRouteColor, defaultRouteTextColor, longNameSplitter} = operator || {}

--- a/lib/components/viewers/route-viewer.js
+++ b/lib/components/viewers/route-viewer.js
@@ -10,6 +10,7 @@ import Icon from '../narrative/icon'
 
 import { setMainPanelContent, setViewedRoute } from '../../actions/ui'
 import { findRoutes, findRoute } from '../../actions/api'
+import { ComponentContext } from '../../util/contexts'
 import { getModeFromRoute } from '../../util/viewer'
 
 /**
@@ -32,7 +33,6 @@ function getContrastYIQ (hexcolor) {
 class RouteViewer extends Component {
   static propTypes = {
     hideBackButton: PropTypes.bool,
-    ModeIcon: PropTypes.element.isRequired,
     routes: PropTypes.object
   }
 
@@ -47,7 +47,6 @@ class RouteViewer extends Component {
       findRoute,
       hideBackButton,
       languageConfig,
-      ModeIcon,
       transitOperators,
       routes,
       setViewedRoute,
@@ -95,7 +94,6 @@ class RouteViewer extends Component {
                   findRoute={findRoute}
                   isActive={viewedRoute && viewedRoute.routeId === route.id}
                   key={route.id}
-                  ModeIcon={ModeIcon}
                   operator={operator}
                   route={route}
                   setViewedRoute={setViewedRoute}
@@ -157,6 +155,8 @@ const RouteDetails = styled.div`
 `
 
 class RouteRow extends PureComponent {
+  static contextType = ComponentContext
+
   _onClick = () => {
     const { findRoute, isActive, route, setViewedRoute } = this.props
     if (isActive) {
@@ -186,7 +186,9 @@ class RouteRow extends PureComponent {
   }
 
   render () {
-    const {isActive, ModeIcon, route, operator} = this.props
+    const {isActive, route, operator} = this.props
+    const { ModeIcon } = this.context
+
     const {defaultRouteColor, defaultRouteTextColor, longNameSplitter} = operator || {}
     const backgroundColor = `#${defaultRouteColor || route.color || 'ffffff'}`
     // NOTE: text color is not a part of short response route object, so there

--- a/lib/components/viewers/viewer-container.js
+++ b/lib/components/viewers/viewer-container.js
@@ -9,16 +9,15 @@ import { MainPanelContent } from '../../actions/ui'
 
 class ViewerContainer extends Component {
   static propTypes = {
-    ModeIcon: PropTypes.element.isRequired,
     uiState: PropTypes.object
   }
 
   render () {
-    const { ModeIcon, uiState } = this.props
+    const { uiState } = this.props
 
     // check for main panel content
     if (uiState.mainPanelContent === MainPanelContent.ROUTE_VIEWER) {
-      return <RouteViewer ModeIcon={ModeIcon} />
+      return <RouteViewer />
     }
 
     // check for stop viewer

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ import StylizedMap from './components/map/stylized-map'
 import OsmBaseLayer from './components/map/osm-base-layer'
 import TileOverlay from './components/map/tile-overlay'
 
+import DefaultItinerary from './components/narrative/default/default-itinerary'
 import ItineraryCarousel from './components/narrative/itinerary-carousel'
 import NarrativeItineraries from './components/narrative/narrative-itineraries'
 import NarrativeItinerary from './components/narrative/narrative-itinerary'
@@ -78,6 +79,7 @@ export {
   TileOverlay,
 
   // narrative components
+  DefaultItinerary,
   LineItinerary,
   NarrativeItineraries,
   NarrativeItinerary,

--- a/lib/util/contexts.js
+++ b/lib/util/contexts.js
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export const ComponentContext = React.createContext({})


### PR DESCRIPTION
This PR depends on #201. 

In response to https://github.com/opentripplanner/otp-react-redux/pull/201#discussion_r524368723, this PR refactors the app to avoid needless prop-drilling of custom components sent in by implementing applications by utilizing the React context as needed.

Although this PR doesn't yet have any commits that indicate a breaking change, there are changes that could be considered breaking. The `itineraryClass`, `itineraryFooter`, `LegIcon` and `ModeIcon` are now all supposed to be added to a `components` property in the `ResponsiveWebapp` instead of in individual components. This also introduces the assumption that implementers of otp-react-redux will use the `ResponsiveWebapp` or directly import the `ComponentContext` and wrap components in a Provider in their app.