### PR TITLE
Move/fix banned routes handler

### DIFF
--- a/lib/components/app/call-taker-panel.js
+++ b/lib/components/app/call-taker-panel.js
@@ -116,11 +116,6 @@ class CallTakerPanel extends Component {
     routingQuery()
   }
 
-  _setBannedRoutes = options => {
-    const bannedRoutes = options ? options.map(o => o.value).join(',') : ''
-    this.props.setQueryParam({ bannedRoutes })
-  }
-
   modeToOptionValue = mode => {
     const isTransit = hasTransit(mode)
     const isBike = hasBike(mode)
@@ -393,6 +388,11 @@ class CallTakerAdvancedOptions extends Component {
       const routeOptions = Object.values(routes).map(this.routeToOption)
       this.setState({routeOptions})
     }
+  }
+
+  _setBannedRoutes = options => {
+    const bannedRoutes = options ? options.map(o => o.value).join(',') : ''
+    this.props.setQueryParam({ bannedRoutes })
   }
 
   _setPreferredRoutes = options => {


### PR DESCRIPTION
Fix banned routes selection in calltaker module (during a refactor, the handler didn't get moved to the new component).