### PR TITLE
Avoid showing duplicate batch itineraries

### DIFF
--- a/lib/components/user/monitored-trip/saved-trip-screen.js
+++ b/lib/components/user/monitored-trip/saved-trip-screen.js
@@ -68,6 +68,9 @@ class SavedTripScreen extends Component {
       isActive: true,
       itinerary,
       leadTimeInMinutes: 30,
+      // when creating a monitored trip, the query params will be changed on the
+      // backend so that the modes parameter will reflect the modes seen in the
+      // itinerary
       queryParams,
       tripName: '',
       // FIXME: Handle populating/checking userID from middleware too,

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -72,14 +72,35 @@ function getActiveSearchRealtimeResponse (otpState) {
   return search && search.response
 }
 
+// Ignore certain keys that could add significant calculation time to hashing.
+// The alerts are irrelevant, but the intermediateStops, interStopGeometry and
+// steps could have the legGeometry substitute as an equivalent hash value
+const blackListedKeys = [
+  'alerts',
+  'intermediateStops',
+  'interStopGeometry',
+  'steps'
+]
+// make blackListedKeys into an object due to superior lookup performance
+const blackListedKeyLookup = {}
+blackListedKeys.forEach(key => {
+  blackListedKeyLookup[key] = true
+})
+
 /**
  * A memoized function to hash the itinerary.
- * NOTE: It can take a while (>300ms) for the object-hash library to calculate
+ * NOTE: It can take a while (>30ms) for the object-hash library to calculate
  * an itinerary's hash for some lengthy itineraries. If better performance is
- * desired, a custom hash function should be written that only uses certain
- * parts of the itinerary instead of everything.
+ * desired, additional values to blackListedKeys should be added to avoid
+ * spending extra time hashing values that wouldn't result in different
+ * itineraries.
  */
-const hashItinerary = memoize(itinerary => hash(itinerary))
+const hashItinerary = memoize(
+  itinerary => hash(
+    itinerary,
+    { excludeKeys: key => blackListedKeyLookup[key] }
+  )
+)
 
 /**
  * Get the active itineraries for the active search, which is dependent on

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -7,7 +7,7 @@ import { createSelector } from 'reselect'
 
 import { MainPanelContent } from '../actions/ui'
 
-const { calculateFares, isTransit } = coreUtils.itinerary
+const { calculateFares } = coreUtils.itinerary
 
 /**
  * Get the active search object
@@ -287,14 +287,6 @@ export function getTotalFareAsString (itinerary) {
   const {centsToString} = calculateFares(itinerary)
   // Return total fare as formatted string.
   return centsToString(getTotalFare(itinerary))
-}
-
-function itineraryHasTransit (itinerary) {
-  let itinHasTransit = false
-  itinerary.legs.forEach(leg => {
-    if (isTransit(leg.mode)) itinHasTransit = true
-  })
-  return itinHasTransit
 }
 
 /**

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -7,7 +7,7 @@ import { createSelector } from 'reselect'
 
 import { MainPanelContent } from '../actions/ui'
 
-const { calculateFares, hasBike, isCar, isTransit, isWalk } = coreUtils.itinerary
+const { calculateFares, isTransit } = coreUtils.itinerary
 
 /**
  * Get the active search object

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -148,39 +148,13 @@ export const getActiveItineraries = createSelector(
         }
       })
     }
-    const {filter, sort} = otpStateFilter
+    const {sort} = otpStateFilter
     const {direction, type} = sort
-    const filteredItineraries = itineraries
-      .filter(itinerary => {
-        switch (filter) {
-          case 'ALL':
-            return true
-          case 'ACTIVE':
-            // ACTIVE filter checks that the only modes contained in the itinerary
-            // are 'active' (i.e., walk or bike). FIXME: add micromobility?
-            let allActiveModes = true
-            itinerary.legs.forEach(leg => {
-              if (!isWalk(leg.mode) && !hasBike(leg.mode)) allActiveModes = false
-            })
-            return allActiveModes
-          case 'TRANSIT':
-            return itineraryHasTransit(itinerary)
-          case 'CAR':
-            let hasCar = false
-            itinerary.legs.forEach(leg => {
-              if (isCar(leg.mode)) hasCar = true
-            })
-            return hasCar
-          default:
-            // return true for unrecognized or falsy filter
-            return true
-        }
-      })
     // If no sort type is provided (e.g., because batch routing is not enabled),
     // do not sort itineraries (default sort from API response is used).
     return !type
-      ? filteredItineraries
-      : filteredItineraries.sort((a, b) => sortItineraries(type, direction, a, b, config))
+      ? itineraries
+      : itineraries.sort((a, b) => sortItineraries(type, direction, a, b, config))
   }
 )
 

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -1,6 +1,9 @@
 import coreUtils from '@opentripplanner/core-utils'
 import isEqual from 'lodash.isequal'
+import memoize from 'lodash.memoize'
 import moment from 'moment'
+import hash from 'object-hash'
+import { createSelector } from 'reselect'
 
 import { MainPanelContent } from '../actions/ui'
 
@@ -54,61 +57,111 @@ export function getActiveError (otpState) {
 }
 
 /**
+ * Helper to get the active search's non-realtime response
+ */
+function getActiveSearchNonRealtimeResponse (otpState) {
+  const search = getActiveSearch(otpState)
+  return search && search.nonRealtimeResponse
+}
+
+/**
+ * Helper to get the active search's realtime response
+ */
+function getActiveSearchRealtimeResponse (otpState) {
+  const search = getActiveSearch(otpState)
+  return search && search.response
+}
+
+/**
+ * A memoized function to hash the itinerary.
+ * NOTE: It can take a while (>300ms) for the object-hash library to calculate
+ * an itinerary's hash for some lengthy itineraries. If better performance is
+ * desired, a custom hash function should be written that only uses certain
+ * parts of the itinerary instead of everything.
+ */
+const hashItinerary = memoize(itinerary => hash(itinerary))
+
+/**
  * Get the active itineraries for the active search, which is dependent on
  * whether realtime or non-realtime results should be displayed
  * @param {Object} otpState the OTP state object
  * @return {Array}      array of itinerary objects from the OTP plan response,
  *                      or null if there is no active search
  */
-export function getActiveItineraries (otpState) {
-  const search = getActiveSearch(otpState)
-  const { config, useRealtime } = otpState
-  // set response to use depending on useRealtime
-  const response = !search
-    ? null
-    : useRealtime
-      ? search.response
-      : search.nonRealtimeResponse
-  const itineraries = []
-  if (response) {
-    response.forEach(res => {
-      if (res && res.plan) itineraries.push(...res.plan.itineraries)
-    })
+export const getActiveItineraries = createSelector(
+  otpState => otpState.config,
+  getActiveSearchNonRealtimeResponse,
+  otpState => otpState.filter,
+  getActiveSearchRealtimeResponse,
+  otpState => otpState.useRealtime,
+  (
+    config,
+    nonRealtimeResponse,
+    otpStateFilter,
+    realtimeResponse,
+    useRealtime
+  ) => {
+    // set response to use depending on useRealtime
+    const response = (!nonRealtimeResponse && !realtimeResponse)
+      ? null
+      : useRealtime
+        ? realtimeResponse
+        : nonRealtimeResponse
+    const itineraries = []
+    // keep track of itinerary hashes in order to not include duplicate
+    // itineraries. Duplicate itineraries can occur in batch routing where a walk
+    // to transit trip can sometimes still be the most optimal trip even when
+    // additional modes such as bike rental were also requested
+    const seenItineraryHashes = {}
+    if (response) {
+      response.forEach(res => {
+        if (res && res.plan) {
+          res.plan.itineraries.forEach(itinerary => {
+            // hashing takes a while on itineraries
+            const itineraryHash = hashItinerary(itinerary)
+            if (!seenItineraryHashes[itineraryHash]) {
+              itineraries.push(itinerary)
+              seenItineraryHashes[itineraryHash] = true
+            }
+          })
+        }
+      })
+    }
+    const {filter, sort} = otpStateFilter
+    const {direction, type} = sort
+    const filteredItineraries = itineraries
+      .filter(itinerary => {
+        switch (filter) {
+          case 'ALL':
+            return true
+          case 'ACTIVE':
+            // ACTIVE filter checks that the only modes contained in the itinerary
+            // are 'active' (i.e., walk or bike). FIXME: add micromobility?
+            let allActiveModes = true
+            itinerary.legs.forEach(leg => {
+              if (!isWalk(leg.mode) && !hasBike(leg.mode)) allActiveModes = false
+            })
+            return allActiveModes
+          case 'TRANSIT':
+            return itineraryHasTransit(itinerary)
+          case 'CAR':
+            let hasCar = false
+            itinerary.legs.forEach(leg => {
+              if (isCar(leg.mode)) hasCar = true
+            })
+            return hasCar
+          default:
+            // return true for unrecognized or falsy filter
+            return true
+        }
+      })
+    // If no sort type is provided (e.g., because batch routing is not enabled),
+    // do not sort itineraries (default sort from API response is used).
+    return !type
+      ? filteredItineraries
+      : filteredItineraries.sort((a, b) => sortItineraries(type, direction, a, b, config))
   }
-  const {filter, sort} = otpState.filter
-  const {direction, type} = sort
-  const filteredItineraries = itineraries
-    .filter(itinerary => {
-      switch (filter) {
-        case 'ALL':
-          return true
-        case 'ACTIVE':
-          // ACTIVE filter checks that the only modes contained in the itinerary
-          // are 'active' (i.e., walk or bike). FIXME: add micromobility?
-          let allActiveModes = true
-          itinerary.legs.forEach(leg => {
-            if (!isWalk(leg.mode) && !hasBike(leg.mode)) allActiveModes = false
-          })
-          return allActiveModes
-        case 'TRANSIT':
-          return itineraryHasTransit(itinerary)
-        case 'CAR':
-          let hasCar = false
-          itinerary.legs.forEach(leg => {
-            if (isCar(leg.mode)) hasCar = true
-          })
-          return hasCar
-        default:
-          console.warn(`Filter (${filter}) not supported`)
-          return true
-      }
-    })
-  // If no sort type is provided (e.g., because batch routing is not enabled),
-  // do not sort itineraries (default sort from API response is used).
-  return !type
-    ? filteredItineraries
-    : filteredItineraries.sort((a, b) => sortItineraries(type, direction, a, b, config))
-}
+)
 
 /**
  * Array sort function for itineraries (in batch routing context) that attempts

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "redux-actions": "^1.2.1",
     "redux-logger": "^2.7.4",
     "redux-thunk": "^2.3.0",
+    "reselect": "^4.0.0",
     "seamless-immutable": "^7.1.3",
     "styled-components": "^5.0.0",
     "transitive-js": "^0.13.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14579,6 +14579,11 @@ require-relative@^0.8.7:
   resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
   integrity sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=
 
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
 resize-observer-polyfill@^1.5.0, resize-observer-polyfill@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"


### PR DESCRIPTION
This PR fixes #349 by not adding duplicate itineraries to the list of active itineraries. Using the already-available library of `object-hash`, we can reliably calculate a hash that can identify duplicate itineraries. However, there is a big performance cost for hashing the complete itinerary - especially on lengthy itineraries. Therefore, I made some extra performance improvements to make sure the app didn't slow down a ton. I added the `reselect` dependency and added reselect-style memorization to the  `getActiveItineraries` function. However, each time a new response was received, the function would run again, so I also memorized the calculation of the hash of each itinerary. It could be possible to further improve the itinerary hashing performance by adding additional black-listed keys that won't contribute to there being different itineraries.