### PR TITLE
Redirect to hash URL if search URL contains no hash

### DIFF
--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -108,8 +108,6 @@ class ResponsiveWebapp extends Component {
   }
 
   componentDidMount () {
-    // Add on back button press behavior.
-    window.addEventListener('popstate', handleBackButtonPress)
     const {
       getCurrentPosition,
       handleBackButtonPress,
@@ -118,9 +116,10 @@ class ResponsiveWebapp extends Component {
       matchContentToUrl,
       parseUrlQueryString,
       receivedPositionResponse,
-      setUrlSearch,
       title
     } = this.props
+    // Add on back button press behavior.
+    window.addEventListener('popstate', handleBackButtonPress)
     document.title = title
     if (window.location.search) {
       // If a URL is detected without hash routing (e.g., http://localhost:9966?sessionId=test),

--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -109,17 +109,34 @@ class ResponsiveWebapp extends Component {
 
   componentDidMount () {
     // Add on back button press behavior.
-    window.addEventListener('popstate', this.props.handleBackButtonPress)
-    const { location, title } = this.props
+    window.addEventListener('popstate', handleBackButtonPress)
+    const {
+      getCurrentPosition,
+      handleBackButtonPress,
+      initializeModules,
+      location,
+      matchContentToUrl,
+      parseUrlQueryString,
+      receivedPositionResponse,
+      setUrlSearch,
+      title
+    } = this.props
     document.title = title
+    if (window.location.search) {
+      // If a URL is detected without hash routing (e.g., http://localhost:9966?sessionId=test),
+      // window.location.search will have a value. In this case, we need to redirect to the URL root with the
+      // search reconstructed for use with the hash router. This redirect should cause little disruption.
+      window.location.href = `${URL_ROOT}/#/${window.location.search}`
+      return
+    }
     if (isMobile()) {
       // If on mobile browser, check position on load
-      this.props.getCurrentPosition()
+      getCurrentPosition()
 
       // Also, watch for changes in position on mobile
       navigator.geolocation.watchPosition(
         // On success
-        position => { this.props.receivedPositionResponse({ position }) },
+        position => { receivedPositionResponse({ position }) },
         // On error
         error => { console.log('error in watchPosition', error) },
         // Options
@@ -129,14 +146,14 @@ class ResponsiveWebapp extends Component {
     // Handle routing to a specific part of the app (e.g. stop viewer) on page
     // load. (This happens prior to routing request in case special routerId is
     // set from URL.)
-    this.props.matchContentToUrl(this.props.location)
+    matchContentToUrl(location)
     if (location && location.search) {
       // Set search params and plan trip if routing enabled and a query exists
       // in the URL.
-      this.props.parseUrlQueryString()
+      parseUrlQueryString()
     }
     // Initialize call taker/field trip modules (check for valid auth session).
-    this.props.initializeModules()
+    initializeModules()
   }
 
   componentWillUnmount () {


### PR DESCRIPTION
Fixes #325. To test:
1. Use trimet call config
2. Go to http://localhost:9966?sessionId=test
3. Auto-redirects to http://localhost:9966/#/?sessionId=test
3. Trips are now plannable (previously things errored out in the app).