### PR TITLE
Fix scrolling and overflow in route viewer.

### DIFF
--- a/lib/components/viewers/route-viewer.js
+++ b/lib/components/viewers/route-viewer.js
@@ -113,13 +113,13 @@ const StyledRouteRow = styled.div`
 `
 
 const RouteRowButton = styled(Button)`
-  padding: 8px;
+  align-items: center;
+  display: flex;
+  padding: 6px;
   width: 100%;
 `
 
-const RouteRowElement = styled.div`
-  display: inline-block;
-  vertical-align: middle;
+const RouteRowElement = styled.span`
 `
 
 const OperatorImg = styled.img`
@@ -127,28 +127,30 @@ const OperatorImg = styled.img`
   margin-right: 8px;
 `
 
-const ModeIconElement = styled(RouteRowElement)`
+const ModeIconElement = styled.span`
+  display: inline-block;
+  vertical-align: bottom;
   height: 22px;
 `
 
-const RouteNameElement = styled(RouteRowElement)`
-  margin-top: 2px;
-`
-
-const StyledLabel = styled(Label)`
+const RouteNameElement = styled(Label)`
   background-color: ${props => (
-    props.backgroundColor === '#ffffff'
+    props.backgroundColor === '#ffffff' || props.backgroundColor === 'white'
       ? 'rgba(0,0,0,0)'
       : props.backgroundColor
   )};
   color: ${props => props.color};
+  flex: 0 1 auto;
+  font-size: medium;
+  font-weight: 400;
   margin-left: ${props => (
     props.backgroundColor === '#ffffff' || props.backgroundColor === 'white'
       ? 0
       : '8px'
   )};
-  font-size: medium;
-  font-weight: 400;
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `
 
 const RouteDetails = styled.div`
@@ -217,10 +219,12 @@ class RouteRow extends PureComponent {
           <ModeIconElement>
             <ModeIcon height={22} mode={getModeFromRoute(route)} width={22} />
           </ModeIconElement>
-          <RouteNameElement>
-            <StyledLabel backgroundColor={backgroundColor} color={color}>
-              <b>{route.shortName}</b> {longName}
-            </StyledLabel>
+          <RouteNameElement
+            backgroundColor={backgroundColor}
+            color={color}
+            title={`${route.shortName} ${longName}`}
+          >
+            <b>{route.shortName}</b> {longName}
           </RouteNameElement>
         </RouteRowButton>
         <VelocityTransitionGroup enter={{animation: 'slideDown'}} leave={{animation: 'slideUp'}}>

--- a/lib/components/viewers/viewers.css
+++ b/lib/components/viewers/viewers.css
@@ -32,7 +32,10 @@
 }
 
 .otp .route-viewer-body, .otp .stop-viewer-body, .otp .trip-viewer-body {
+  overflow-x: hidden;
   overflow-y: auto;
+}
+.otp .stop-viewer-body, .otp .trip-viewer-body {
   padding: 12px;
 }
 


### PR DESCRIPTION
This PR fixes #320.

EDIT: Per request at https://github.com/opentripplanner/otp-react-redux/pull/321#pullrequestreview-583824022, long clipped route labels in the route viewer are rendered with an ellipsis (this changes the rendering code for the route viewer to take advantage of flex boxes).

![image](https://user-images.githubusercontent.com/56846598/107300783-2b34c400-6a48-11eb-8435-8bf2e9b4592e.png)

