### PR TITLE
Update call list items

### DIFF
--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -61,14 +61,15 @@ export function setQueryParam (payload, searchId) {
   }
 }
 
-export function parseUrlQueryString (params = getUrlParams()) {
+export function parseUrlQueryString (params = getUrlParams(), source) {
   return function (dispatch, getState) {
     // Filter out the OTP (i.e. non-UI) params and set the initial query
     const planParams = {}
     Object.keys(params).forEach(key => {
       if (!key.startsWith('ui_')) planParams[key] = params[key]
     })
-    const searchId = params.ui_activeSearch || coreUtils.storage.randId()
+    let searchId = params.ui_activeSearch || coreUtils.storage.randId()
+    if (source) searchId += source
     // Convert strings to numbers/objects and dispatch
     planParamsToQueryAsync(planParams, getState().otp.config)
       .then(query => dispatch(setQueryParam(query, searchId)))

--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -61,6 +61,16 @@ export function setQueryParam (payload, searchId) {
   }
 }
 
+/**
+ * An action that parses the active URL's query params (or whatever is passed in)
+ * and updates the state with the OTP plan query params. A new search will be
+ * performed according to the behavior of setQueryParam (i.e., if the passed
+ * searchId is not null).
+ * @param  {Object} params an object containing URL query params
+ * @param  {string} source optionally contains the source of the query params
+ *                         (e.g., _CALL indicates that the source is from a past
+ *                         query made during a call taker session)
+ */
 export function parseUrlQueryString (params = getUrlParams(), source) {
   return function (dispatch, getState) {
     // Filter out the OTP (i.e. non-UI) params and set the initial query

--- a/lib/components/admin/call-record.js
+++ b/lib/components/admin/call-record.js
@@ -14,6 +14,20 @@ export default class CallRecord extends Component {
     expanded: false
   }
 
+  _getCallDuration = () => {
+    const {call} = this.props
+    const startTimeMoment = moment(call.startTime)
+    const endTimeMoment = moment(call.endTime)
+    const [hours, minutes, seconds] = moment.utc(
+      moment.duration(endTimeMoment.diff(startTimeMoment)).asMilliseconds()
+    ).format('HH:mm:ss').split(':').map(val => +val)
+    const parts = []
+    if (seconds) parts.push(`${seconds} sec`)
+    if (minutes) parts.push(`${minutes} min`)
+    if (hours) parts.push(`${hours} hr`)
+    return parts.join(', ')
+  }
+
   _toggleExpanded = () => {
     const {call, fetchQueries} = this.props
     const {expanded} = this.state
@@ -58,15 +72,17 @@ export default class CallRecord extends Component {
         </div>
       )
     }
+    const startTimeMoment = moment(call.startTime)
     return (
-      <div style={{margin: '5px 0'}}>
+      <div style={{borderBottom: '1px solid grey', margin: '5px 0'}}>
         <button
           style={{width: '100%'}}
           className='clear-button-formatting'
           onClick={this._toggleExpanded}
         >
           <Icon type='phone' className='fa-flip-horizontal' />
-          Call {index} ({moment(call.endTime).fromNow()})
+          {startTimeMoment.format('h:mm a, MMM D')}<br />
+          (Length: {this._getCallDuration()})
         </button>
         {expanded
           ? <ul className='list-unstyled'>

--- a/lib/components/admin/call-record.js
+++ b/lib/components/admin/call-record.js
@@ -23,9 +23,9 @@ export default class CallRecord extends Component {
       moment.duration(endTimeMoment.diff(startTimeMoment)).asMilliseconds()
     ).format('HH:mm:ss').split(':').map(val => +val)
     const parts = []
-    if (seconds) parts.push(`${seconds} sec`)
-    if (minutes) parts.push(`${minutes} min`)
     if (hours) parts.push(`${hours} hr`)
+    if (minutes) parts.push(`${minutes} min`)
+    if (seconds) parts.push(`${seconds} sec`)
     return parts.join(', ')
   }
 

--- a/lib/components/admin/call-record.js
+++ b/lib/components/admin/call-record.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import CallTimeCounter from './call-time-counter'
 import Icon from '../narrative/icon'
 import QueryRecord from './query-record'
+import {CallRecordButton, CallRecordIcon} from './styled'
 import {searchToQuery} from '../../util/call-taker'
 
 /**
@@ -38,7 +39,7 @@ export default class CallRecord extends Component {
   render () {
     // FIXME: consolidate red color with call taker controls
     const RED = '#C35134'
-    const {call, index, inProgress, searches} = this.props
+    const {call, inProgress, searches} = this.props
     const {expanded} = this.state
     if (!call) return null
     if (inProgress) {
@@ -61,29 +62,33 @@ export default class CallRecord extends Component {
             In progress... click <Icon type='stop' /> to save{' '}
             ({call.searches.length} searches)
           </small>
-          <div>
+          <ul className='list-unstyled'>
             {activeQueries.length > 0
               ? activeQueries.map((query, i) => (
                 <QueryRecord key={i} query={query} index={i} />
               ))
               : 'No queries recorded.'
             }
-          </div>
+          </ul>
         </div>
       )
     }
+    // Default (no active call) view
     const startTimeMoment = moment(call.startTime)
     return (
       <div style={{borderBottom: '1px solid grey', margin: '5px 0'}}>
-        <button
-          style={{width: '100%'}}
+        <CallRecordButton
           className='clear-button-formatting'
           onClick={this._toggleExpanded}
         >
-          <Icon type='phone' className='fa-flip-horizontal' />
-          {startTimeMoment.format('h:mm a, MMM D')}<br />
-          (Length: {this._getCallDuration()})
-        </button>
+          <CallRecordIcon
+            type='phone'
+            className='fa-flip-horizontal' />
+          <div>
+            {startTimeMoment.format('h:mm a, MMM D')}<br />
+            (Length: {this._getCallDuration()})
+          </div>
+        </CallRecordButton>
         {expanded
           ? <ul className='list-unstyled'>
             {call.queries && call.queries.length > 0

--- a/lib/components/admin/call-record.js
+++ b/lib/components/admin/call-record.js
@@ -5,7 +5,7 @@ import React, { Component } from 'react'
 import CallTimeCounter from './call-time-counter'
 import Icon from '../narrative/icon'
 import QueryRecord from './query-record'
-import {CallRecordButton, CallRecordIcon} from './styled'
+import {CallRecordButton, CallRecordIcon, QueryList} from './styled'
 import {searchToQuery} from '../../util/call-taker'
 
 /**
@@ -57,29 +57,26 @@ export default class CallRecord extends Component {
             In progress... click <Icon type='stop' /> to save{' '}
             ({call.searches.length} searches)
           </small>
-          <ul className='list-unstyled'>
+          <QueryList>
             {activeQueries.length > 0
               ? activeQueries.map((query, i) => (
                 <QueryRecord key={i} query={query} index={i} />
               ))
               : 'No queries recorded.'
             }
-          </ul>
+          </QueryList>
         </div>
       )
     }
     // Default (no active call) view
     const startTimeMoment = moment(call.startTime)
     return (
-      <div style={{borderBottom: '1px solid grey', margin: '5px 0'}}>
+      <div style={{borderBottom: '1px solid grey', margin: '5px 0', paddingBottom: '2px'}}>
         <CallRecordButton
           className='clear-button-formatting'
           onClick={this._toggleExpanded}
         >
-          <CallRecordIcon
-            className='fa-flip-horizontal'
-            style={{width: '5%'}}
-            type='phone' />
+          <CallRecordIcon className='fa-flip-horizontal' type='phone' />
           <span style={{flex: '0 0 120px'}}>
             {startTimeMoment.format('h:mm a, MMM D')}
           </span>
@@ -92,14 +89,14 @@ export default class CallRecord extends Component {
           </small>
         </CallRecordButton>
         {expanded
-          ? <ul className='list-unstyled' style={{marginLeft: '22px'}}>
+          ? <QueryList>
             {call.queries && call.queries.length > 0
               ? call.queries.map((query, i) => (
                 <QueryRecord key={i} query={query} index={i} />
               ))
               : 'No queries recorded.'
             }
-          </ul>
+          </QueryList>
           : null
         }
       </div>

--- a/lib/components/admin/call-record.js
+++ b/lib/components/admin/call-record.js
@@ -1,3 +1,4 @@
+import humanizeDuration from 'humanize-duration'
 import moment from 'moment'
 import React, { Component } from 'react'
 
@@ -17,16 +18,10 @@ export default class CallRecord extends Component {
 
   _getCallDuration = () => {
     const {call} = this.props
-    const startTimeMoment = moment(call.startTime)
-    const endTimeMoment = moment(call.endTime)
-    const [hours, minutes, seconds] = moment.utc(
-      moment.duration(endTimeMoment.diff(startTimeMoment)).asMilliseconds()
-    ).format('HH:mm:ss').split(':').map(val => +val)
-    const parts = []
-    if (hours) parts.push(`${hours} hr`)
-    if (minutes) parts.push(`${minutes} min`)
-    if (seconds) parts.push(`${seconds} sec`)
-    return parts.join(', ')
+    const start = moment(call.startTime)
+    const end = moment(call.endTime)
+    const millis = moment.duration(end.diff(start)).asMilliseconds()
+    return humanizeDuration(millis)
   }
 
   _toggleExpanded = () => {
@@ -82,15 +77,22 @@ export default class CallRecord extends Component {
           onClick={this._toggleExpanded}
         >
           <CallRecordIcon
-            type='phone'
-            className='fa-flip-horizontal' />
-          <div>
-            {startTimeMoment.format('h:mm a, MMM D')}<br />
-            (Length: {this._getCallDuration()})
-          </div>
+            className='fa-flip-horizontal'
+            style={{width: '5%'}}
+            type='phone' />
+          <span style={{flex: '0 0 120px'}}>
+            {startTimeMoment.format('h:mm a, MMM D')}
+          </span>
+          <small
+            className='text-muted'
+            style={{marginLeft: '5px', paddingTop: '2px', width: '60%'}}
+          >
+            <Icon type='clock-o' />{' '}
+            {this._getCallDuration()}
+          </small>
         </CallRecordButton>
         {expanded
-          ? <ul className='list-unstyled'>
+          ? <ul className='list-unstyled' style={{marginLeft: '22px'}}>
             {call.queries && call.queries.length > 0
               ? call.queries.map((query, i) => (
                 <QueryRecord key={i} query={query} index={i} />

--- a/lib/components/admin/call-taker-windows.js
+++ b/lib/components/admin/call-taker-windows.js
@@ -20,7 +20,7 @@ class CallTakerWindows extends Component {
       <DraggableWindow
         header={<WindowHeader><Icon type='history' /> Call history</WindowHeader>}
         onClickClose={toggleCallHistory}
-        style={{right: '15px', top: '50px'}}
+        style={{right: '15px', top: '50px', width: '450px'}}
       >
         {activeCall
           ? <CallRecord

--- a/lib/components/admin/query-record.js
+++ b/lib/components/admin/query-record.js
@@ -1,3 +1,4 @@
+import { planParamsToQuery } from '@opentripplanner/core-utils/lib/query'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 
@@ -8,9 +9,14 @@ import Icon from '../narrative/icon'
  * Displays information for a query stored for the Call Taker module.
  */
 class QueryRecordLayout extends Component {
+  _getParams = () => {
+    const {query} = this.props
+    return planParamsToQuery(JSON.parse(query.queryParams))
+  }
+
   _viewQuery = () => {
-    const {parseUrlQueryString, query} = this.props
-    const params = JSON.parse(query.queryParams)
+    const {parseUrlQueryString} = this.props
+    const params = this._getParams()
     if ('arriveBy' in params) {
       params.departArrive = params.arriveBy ? 'ARRIVE' : 'DEPART'
     }
@@ -18,20 +24,24 @@ class QueryRecordLayout extends Component {
   }
 
   render () {
-    const {index} = this.props
+    const params = this._getParams()
+    // console.log(this.props, params)
     return (
       <li>
         <button onClick={this._viewQuery} className='clear-button-formatting'>
           <Icon type='search' />
         </button>{' '}
-        Query {index + 1}
+        {params.time}<br />
+        {params.from.name} to {params.to.name}
       </li>
     )
   }
 }
 
 const mapStateToProps = (state, ownProps) => {
-  return {}
+  return {
+    config: state.otp.config
+  }
 }
 
 const {parseUrlQueryString} = formActions

--- a/lib/components/admin/query-record.js
+++ b/lib/components/admin/query-record.js
@@ -43,7 +43,6 @@ class QueryRecordLayout extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    config: state.otp.config,
     timeFormat: getTimeFormat(state.otp.config)
   }
 }

--- a/lib/components/admin/query-record.js
+++ b/lib/components/admin/query-record.js
@@ -1,4 +1,6 @@
 import { planParamsToQuery } from '@opentripplanner/core-utils/lib/query'
+import { getTimeFormat, OTP_API_TIME_FORMAT } from '@opentripplanner/core-utils/lib/time'
+import moment from 'moment'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 
@@ -24,13 +26,16 @@ class QueryRecordLayout extends Component {
   }
 
   render () {
+    const {query, timeFormat} = this.props
     const params = this._getParams()
-    console.log(this.props, params)
+    const time = query.timeStamp
+      ? moment(query.timeStamp).format(timeFormat)
+      : moment(params.time, OTP_API_TIME_FORMAT).format(timeFormat)
     return (
       <li>
         <CallRecordButton onClick={this._viewQuery} className='clear-button-formatting'>
           <CallRecordIcon type='search' />
-          {params.time}<br />
+          {time}<br />
           {params.from.name} to {params.to.name}
         </CallRecordButton>
       </li>
@@ -40,7 +45,8 @@ class QueryRecordLayout extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    config: state.otp.config
+    config: state.otp.config,
+    timeFormat: getTimeFormat(state.otp.config)
   }
 }
 

--- a/lib/components/admin/query-record.js
+++ b/lib/components/admin/query-record.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 
 import * as formActions from '../../actions/form'
-import Icon from '../narrative/icon'
+import {CallRecordButton, CallRecordIcon} from './styled'
 
 /**
  * Displays information for a query stored for the Call Taker module.
@@ -20,19 +20,19 @@ class QueryRecordLayout extends Component {
     if ('arriveBy' in params) {
       params.departArrive = params.arriveBy ? 'ARRIVE' : 'DEPART'
     }
-    parseUrlQueryString(params)
+    parseUrlQueryString(params, '_CALL')
   }
 
   render () {
     const params = this._getParams()
-    // console.log(this.props, params)
+    console.log(this.props, params)
     return (
       <li>
-        <button onClick={this._viewQuery} className='clear-button-formatting'>
-          <Icon type='search' />
-        </button>{' '}
-        {params.time}<br />
-        {params.from.name} to {params.to.name}
+        <CallRecordButton onClick={this._viewQuery} className='clear-button-formatting'>
+          <CallRecordIcon type='search' />
+          {params.time}<br />
+          {params.from.name} to {params.to.name}
+        </CallRecordButton>
       </li>
     )
   }

--- a/lib/components/admin/query-record.js
+++ b/lib/components/admin/query-record.js
@@ -19,9 +19,7 @@ class QueryRecordLayout extends Component {
   _viewQuery = () => {
     const {parseUrlQueryString} = this.props
     const params = this._getParams()
-    if ('arriveBy' in params) {
-      params.departArrive = params.arriveBy ? 'ARRIVE' : 'DEPART'
-    }
+    params.departArrive = params.arriveBy ? 'ARRIVE' : 'DEPART'
     parseUrlQueryString(params, '_CALL')
   }
 

--- a/lib/components/admin/styled.js
+++ b/lib/components/admin/styled.js
@@ -82,6 +82,10 @@ export const Half = styled.div`
   width: 50%
 `
 
+export const CallRecordRow = styled.div`
+
+`
+
 export const CallRecordButton = styled.button`
   display: flex;
   flexDirection: row;
@@ -126,6 +130,12 @@ export const textCss = css`
 
 export const Para = styled.p`
   ${textCss}
+`
+
+export const QueryList = styled.ul`
+  list-style: none;
+  margin-left: 22px;
+  padding-left: 0;
 `
 
 export const Text = styled.span`

--- a/lib/components/admin/styled.js
+++ b/lib/components/admin/styled.js
@@ -2,6 +2,7 @@ import { Button as BsButton } from 'react-bootstrap'
 import styled, {css} from 'styled-components'
 
 import DefaultCounter from './call-time-counter'
+import Icon from '../narrative/icon'
 
 // Call Taker Controls Components
 
@@ -79,6 +80,17 @@ export const Container = styled.div`
 
 export const Half = styled.div`
   width: 50%
+`
+
+export const CallRecordButton = styled.button`
+  display: flex;
+  flexDirection: row;
+  width: 100%;
+`
+
+export const CallRecordIcon = styled(Icon)`
+  margin-right: 3px;
+  padding-top: 4px;
 `
 
 // Make sure button extends to end of window.

--- a/lib/reducers/call-taker.js
+++ b/lib/reducers/call-taker.js
@@ -112,9 +112,10 @@ function createCallTakerReducer () {
             activeCall: { searches: { $push: [searchId] } }
           })
         } else if (state.callHistory.visible && searchId.indexOf('_CALL') === -1) {
-          console.log(searchId)
           // If call not in progress, but history is visible,
-          // construct new call and add search.
+          // construct new call and add search. Excepting the case where the
+          // searchId contains _CALL, which indicates that a user is viewing a
+          // past call record (and not intending to start a new call session).
           const newCall = constructNewCall()
           newCall.searches.push(searchId)
           // Initialize new call and show call history window.

--- a/lib/reducers/call-taker.js
+++ b/lib/reducers/call-taker.js
@@ -103,18 +103,20 @@ function createCallTakerReducer () {
         })
       }
       case 'ROUTING_RESPONSE': {
+        const {searchId} = action.payload
         if (state.activeCall) {
           // If call is in progress, record search ID when a routing response is
           // fulfilled.
           // TODO: How should we handle routing errors.
           return update(state, {
-            activeCall: { searches: { $push: [action.payload.searchId] } }
+            activeCall: { searches: { $push: [searchId] } }
           })
-        } else if (state.callHistory.visible) {
+        } else if (state.callHistory.visible && searchId.indexOf('_CALL') === -1) {
+          console.log(searchId)
           // If call not in progress, but history is visible,
           // construct new call and add search.
           const newCall = constructNewCall()
-          newCall.searches.push(action.payload.searchId)
+          newCall.searches.push(searchId)
           // Initialize new call and show call history window.
           return update(state, { activeCall: { $set: newCall } })
         }

--- a/lib/util/call-taker.js
+++ b/lib/util/call-taker.js
@@ -173,7 +173,6 @@ export function searchToQuery (search, call, otpConfig) {
     queryParams: JSON.stringify(queryParams),
     fromPlace: from.name || placeToLatLonStr(from),
     toPlace: to.name || placeToLatLonStr(to),
-    timeStamp: search.query.timestamp,
     call
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "formik-error-focus": "^1.1.0",
     "haversine": "^1.1.0",
     "history": "^4.7.2",
+    "humanize-duration": "^3.25.2",
     "immutability-helper": "^2.1.1",
     "immutable": "^3.8.1",
     "isomorphic-fetch": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,7 +60,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.11.5", "@babel/generator@^7.11.6", "@babel/generator@^7.12.11", "@babel/generator@^7.4.0", "@babel/generator@^7.9.4":
+"@babel/generator@^7.11.6", "@babel/generator@^7.12.11", "@babel/generator@^7.4.0", "@babel/generator@^7.9.4":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.11.tgz#98a7df7b8c358c9a37ab07a24056853016aba3af"
   integrity sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==
@@ -298,7 +298,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.2.tgz#871807f10442b92ff97e4783b9b54f6a0ca812d0"
   integrity sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.5", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.4.3":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.11.5", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.4.3":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.11.tgz#9ce3595bcd74bc5c466905e86c535b8b25011e79"
   integrity sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==
@@ -8005,6 +8005,11 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
+humanize-duration@^3.25.2:
+  version "3.25.2"
+  resolved "https://registry.yarnpkg.com/humanize-duration/-/humanize-duration-3.25.2.tgz#5259585b749ecc5ad5a60fb37121aee0e9ab0c5e"
+  integrity sha512-zSerjahuzBazDaE8skjMI7Xmrt/EirvW5cDsXgysx8tYIjcgCMnI5Y5985y3LxYeLah9L5cQY3WEw1k7GRWbfg==
+
 humanize-ms@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
@@ -14527,11 +14532,6 @@ resolve-options@^1.1.0:
   dependencies:
     value-or-function "^3.0.0"
 
-resolve-pathname@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
-  integrity sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==
-
 resolve-pathname@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
@@ -16704,11 +16704,6 @@ validate-npm-package-name@^3.0.0, validate-npm-package-name@~3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
-
-value-equal@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
-  integrity sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw==
 
 value-equal@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR addresses the following call taker items:
- updates the call and query list item labels to be more descriptive (see screenshot).
- seeks to fix an issue where viewing a past call record query initiated a new call (by adding `_CALL` to the `searchId`).

If others have alternative approaches for item 2, I'm happy to entertain them!


![image](https://user-images.githubusercontent.com/2370911/115079092-a1cdc200-9ece-11eb-8bea-3ceb0068bf0c.png)
