### PR TITLE
Replace window event listeners with css @media query

### DIFF
--- a/lib/components/app/batch-routing-panel.js
+++ b/lib/components/app/batch-routing-panel.js
@@ -211,20 +211,19 @@ class BatchRoutingPanel extends Component {
           !activeSearch && showUserSettings &&
           <UserSettings />
         */}
-        <div className='desktop-narrative-container'>
-          <NarrativeContainer>
-            <NarrativeItineraries
-              containerStyle={{
-                display: 'flex',
-                flexDirection: 'column',
-                position: 'absolute',
-                right: '0',
-                left: '0',
-                bottom: '0'
-              }}
-            />
-          </NarrativeContainer>
-        </div>
+        {/* TODO: Implement mobile view */}
+        <NarrativeContainer className='desktop-narrative-container'>
+          <NarrativeItineraries
+            containerStyle={{
+              display: 'flex',
+              flexDirection: 'column',
+              position: 'absolute',
+              right: '0',
+              left: '0',
+              bottom: '0'
+            }}
+          />
+        </NarrativeContainer>
       </ViewerContainer>
     )
   }

--- a/lib/components/app/batch-routing-panel.js
+++ b/lib/components/app/batch-routing-panel.js
@@ -76,6 +76,22 @@ const ModeButtonsCompressed = styled(ModeButtons)`
     border-radius: 0px 5px 5px 0px;
   }
 `
+// Style for setting the top of the narrative itineraries based on the width of the window.
+// If the window width is less than 1200px (Bootstrap's "large" size), the
+// mode buttons will be shown on their own row, meaning that the
+// top position of this component needs to be lower (higher value
+// equals lower position on the page).
+// TODO: figure out a better way to use flex rendering for accommodating the mode button overflow.
+const NarrativeContainer = styled.div`
+  & .options.itinerary {
+    @media (min-width: 1200px) {
+      top: 160px;
+    }
+    @media (max-width: 1199px) {
+      top: 210px;
+    }
+  }
+`
 
 /**
  * Main panel for the batch/trip comparison form.
@@ -85,17 +101,6 @@ class BatchRoutingPanel extends Component {
     expanded: null,
     selectedModes: POSSIBLE_MODES
   }
-
-  componentDidMount () {
-    this.updateWindowWidth()
-    window.addEventListener('resize', this.updateWindowWidth)
-  }
-
-  componentWillUnmount () {
-    window.removeEventListener('resize', this.updateWindowWidth)
-  }
-
-  updateWindowWidth = () => this.setState({width: window.innerWidth})
 
   _onClickMode = (mode) => {
     const {possibleCombinations, setQueryParam} = this.props
@@ -141,7 +146,7 @@ class BatchRoutingPanel extends Component {
 
   render () {
     const {config, currentQuery, mobile} = this.props
-    const {expanded, selectedModes, width} = this.state
+    const {expanded, selectedModes} = this.state
     const actionText = mobile ? 'tap' : 'click'
     return (
       <ViewerContainer className='batch-routing-panel'>
@@ -207,22 +212,18 @@ class BatchRoutingPanel extends Component {
           <UserSettings />
         */}
         <div className='desktop-narrative-container'>
-          <NarrativeItineraries
-            containerStyle={{
-              display: 'flex',
-              flexDirection: 'column',
-              position: 'absolute',
-              // This is variable dependent on height of the form above. If the
-              // screen width is less than 1200 (Bootstrap's "large" size), the
-              // mode buttons will be shown on their own row, meaning that the
-              // top position of this component needs to be lower (higher value
-              // equals lower position on the page).
-              top: width < 1200 ? '210px' : '160px',
-              right: '0',
-              left: '0',
-              bottom: '0'
-            }}
-          />
+          <NarrativeContainer>
+            <NarrativeItineraries
+              containerStyle={{
+                display: 'flex',
+                flexDirection: 'column',
+                position: 'absolute',
+                right: '0',
+                left: '0',
+                bottom: '0'
+              }}
+            />
+          </NarrativeContainer>
         </div>
       </ViewerContainer>
     )


### PR DESCRIPTION
This PR replaces code that sets up `window.onresize` event handlers with CSS `@media` queries for element positioning.