### PR TITLE
Fetch trips on user persist

### DIFF
--- a/lib/actions/user.js
+++ b/lib/actions/user.js
@@ -9,6 +9,7 @@ const API_MONITORED_TRIP_PATH = '/api/secure/monitoredtrip'
 const API_OTPUSER_PATH = '/api/secure/user'
 const API_OTPUSER_VERIFY_SMS_SUBPATH = '/verify_sms'
 
+const setAccessToken = createAction('SET_ACCESS_TOKEN')
 const setCurrentUser = createAction('SET_CURRENT_USER')
 const setCurrentUserMonitoredTrips = createAction('SET_CURRENT_USER_MONITORED_TRIPS')
 const setLastPhoneSmsRequest = createAction('SET_LAST_PHONE_SMS_REQUEST')
@@ -60,10 +61,25 @@ export function fetchAuth0Token (auth0) {
     try {
       const accessToken = await auth0.getAccessTokenSilently()
 
-      dispatch(setCurrentUser({ accessToken }))
+      dispatch(setAccessToken(accessToken))
     } catch (error) {
       // TODO: improve UI if there is an error.
       alert('Error obtaining an authorization token.')
+    }
+  }
+}
+
+/**
+ * Updates the redux state with newly saved user info.
+ * For existing users, also fetches monitored trips again.
+ */
+function setUser (user, isNewAccount) {
+  return async function (dispatch, getState) {
+    dispatch(setCurrentUser(user))
+
+    // Also (re-)load monitored trips for existing users.
+    if (!isNewAccount) {
+      dispatch(fetchUserMonitoredTrips())
     }
   }
 }
@@ -103,12 +119,8 @@ export function fetchOrInitializeUser (auth0User) {
 
     const isNewAccount = status === 'error' || (user && user.result === 'ERR')
     const userData = isNewAccount ? createNewUser(auth0User) : user
-    dispatch(setCurrentUser({ accessToken, user: userData }))
 
-    // Also load monitored trips for existing users.
-    if (!isNewAccount) {
-      dispatch(fetchUserMonitoredTrips())
-    }
+    dispatch(setUser(userData, isNewAccount))
   }
 }
 
@@ -145,7 +157,7 @@ export function createOrUpdateUser (userData, silentOnSuccess = false) {
 
       // Update application state with the user entry as saved
       // (as returned) by the middleware.
-      dispatch(setCurrentUser({ accessToken, user: data }))
+      dispatch(setUser(data))
     } else {
       alert(`An error was encountered:\n${JSON.stringify(message)}`)
     }

--- a/lib/actions/user.js
+++ b/lib/actions/user.js
@@ -70,15 +70,16 @@ export function fetchAuth0Token (auth0) {
 }
 
 /**
- * Updates the redux state with newly saved user info.
- * For existing users, also fetches monitored trips again.
+ * Updates the redux state with the provided user data,
+ * and also fetches monitored trips if requested when
+ * - initializing the user state with an existing persisted user, or
+ * - POST-ing a user for the first time.
  */
