### PR TITLE
fix(ItineraryBody): Remove width limitation for PlaceRow items.

### DIFF
--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -3,7 +3,7 @@ import TransitLegSummary from '@opentripplanner/itinerary-body/lib/defaults/tran
 import ItineraryBody from '@opentripplanner/itinerary-body/lib/otp-react-redux/itinerary-body'
 import LineColumnContent from '@opentripplanner/itinerary-body/lib/otp-react-redux/line-column-content'
 import PlaceName from '@opentripplanner/itinerary-body/lib/otp-react-redux/place-name'
-import { PlaceName as PlaceNameWrapper } from '@opentripplanner/itinerary-body/lib/styled'
+import { PlaceName as PlaceNameWrapper, PlaceRowWrapper } from '@opentripplanner/itinerary-body/lib/styled'
 import RouteDescription from '@opentripplanner/itinerary-body/lib/otp-react-redux/route-description'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
@@ -25,6 +25,9 @@ const ItineraryBodyContainer = styled.div`
 const StyledItineraryBody = styled(ItineraryBody)`
   ${PlaceNameWrapper} {
     font-weight: inherit;
+  }
+  ${PlaceRowWrapper} {
+    max-width: inherit;
   }
 `
 


### PR DESCRIPTION
This PR partially addresses https://github.com/ibi-group/trimet-mod-otp/issues/282 by removing a width limitation for `PlaceRowWrapper` inside `ConnectedItineraryBody` components, so that place labels and alert boxes occupy the entire width available, especially on wide screens.

This PR supersedes https://github.com/opentripplanner/otp-ui/pull/223 and https://github.com/ibi-group/otp-ui/pull/5.

![image](https://user-images.githubusercontent.com/56846598/101095081-5fdd5880-358b-11eb-8c7f-ab5c83dfa797.png)
