### PR TITLE
Display generic mode icon instead of company logo

### DIFF
--- a/lib/components/narrative/default/itinerary-summary.js
+++ b/lib/components/narrative/default/itinerary-summary.js
@@ -1,3 +1,4 @@
+import clone from 'clone'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
@@ -61,6 +62,21 @@ export default class ItinerarySummary extends Component {
         style.borderTopRightRadius = '4px'
         style.borderBottomRightRadius = '4px'
       }
+
+      // For some reason, OTP returns the rental company (network) info
+      // for the first rental leg encountered, but not on subsequent legs
+      // (assuming the same rental company is used),
+      // so we remove the network info to display the plain mode icon
+      // (e.g. the BICYCLE icon instead of a bikeshare company logo)
+      // instead of the company icon or blank if no company icon is found.
+      //
+      // FIXME: find a way to use ModeIcon instead.
+      // Currently, that would require passing ModeIcon as an extra prop in multiple places.
+      const legWithoutNetwork = clone(leg)
+      if (legWithoutNetwork.from) {
+        legWithoutNetwork.from.networks = undefined
+      }
+
       blocks.push(
         <div
           style={style}
@@ -68,7 +84,7 @@ export default class ItinerarySummary extends Component {
           key={blocks.length}
           className='summary-block mode-block'
         >
-          <LegIcon leg={leg} />
+          <LegIcon leg={legWithoutNetwork} />
         </div>
       )
     })


### PR DESCRIPTION
This PR fixes #310 with a minimal change that removes rental company info from the leg object passed to `LegIcon`.