-function setUser (user, isNewAccount) {
-  return async function (dispatch, getState) {
+function setUser (user, fetchTrips) {
+  return function (dispatch, getState) {
     dispatch(setCurrentUser(user))
 
-    // Also (re-)load monitored trips for existing users.
-    if (!isNewAccount) {
+    if (fetchTrips) {
       dispatch(fetchUserMonitoredTrips())
     }
   }
@@ -120,7 +121,8 @@ export function fetchOrInitializeUser (auth0User) {
     const isNewAccount = status === 'error' || (user && user.result === 'ERR')
     const userData = isNewAccount ? createNewUser(auth0User) : user
 
-    dispatch(setUser(userData, isNewAccount))
+    // Set uset in redux state. (Fetch trips for existing users.)
+    dispatch(setUser(userData, !isNewAccount))
   }
 }
 
@@ -137,7 +139,8 @@ export function createOrUpdateUser (userData, silentOnSuccess = false) {
     let requestUrl, method
 
     // Determine URL and method to use.
-    if (isNewUser(loggedInUser)) {
+    const isPost = isNewUser(loggedInUser)
+    if (isPost) {
       requestUrl = `${apiBaseUrl}${API_OTPUSER_PATH}`
       method = 'POST'
     } else {
@@ -156,8 +159,8 @@ export function createOrUpdateUser (userData, silentOnSuccess = false) {
       }
 
       // Update application state with the user entry as saved
-      // (as returned) by the middleware.
-      dispatch(setUser(data))
+      // (as returned) by the middleware. (Fetch trips if POST-ing.)
+      dispatch(setUser(data, isPost))
     } else {
       alert(`An error was encountered:\n${JSON.stringify(message)}`)
     }

--- a/lib/components/user/saved-trip-list.js
+++ b/lib/components/user/saved-trip-list.js
@@ -8,7 +8,6 @@ import * as uiActions from '../../actions/ui'
 import * as userActions from '../../actions/user'
 import DesktopNav from '../app/desktop-nav'
 import { RETURN_TO_CURRENT_ROUTE } from '../../util/ui'
-import AwaitingScreen from './awaiting-screen'
 import LinkButton from './link-button'
 import TripSummaryPane from './trip-summary-pane'
 import withLoggedInUserSupport from './with-logged-in-user-support'
@@ -16,53 +15,72 @@ import withLoggedInUserSupport from './with-logged-in-user-support'
 /**
  * This component displays the list of saved trips for the logged-in user.
  */
-const SavedTripList = ({ trips }) => {
-  // TODO: Improve navigation.
-  const accountLink = <p><LinkButton to='/account'>Back to My Account</LinkButton></p>
-  let content
+class SavedTripList extends Component {
+  componentDidMount () {
+    const { loggedInUser, routeTo } = this.props
 
-  if (!trips) {
-    // Flash an indication while user trips are being loaded.
-    content = <AwaitingScreen />
-  } else if (trips.length === 0) {
-    content = (
-      <>
-        {accountLink}
-        <h1>You have no saved trips</h1>
-        <p>Perform a trip search from the map first.</p>
-      </>
-    )
-  } else {
-    // Stack the saved trip summaries and commands.
-    content = (
-      <>
-        {accountLink}
-        <h1>My saved trips</h1>
-        {trips.map((trip, index) => <ConnectedTripListItem key={index} trip={trip} />)}
-      </>
-    )
+    if (!loggedInUser.hasConsentedToTerms) {
+      // If a user signed up in Auth0 and did not complete the New Account wizard
+      // make the user finish set up their accounts first.
+      // monitoredTrips should not be null otherwise.
+      routeTo('/account')
+    }
+
+    // TODO: Update title bar during componentDidMount.
   }
 
-  return (
-    <div className='otp'>
-      {/* TODO: Do mobile view. */}
-      <DesktopNav />
-      <div className='container'>
-        {content}
+  render () {
+    const { trips } = this.props
+    // TODO: Improve navigation.
+    const accountLink = <p><LinkButton to='/account'>Back to My Account</LinkButton></p>
+    let content
+
+    if (!trips) {
+      // Show nothing. This situation occurs when an Auth0 user did not complete account setup.
+      // A redirect from componentDidMount should occur, and this render should not be perceptible.
+    } else if (trips.length === 0) {
+      content = (
+        <>
+          {accountLink}
+          <h1>You have no saved trips</h1>
+          <p>Perform a trip search from the map first.</p>
+        </>
+      )
+    } else {
+      // Stack the saved trip summaries and commands.
+      content = (
+        <>
+          {accountLink}
+          <h1>My saved trips</h1>
+          {trips.map((trip, index) => <ConnectedTripListItem key={index} trip={trip} />)}
+        </>
+      )
+    }
+
+    return (
+      <div className='otp'>
+        {/* TODO: Do mobile view. */}
+        <DesktopNav />
+        <div className='container'>
+          {content}
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
 }
 
 // connect to the redux store
 
 const mapStateToProps = (state, ownProps) => {
   return {
+    loggedInUser: state.user.loggedInUser,
     trips: state.user.loggedInUserMonitoredTrips
   }
 }
 
-const mapDispatchToProps = {}
+const mapDispatchToProps = {
+  routeTo: uiActions.routeTo
+}
 
 export default withLoggedInUserSupport(
   withAuthenticationRequired(

--- a/lib/components/user/saved-trip-screen.js
+++ b/lib/components/user/saved-trip-screen.js
@@ -8,7 +8,6 @@ import * as yup from 'yup'
 import * as uiActions from '../../actions/ui'
 import * as userActions from '../../actions/user'
 import DesktopNav from '../app/desktop-nav'
-import AwaitingScreen from './awaiting-screen'
 import SavedTripEditor from './saved-trip-editor'
 import TripBasicsPane from './trip-basics-pane'
 import TripNotificationsPane from './trip-notifications-pane'
@@ -104,12 +103,17 @@ class SavedTripScreen extends Component {
     summary: TripSummaryPane
   }
 
-  async componentDidMount () {
-    const { isCreating, monitoredTrips } = this.props
+  componentDidMount () {
+    const { isCreating, loggedInUser, monitoredTrips, routeTo } = this.props
 
-    // There is a middleware limit of 5 saved trips,
-    // so if that limit is already reached, alert, then show editing mode.
-    if (isCreating && hasMaxTripCount(monitoredTrips)) {
+    if (!loggedInUser.hasConsentedToTerms) {
+      // If a user signed up in Auth0 and did not complete the New Account wizard
+      // make the user finish set up their accounts first.
+      // monitoredTrips should not be null otherwise.
+      routeTo('/account')
+    } else if (isCreating && hasMaxTripCount(monitoredTrips)) {
+      // There is a middleware limit of 5 saved trips,
+      // so if that limit is already reached, alert, then show editing mode.
       alert('You already have reached the maximum of five saved trips.\n' +
           'Please remove unused trips from your saved trips, and try again.')
 
@@ -145,8 +149,8 @@ class SavedTripScreen extends Component {
 
     let screenContents
     if (!monitoredTrips) {
-      // Flash an indication while user trips are being loaded.
-      screenContents = <AwaitingScreen />
+      // Show nothing. This situation occurs when an Auth0 user did not complete account setup.
+      // A redirect from componentDidMount should occur, and this render should not be perceptible.
     } else {
       const monitoredTrip = this._getTripToEdit(this.props)
       const otherTripNames = monitoredTrips

--- a/lib/reducers/create-user-reducer.js
+++ b/lib/reducers/create-user-reducer.js
@@ -17,10 +17,14 @@ function createUserReducer () {
 
   return (state = initialState, action) => {
     switch (action.type) {
+      case 'SET_ACCESS_TOKEN': {
+        return update(state, {
+          accessToken: { $set: action.payload }
+        })
+      }
       case 'SET_CURRENT_USER': {
         return update(state, {
-          accessToken: { $set: action.payload.accessToken },
-          loggedInUser: { $set: action.payload.user }
+          loggedInUser: { $set: action.payload }
         })
       }
 


### PR DESCRIPTION
This PR fixes #312 with the following changes:
- Monitored trips are now fetched after POST-ing a new user (in addition to 
- If the user did not finish setting up their account, and they attempt to save a new trip or access the Saved Trips page, the user is redirected to the accounts page.

Internally:
- Separate actions for setting user state and access token
- The action for setting the user state has option to also fetch the user's monitored trips.
