### PR TITLE
Add config for dateTime format

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -196,3 +196,7 @@ itinerary:
 # phoneFormatOptions:
 #  # ISO 2-letter country code for phone number formats (defaults to 'US')
 #  countryCode: US
+
+# Format the date time format for display.
+dateTime:
+  longDateFormat: DD-MM-YYYY


### PR DESCRIPTION
Merge #218 added a config option for the format of the date display. But the change in the example config was not included.

Fixes #260