### PR TITLE
Add sign mode support for stop viewer

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -189,13 +189,13 @@ export const clearPanel = createAction('CLEAR_MAIN_PANEL')
 
 // Stop/Route/Trip Viewer actions
 
-export function setViewedStop (payload) {
+export function setViewedStop (payload, redirect = true) {
   return function (dispatch, getState) {
     dispatch(viewStop(payload))
     const path = payload && payload.stopId
       ? `/stop/${payload.stopId}`
       : '/stop'
-    dispatch(routeTo(path))
+    if (redirect) dispatch(routeTo(path))
   }
 }
 

--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -23,6 +23,7 @@ import { RedirectWithQuery } from '../form/connected-links'
 import Map from '../map/map'
 import MobileMain from '../mobile/main'
 import PrintLayout from './print-layout'
+import StopViewer from '../viewers/stop-viewer'
 import { getAuth0Config } from '../../util/auth'
 import {
   ACCOUNT_PATH,
@@ -303,6 +304,10 @@ class RouterWrapperWithAuth0 extends Component {
                 '/stop/:id'
               ]}
               render={() => <WebappWithRouter {...this.props} />}
+            />
+            <Route
+              render={() => <StopViewer signMode />}
+              path={`/sign/stop/:id`}
             />
             <Route
               component={FavoritePlaceScreen}

--- a/lib/components/viewers/stop-viewer.js
+++ b/lib/components/viewers/stop-viewer.js
@@ -3,6 +3,7 @@ import 'moment-timezone'
 import coreUtils from '@opentripplanner/core-utils'
 import FromToLocationPicker from '@opentripplanner/from-to-location-picker'
 import PropTypes from 'prop-types'
+import qs from 'qs'
 import React, { Component } from 'react'
 import { Alert, Button, Glyphicon } from 'react-bootstrap'
 import { connect } from 'react-redux'
@@ -69,8 +70,17 @@ class StopViewer extends Component {
   _onClickPlanFrom = () => this._setLocationFromStop('from')
 
   componentDidMount () {
+    const { findStop, setViewedStop, signMode, viewedStop } = this.props
+    let stopId = viewedStop?.stopId
+    if (signMode || !stopId) {
+      // If in sign mode, or the stop id is not otherwise defined, handle parsing
+      // from the URL path.
+      const pathParts = window.location.href.split('?')[0].split('/')
+      stopId = pathParts[pathParts.length - 1]
+      setViewedStop({ stopId }, false)
+    }
     // Load the viewed stop in the store when the Stop Viewer first mounts
-    this.props.findStop({ stopId: this.props.viewedStop.stopId })
+    findStop({ stopId })
   }
 
   _toggleFavorite = () => {
@@ -113,6 +123,19 @@ class StopViewer extends Component {
     const date = evt.target.value
     this._findStopTimesForDate(date)
     this.setState({ date })
+  }
+
+  _renderAlerts = () => {
+    const alertsFromQueryParams = qs.parse(window.location.href.split(/\?(.+)/)[1]).alertText
+    if (alertsFromQueryParams) {
+      return (
+        <div>
+          <h3>Custom alert from query param!</h3>
+          <p>{alertsFromQueryParams}</p>
+        </div>
+      )
+    }
+    // TODO: Also get alerts from OTP API (not implented in API yet).
   }
 
   _renderHeader = () => {
@@ -272,7 +295,7 @@ class StopViewer extends Component {
       <div className='stop-viewer'>
         {/* Header Block */}
         {this._renderHeader()}
-
+        {this._renderAlerts()}
         {stopData && (
           <div className='stop-viewer-body'>
             {this._renderControls()}
@@ -292,13 +315,14 @@ class StopViewer extends Component {
 const mapStateToProps = (state, ownProps) => {
   const showUserSettings = getShowUserSettings(state.otp)
   const stopViewerConfig = getStopViewerConfig(state.otp)
+  const {viewedStop} = state.otp.ui
   return {
     autoRefreshStopTimes: state.otp.user.autoRefreshStopTimes,
     favoriteStops: state.otp.user.favoriteStops,
     homeTimezone: state.otp.config.homeTimezone,
-    viewedStop: state.otp.ui.viewedStop,
+    viewedStop,
     showUserSettings,
-    stopData: state.otp.transitIndex.stops[state.otp.ui.viewedStop.stopId],
+    stopData: state.otp.transitIndex.stops[viewedStop?.stopId],
     stopViewerArriving: state.otp.config.language.stopViewerArriving,
     stopViewerConfig,
     timeFormat: getTimeFormat(state.otp.config),
@@ -313,6 +337,7 @@ const mapDispatchToProps = {
   rememberStop: mapActions.rememberStop,
   setLocation: mapActions.setLocation,
   setMainPanelContent: uiActions.setMainPanelContent,
+  setViewedStop: uiActions.setViewedStop,
   toggleAutoRefresh: uiActions.toggleAutoRefresh
 }
 


### PR DESCRIPTION
This is a WIP branch for supporting a sign mode for showing stop arrivals within otp-rr. E.g.:

![image](https://user-images.githubusercontent.com/2370911/115047794-da59a580-9ea6-11eb-926e-7254ee6f63a8.png)

