### PR TITLE
Update auth0 scope for ibi-group/otp-middleware#120

### DIFF
--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -1,5 +1,6 @@
 export const AUTH0_AUDIENCE = 'https://otp-middleware'
-export const AUTH0_SCOPE = ''
+// This should match the value expected in otp-middleware OtpUser#AUTH0_SCOPE
+export const AUTH0_SCOPE = 'otp-user'
 export const DEFAULT_APP_TITLE = 'OpenTripPlanner'
 export const PERSISTENCE_STRATEGY_OTP_MIDDLEWARE = 'otp_middleware'
 


### PR DESCRIPTION
ibi-group/otp-middleware#120 requires that the MOD UI client set the `AUTH0_SCOPE` value to `otp-user` to match the value set in `OtpUser.class`.