### PR TITLE
fix(TripBasicsPane): Hide trip status on first save.

### DIFF
--- a/lib/components/user/monitored-trip/trip-basics-pane.js
+++ b/lib/components/user/monitored-trip/trip-basics-pane.js
@@ -103,7 +103,9 @@ class TripBasicsPane extends Component {
 
       return (
         <div>
-          <TripStatus monitoredTrip={monitoredTrip} />
+          {/* Do not show trip status when saving trip for the first time
+              (it doesn't exist in backend yet). */}
+          {!isCreating && <TripStatus monitoredTrip={monitoredTrip} />}
           <ControlLabel>Selected itinerary:</ControlLabel>
           <TripSummary monitoredTrip={monitoredTrip} />
 


### PR DESCRIPTION
This PR addresses https://github.com/opentripplanner/otp-react-redux/pull/290/files#r556614358.