### PR TITLE
fix setActiveLeg zoom

### DIFF
--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -6,7 +6,6 @@ import ItineraryBody from '../line-itin/connected-itinerary-body'
 import ItinerarySummary from './itinerary-summary'
 import SimpleRealtimeAnnotation from '../simple-realtime-annotation'
 import { getTotalFareAsString } from '../../../util/state'
-import { setActiveLeg } from "../../../actions/narrative";
 
 const { isBicycle, isTransit } = coreUtils.itinerary
 const { formatDuration, formatTime } = coreUtils.time

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -6,6 +6,7 @@ import ItineraryBody from '../line-itin/connected-itinerary-body'
 import ItinerarySummary from './itinerary-summary'
 import SimpleRealtimeAnnotation from '../simple-realtime-annotation'
 import { getTotalFareAsString } from '../../../util/state'
+import { setActiveLeg } from "../../../actions/narrative";
 
 const { isBicycle, isTransit } = coreUtils.itinerary
 const { formatDuration, formatTime } = coreUtils.time
@@ -121,6 +122,7 @@ export default class DefaultItinerary extends NarrativeItinerary {
       expanded,
       itinerary,
       LegIcon,
+      setActiveLeg,
       showRealtimeAnnotation,
       timeFormat
     } = this.props
@@ -184,7 +186,7 @@ export default class DefaultItinerary extends NarrativeItinerary {
         {(active && expanded) &&
           <>
             {showRealtimeAnnotation && <SimpleRealtimeAnnotation />}
-            <ItineraryBody timeOptions={timeOptions} itinerary={itinerary} LegIcon={LegIcon} />
+            <ItineraryBody timeOptions={timeOptions} itinerary={itinerary} LegIcon={LegIcon} setActiveLeg={setActiveLeg} />
           </>
         }
       </div>

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -15,11 +15,12 @@ import {
 import Icon from '../narrative/icon'
 import { ComponentContext } from '../../util/contexts'
 import {
-  getResponsesWithErrors,
   getActiveItineraries,
   getActiveSearch,
-  getRealtimeEffects
+  getRealtimeEffects,
+  getResponsesWithErrors
 } from '../../util/state'
+
 import SaveTripButton from './save-trip-button'
 
 // TODO: move to utils?
@@ -201,6 +202,7 @@ class NarrativeItineraries extends Component {
                 itinerary={itinerary}
                 key={index}
                 LegIcon={LegIcon}
+                setActiveLeg={setActiveLeg}
                 onClick={active ? this._toggleDetailedItinerary : undefined}
                 routingType='ITINERARY'
                 showRealtimeAnnotation={showRealtimeAnnotation}


### PR DESCRIPTION
This PR fixes the bug (#338) where setActiveLeg doesn't zoom to that particular part of the leg. 

Clicking on the text next in the red box should zoom the map to that particular leg using setActiveLeg.

The fix included importing and passing setActiveLeg as a prop to the ItineraryBody component in both:

- narative-itinerary.js
- default-itinierary.js

![109985503-d0069200-7cd2-11eb-94cd-6ef1669e5837](https://user-images.githubusercontent.com/4264701/110815014-e9cf4880-8281-11eb-8bd7-2ad1aac12c9e.png)

