### PR TITLE
Consolidate batch-routing errors into errors section

### DIFF
--- a/lib/components/form/error-message.js
+++ b/lib/components/form/error-message.js
@@ -1,54 +1,31 @@
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
+import React from 'react'
 import { connect } from 'react-redux'
 import TripTools from '../narrative/trip-tools'
 
-import { getActiveError } from '../../util/state'
+import { getActiveError, getErrorMessage } from '../../util/state'
 
-class ErrorMessage extends Component {
-  static propTypes = {
-    error: PropTypes.object
-  }
+const ErrorMessage = ({ message }) => {
+  if (!message) return null
 
-  render () {
-    const { error, errorMessages, currentQuery } = this.props
-    if (!error) return null
-
-    let message = error.msg
-    // check for configuration-defined message override
-    if (errorMessages) {
-      const msgConfig = errorMessages.find(m => m.id === error.id)
-      if (msgConfig) {
-        if (msgConfig.modes) {
-          for (const mode of msgConfig.modes) {
-            if (currentQuery.mode.includes(mode)) {
-              message = msgConfig.msg
-              break
-            }
-          }
-        } else message = msgConfig.msg
-      }
-    }
-
-    return (
-      <div className='error-message'>
-        <div className='header'>
-          <i className='fa fa-exclamation-circle' /> Could Not Plan Trip
-        </div>
-        <div className='message'>{message}</div>
-        <TripTools buttonTypes={['START_OVER', 'REPORT_ISSUE']} />
+  return (
+    <div className='error-message'>
+      <div className='header'>
+        <i className='fa fa-exclamation-circle' /> Could Not Plan Trip
       </div>
-    )
-  }
+      <div className='message'>{message}</div>
+      <TripTools buttonTypes={['START_OVER', 'REPORT_ISSUE']} />
+    </div>
+  )
 }
 
 // connect to the redux store
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    error: getActiveError(state.otp),
-    currentQuery: state.otp.currentQuery,
-    errorMessages: state.otp.config.errorMessages
+    message: getErrorMessage(
+      getActiveError(state.otp),
+      state.otp.config.errorMessages
+    )
   }
 }
 

--- a/lib/components/narrative/narrative-itineraries-errors.js
+++ b/lib/components/narrative/narrative-itineraries-errors.js
@@ -1,0 +1,45 @@
+import { getCompanyIcon } from '@opentripplanner/icons/lib/companies'
+import styled from 'styled-components'
+
+import Icon from '../narrative/icon'
+import { getErrorMessage } from '../../util/state'
+
+const IssueContainer = styled.div`
+  border-top: 1px solid grey;
+  display: flex;
+  padding: 10px;
+`
+
+const IssueIconContainer = styled.div`
+  font-size: 18px;
+  height: 24px;
+  width: 24px;
+`
+
+const IssueContents = styled.div`
+  font-size: 14px;
+  margin-left: 10px;
+  text-align: left;
+`
+
+export default function NarrativeItinerariesErrors ({ errorMessages, errors }) {
+  return errors.map((error, idx) => {
+    let icon
+    if (error.network) {
+      const CompanyIcon = getCompanyIcon(error.network)
+      icon = <CompanyIcon />
+    } else {
+      icon = <Icon className='text-warning' type='exclamation-triangle' />
+    }
+    return (
+      <IssueContainer key={idx}>
+        <IssueIconContainer>
+          {icon}
+        </IssueIconContainer>
+        <IssueContents>
+          {getErrorMessage(error, errorMessages)}
+        </IssueContents>
+      </IssueContainer>
+    )
+  })
+}

--- a/lib/components/narrative/narrative-itineraries-header.js
+++ b/lib/components/narrative/narrative-itineraries-header.js
@@ -9,11 +9,7 @@ const IssueButton = styled.button`
   border-radius: 5px;
   display: inline-block;
   font-size: 12px;
-  padding: 4px;
-
-  span {
-    margin-left: 4px;
-  }
+  padding: 2px 4px;
 `
 
 export default function NarrativeItinerariesHeader ({
@@ -62,7 +58,14 @@ export default function NarrativeItinerariesHeader ({
             <Icon type='arrow-left' /> View all options
           </button>
 
-          {itineraryIsExpanded && <SaveTripButton />}
+          {itineraryIsExpanded && (
+            // marginLeft: auto is a way of making something "float right"
+            // within a flex container
+            // see https://stackoverflow.com/a/36182782/269834
+            <div style={{marginLeft: 'auto'}}>
+              <SaveTripButton />
+            </div>
+          )}
         </>
         : <>
           <div
@@ -76,7 +79,7 @@ export default function NarrativeItinerariesHeader ({
             </span>
             {errors.length > 0 && (
               <IssueButton onClick={onToggleShowErrors}>
-                <Icon type='warning' />
+                <Icon style={{fontSize: 11, marginRight: 2}} type='warning' />
                 <span>{errors.length} issues</span>
               </IssueButton>
             )}

--- a/lib/components/narrative/narrative-itineraries-header.js
+++ b/lib/components/narrative/narrative-itineraries-header.js
@@ -1,0 +1,109 @@
+import styled from 'styled-components'
+
+import Icon from '../narrative/icon'
+import SaveTripButton from './save-trip-button'
+
+const IssueButton = styled.button`
+  background-color: #ECBE03;
+  border: none;
+  border-radius: 5px;
+  display: inline-block;
+  font-size: 12px;
+  padding: 4px;
+
+  span {
+    margin-left: 4px;
+  }
+`
+
+export default function NarrativeItinerariesHeader ({
+  errors,
+  itineraries,
+  itineraryIsExpanded,
+  onSortChange,
+  onSortDirChange,
+  onToggleShowErrors,
+  onViewAllOptions,
+  pending,
+  showingErrors,
+  sort
+}) {
+  let resultText, titleText
+  if (pending) {
+    resultText = 'Finding your options...'
+    titleText = 'Finding your options...'
+  } else {
+    const itineraryPlural = itineraries.length === 1
+      ? 'itinerary'
+      : 'itineraries'
+    const issuePlural = errors.length === 1
+      ? 'issue'
+      : 'issues'
+    resultText = `${itineraries.length} ${itineraryPlural} found.`
+    titleText = errors.length > 0
+      ? `${itineraries.length} ${itineraryPlural} (and ${errors.length} ${issuePlural}) found`
+      : resultText
+  }
+
+  return (
+    <div
+      className='options header'
+      style={{
+        alignItems: 'end',
+        display: 'flex'
+      }}
+    >
+      {(itineraryIsExpanded || showingErrors)
+        ? <>
+          <button
+            className='clear-button-formatting'
+            onClick={onViewAllOptions}
+          >
+            <Icon type='arrow-left' /> View all options
+          </button>
+
+          {itineraryIsExpanded && <SaveTripButton />}
+        </>
+        : <>
+          <div
+            style={{flexGrow: 1}}
+            title={titleText}
+          >
+            <span style={{
+              marginRight: '10px'
+            }}>
+              {resultText}
+            </span>
+            {errors.length > 0 && (
+              <IssueButton onClick={onToggleShowErrors}>
+                <Icon type='warning' />
+                <span>{errors.length} issues</span>
+              </IssueButton>
+            )}
+          </div>
+          <div style={{display: 'flex', float: 'right'}}>
+            <button
+              className='clear-button-formatting'
+              onClick={onSortDirChange}
+              style={{marginRight: '5px'}}
+            >
+              <Icon type={`sort-amount-${sort.direction.toLowerCase()}`} />
+            </button>
+            <select
+              onBlur={onSortChange}
+              onChange={onSortChange}
+              value={sort.value}
+            >
+              <option value='BEST'>Best option</option>
+              <option value='DURATION'>Duration</option>
+              <option value='ARRIVALTIME'>Arrival time</option>
+              <option value='DEPARTURETIME'>Departure time</option>
+              <option value='WALKTIME'>Walk time</option>
+              <option value='COST'>Cost</option>
+            </select>
+          </div>
+        </>
+      }
+    </div>
+  )
+}

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -2,12 +2,6 @@ import coreUtils from '@opentripplanner/core-utils'
 import { getCompanyIcon } from '@opentripplanner/icons/lib/companies'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import {
-  ListGroup,
-  ListGroupItem,
-  OverlayTrigger,
-  Tooltip
-} from 'react-bootstrap'
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
@@ -26,7 +20,7 @@ import { ComponentContext } from '../../util/contexts'
 import {
   getActiveItineraries,
   getActiveSearch,
-  getFeedWideRentalErrors,
+  getErrorMessage,
   getRealtimeEffects,
   getResponsesWithErrors
 } from '../../util/state'
@@ -34,18 +28,6 @@ import {
 import SaveTripButton from './save-trip-button'
 
 const { ItineraryView } = uiActions
-
-// TODO: move to utils?
-function humanReadableMode (modeStr) {
-  if (!modeStr) return 'N/A'
-  const arr = modeStr.toLowerCase().replace(/_/g, ' ').split(',')
-  if (arr.length > 2) {
-    const last = arr.pop()
-    return arr.join(', ') + ' and ' + last
-  } else {
-    return arr.join(' and ')
-  }
-}
 
 const IssueContainer = styled.div`
   display: flex;
@@ -64,8 +46,9 @@ const IssueContents = styled.div`
   text-align: left;
 `
 
-const IssueWell = styled.div`
+const IssueButton = styled.button`
   background-color: #ECBE03;
+  border: none;
   border-radius: 5px;
   display: inline-block;
   font-size: 12px;
@@ -92,6 +75,8 @@ class NarrativeItineraries extends Component {
   }
 
   static contextType = ComponentContext
+
+  state = { showingErrors: false }
 
   _setActiveLeg = (index, leg) => {
     const { activeLeg, setActiveLeg, setItineraryView } = this.props
@@ -133,6 +118,65 @@ class NarrativeItineraries extends Component {
     setUseRealtimeResponse({useRealtime: !useRealtime})
   }
 
+  _toggleShowErrors = () => {
+    this.setState({ showingErrors: !this.state.showingErrors })
+  }
+
+  _renderErrors = () => {
+    const { errorMessages, errors } = this.props
+    return errors.map((error, idx) => {
+      let icon
+      if (error.network) {
+        const CompanyIcon = getCompanyIcon(error.network)
+        icon = <CompanyIcon />
+      } else {
+        icon = <Icon className='text-warning' type='exclamation-triangle' />
+      }
+      return (
+        <div className='option default-itin' key={idx}>
+          <IssueContainer>
+            <IssueIconContainer>
+              {icon}
+            </IssueIconContainer>
+            <IssueContents>
+              {getErrorMessage(error, errorMessages)}
+            </IssueContents>
+          </IssueContainer>
+        </div>
+      )
+    })
+  }
+
+  _renderErrorsButton = () => {
+    const { errors } = this.props
+    if (errors.length === 0) return null
+    return (
+      <IssueButton onClick={this._toggleShowErrors}>
+        <i className='fa fa-warning' />
+        <span>{errors.length} issues</span>
+      </IssueButton>
+    )
+  }
+
+  _renderDesktopErrorsButtonp = () => {
+    if (coreUtils.ui.isMobile()) return null
+    return this._renderErrorsButton()
+  }
+
+  _renderMobileErrorsButton = () => {
+    if (!coreUtils.ui.isMobile()) return null
+    return (
+      <>
+        {/* force a line break with css flex so the errors button show up
+          below the summary and sort selector */}
+        <div style={{ flexBasis: '100%', height: 5 }} />
+        <div>
+          {this._renderErrorsButton()}
+        </div>
+      </>
+    )
+  }
+
   _renderHeader = () => {
     const {
       errors,
@@ -141,41 +185,7 @@ class NarrativeItineraries extends Component {
       pending,
       sort
     } = this.props
-
-    const issues = []
-    const networksWithFeedWideErrors = {}
-    errors.forEach(error => {
-      // first check if there were feed-wide network errors associated with the
-      // response
-      const feedWideRentalErrors = getFeedWideRentalErrors(error)
-      if (feedWideRentalErrors.length > 0) {
-        // there were errors, add issues for each network that had a feed-wide
-        // error
-        feedWideRentalErrors.forEach(networkWithFeedWideError => {
-          const { network } = networkWithFeedWideError
-          if (!networksWithFeedWideErrors[network]) {
-            const CompanyIcon = getCompanyIcon(network)
-            issues.push({
-              contents: `The ${network} network is unavailable at this moment.`,
-              icon: <CompanyIcon />
-            })
-            networksWithFeedWideErrors[network] = true
-          }
-        })
-
-        // don't continue to next part which would be overall errors with
-        // planning a trip with a certain mode combination
-        return
-      }
-
-      // At this point, an error response involved an error with  planning a
-      // trip with a certain mode combination
-      const mode = humanReadableMode(error.requestParameters.mode)
-      issues.push({
-        contents: `No trip found for ${mode}. ${error.error.msg}`,
-        icon: <Icon className='text-warning' type='exclamation-triangle' />
-      })
-    })
+    const { showingErrors } = this.state
 
     let resultText, titleText
     if (pending) {
@@ -185,13 +195,70 @@ class NarrativeItineraries extends Component {
       const itineraryPlural = itineraries.length === 1
         ? 'itinerary'
         : 'itineraries'
-      const issuePlural = issues.length === 1
+      const issuePlural = errors.length === 1
         ? 'issue'
         : 'issues'
       resultText = `${itineraries.length} ${itineraryPlural} found.`
-      titleText = issues.length > 0
-        ? `${itineraries.length} ${itineraryPlural} (and ${issues.length} ${issuePlural}) found`
+      titleText = errors.length > 0
+        ? `${itineraries.length} ${itineraryPlural} (and ${errors.length} ${issuePlural}) found`
         : resultText
+    }
+
+    let content
+
+    if (itineraryIsExpanded || showingErrors) {
+      content = (
+        <>
+          <button
+            className='clear-button-formatting'
+            onClick={itineraryIsExpanded
+              ? this._toggleDetailedItinerary
+              : this._toggleShowErrors
+            }
+          >
+            <i className='fa fa-arrow-left' /> View all options
+          </button>
+
+          {itineraryIsExpanded && <SaveTripButton />}
+        </>
+      )
+    } else {
+      content = (
+        <>
+          <div
+            title={titleText}
+            style={{
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis'
+            }}>
+            <span>{resultText}</span>
+            {this._renderDesktopErrorsButton()}
+          </div>
+          <div style={{display: 'inherit'}}>
+            <button
+              className='clear-button-formatting'
+              onClick={this._onSortDirChange}
+              style={{marginRight: '5px'}}
+            >
+              <i className={`fa fa-sort-amount-${sort.direction.toLowerCase()}`} />
+            </button>
+            <select
+              onBlur={this._onSortChange}
+              onChange={this._onSortChange}
+              value={sort.value}
+            >
+              <option value='BEST'>Best option</option>
+              <option value='DURATION'>Duration</option>
+              <option value='ARRIVALTIME'>Arrival time</option>
+              <option value='DEPARTURETIME'>Departure time</option>
+              <option value='WALKTIME'>Walk time</option>
+              <option value='COST'>Cost</option>
+            </select>
+          </div>
+          {this._renderMobileErrorsButton()}
+        </>
+      )
     }
 
     return (
@@ -199,85 +266,20 @@ class NarrativeItineraries extends Component {
         className='options header'
         style={{
           display: 'flex',
-          justifyContent: 'space-between',
-          flexGrow: '0'
+          flexGrow: '0',
+          flexWrap: 'wrap',
+          justifyContent: 'space-between'
         }}
       >
-        {itineraryIsExpanded
-          ? <>
-            <button
-              className='clear-button-formatting'
-              onClick={this._toggleDetailedItinerary}>
-              <i className='fa fa-arrow-left' /> View all options
-            </button>
-
-            <SaveTripButton />
-          </>
-          : <>
-            <div
-              title={titleText}
-              style={{
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis'
-              }}>
-              <span>{resultText}</span>
-              {issues.length > 0 && (
-                <OverlayTrigger
-                  overlay={(
-                    <Tooltip id='narrative-issues-tooltip'>
-                      <ListGroup>
-                        {issues.map((issue, i) => (
-                          <ListGroupItem key={i}>
-                            <IssueContainer>
-                              <IssueIconContainer>
-                                {issue.icon}
-                              </IssueIconContainer>
-                              <IssueContents>
-                                {issue.contents}
-                              </IssueContents>
-                            </IssueContainer>
-                          </ListGroupItem>
-                        ))}
-                      </ListGroup>
-                    </Tooltip>
-                  )}
-                  placement='bottom'
-                >
-                  <IssueWell>
-                    <i className='fa fa-warning' />
-                    <span>{issues.length} issues</span>
-                  </IssueWell>
-                </OverlayTrigger>
-              )}
-            </div>
-            <div style={{display: 'inherit'}} className='sort-options'>
-              <button
-                onClick={this._onSortDirChange} className='clear-button-formatting'
-                style={{marginRight: '5px'}}>
-                <i className={`fa fa-sort-amount-${sort.direction.toLowerCase()}`} />
-              </button>
-              <select
-                onBlur={this._onSortChange}
-                onChange={this._onSortChange}
-                value={sort.value}>
-                <option value='BEST'>Best option</option>
-                <option value='DURATION'>Duration</option>
-                <option value='ARRIVALTIME'>Arrival time</option>
-                <option value='DEPARTURETIME'>Departure time</option>
-                <option value='WALKTIME'>Walk time</option>
-                <option value='COST'>Cost</option>
-              </select>
-            </div>
-          </>
-        }
+        {content}
       </div>
     )
   }
 
   _renderLoadingDivs = () => {
     const {itineraries, modes, pending} = this.props
-    if (!pending) return null
+    const {showingErrors} = this.state
+    if (!pending || showingErrors) return null
     // Construct loading divs as placeholders while all itineraries load.
     const count = modes.combinations
       ? modes.combinations.length - itineraries.length
@@ -313,6 +315,7 @@ class NarrativeItineraries extends Component {
       visibleItinerary
     } = this.props
     const { ItineraryBody, LegIcon } = this.context
+    const { showingErrors } = this.state
 
     if (!activeSearch) return null
 
@@ -322,17 +325,13 @@ class NarrativeItineraries extends Component {
       !useRealtime
     )
 
-    return (
-      <div className='options itinerary' style={containerStyle}>
-        {this._renderHeader()}
-        <div
-          // FIXME: Change to a ul with li children?
-          className='list'
-          style={{
-            flexGrow: '1',
-            overflowY: 'auto'
-          }}
-        >
+    let content
+
+    if (showingErrors) {
+      content = this._renderErrors()
+    } else {
+      content = (
+        <>
           {itineraries.map((itinerary, index) => {
             const active = index === activeItinerary
             // Hide non-active itineraries.
@@ -361,6 +360,22 @@ class NarrativeItineraries extends Component {
             )
           })}
           {this._renderLoadingDivs()}
+        </>
+      )
+    }
+
+    return (
+      <div className='options itinerary' style={containerStyle}>
+        {this._renderHeader()}
+        <div
+          // FIXME: Change to a ul with li children?
+          className='list'
+          style={{
+            flexGrow: '1',
+            overflowY: 'auto'
+          }}
+        >
+          {content}
         </div>
       </div>
     )
@@ -372,8 +387,8 @@ class NarrativeItineraries extends Component {
 const mapStateToProps = (state, ownProps) => {
   const activeSearch = getActiveSearch(state.otp)
   const activeItinerary = activeSearch && activeSearch.activeItinerary
-  const {modes} = state.otp.config
-  const {sort} = state.otp.filter
+  const { errorMessages, modes } = state.otp.config
+  const { sort } = state.otp.filter
   const pending = activeSearch ? Boolean(activeSearch.pending) : false
   const itineraries = getActiveItineraries(state.otp)
   const realtimeEffects = getRealtimeEffects(state.otp)
@@ -394,9 +409,13 @@ const mapStateToProps = (state, ownProps) => {
     activeSearch,
     activeStep: activeSearch && activeSearch.activeStep,
     errors: getResponsesWithErrors(state.otp),
+    errorMessages,
     itineraries,
     itineraryIsExpanded,
     itineraryView,
+    // use a key so that the NarrativeItineraries component and its state is
+    // reset each time a new search is shown
+    key: state.otp.activeSearchId,
     modes,
     pending,
     realtimeEffects,

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -30,8 +30,9 @@ import SaveTripButton from './save-trip-button'
 const { ItineraryView } = uiActions
 
 const IssueContainer = styled.div`
+  border-top: 1px solid grey;
   display: flex;
-  padding: 5px;
+  padding: 10px;
 `
 
 const IssueIconContainer = styled.div`
@@ -41,7 +42,7 @@ const IssueIconContainer = styled.div`
 `
 
 const IssueContents = styled.div`
-  font-size: 12px;
+  font-size: 14px;
   margin-left: 10px;
   text-align: left;
 `
@@ -132,16 +133,14 @@ class NarrativeItineraries extends Component {
         icon = <Icon className='text-warning' type='exclamation-triangle' />
       }
       return (
-        <div className='option default-itin' key={idx}>
-          <IssueContainer>
-            <IssueIconContainer>
-              {icon}
-            </IssueIconContainer>
-            <IssueContents>
-              {getErrorMessage(error, errorMessages)}
-            </IssueContents>
-          </IssueContainer>
-        </div>
+        <IssueContainer key={idx}>
+          <IssueIconContainer>
+            {icon}
+          </IssueIconContainer>
+          <IssueContents>
+            {getErrorMessage(error, errorMessages)}
+          </IssueContents>
+        </IssueContainer>
       )
     })
   }
@@ -151,7 +150,7 @@ class NarrativeItineraries extends Component {
     if (errors.length === 0) return null
     return (
       <IssueButton onClick={this._toggleShowErrors}>
-        <i className='fa fa-warning' />
+        <Icon type='warning' />
         <span>{errors.length} issues</span>
       </IssueButton>
     )
@@ -196,7 +195,7 @@ class NarrativeItineraries extends Component {
               : this._toggleShowErrors
             }
           >
-            <i className='fa fa-arrow-left' /> View all options
+            <Icon type='arrow-left' /> View all options
           </button>
 
           {itineraryIsExpanded && <SaveTripButton />}
@@ -210,7 +209,7 @@ class NarrativeItineraries extends Component {
             title={titleText}
           >
             <span style={{
-              marginRight: '10px',
+              marginRight: '10px'
             }}>
               {resultText}
             </span>
@@ -222,7 +221,7 @@ class NarrativeItineraries extends Component {
               onClick={this._onSortDirChange}
               style={{marginRight: '5px'}}
             >
-              <i className={`fa fa-sort-amount-${sort.direction.toLowerCase()}`} />
+              <Icon type={`sort-amount-${sort.direction.toLowerCase()}`} />
             </button>
             <select
               onBlur={this._onSortChange}

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -1,10 +1,8 @@
 import coreUtils from '@opentripplanner/core-utils'
-import { getCompanyIcon } from '@opentripplanner/icons/lib/companies'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton'
 import { connect } from 'react-redux'
-import styled from 'styled-components'
 
 import {
   setActiveItinerary,
@@ -15,50 +13,17 @@ import {
   updateItineraryFilter
 } from '../../actions/narrative'
 import * as uiActions from '../../actions/ui'
-import Icon from '../narrative/icon'
+import NarrativeItinerariesErrors from './narrative-itineraries-errors'
+import NarrativeItinerariesHeader from './narrative-itineraries-header'
 import { ComponentContext } from '../../util/contexts'
 import {
   getActiveItineraries,
   getActiveSearch,
-  getErrorMessage,
   getRealtimeEffects,
   getResponsesWithErrors
 } from '../../util/state'
 
-import SaveTripButton from './save-trip-button'
-
 const { ItineraryView } = uiActions
-
-const IssueContainer = styled.div`
-  border-top: 1px solid grey;
-  display: flex;
-  padding: 10px;
-`
-
-const IssueIconContainer = styled.div`
-  font-size: 18px;
-  height: 24px;
-  width: 24px;
-`
-
-const IssueContents = styled.div`
-  font-size: 14px;
-  margin-left: 10px;
-  text-align: left;
-`
-
-const IssueButton = styled.button`
-  background-color: #ECBE03;
-  border: none;
-  border-radius: 5px;
-  display: inline-block;
-  font-size: 12px;
-  padding: 4px;
-
-  span {
-    margin-left: 4px;
-  }
-`
 
 class NarrativeItineraries extends Component {
   static propTypes = {
@@ -113,144 +78,16 @@ class NarrativeItineraries extends Component {
     updateItineraryFilter({sort: {...sort, direction}})
   }
 
-  _toggleRealtimeItineraryClick = (e) => {
-    const {setUseRealtimeResponse, useRealtime} = this.props
-    setUseRealtimeResponse({useRealtime: !useRealtime})
+  _onViewAllOptions = () => {
+    if (this.props.itineraryIsExpanded) {
+      this._toggleDetailedItinerary()
+    } else {
+      this._toggleShowErrors()
+    }
   }
 
   _toggleShowErrors = () => {
     this.setState({ showingErrors: !this.state.showingErrors })
-  }
-
-  _renderErrors = () => {
-    const { errorMessages, errors } = this.props
-    return errors.map((error, idx) => {
-      let icon
-      if (error.network) {
-        const CompanyIcon = getCompanyIcon(error.network)
-        icon = <CompanyIcon />
-      } else {
-        icon = <Icon className='text-warning' type='exclamation-triangle' />
-      }
-      return (
-        <IssueContainer key={idx}>
-          <IssueIconContainer>
-            {icon}
-          </IssueIconContainer>
-          <IssueContents>
-            {getErrorMessage(error, errorMessages)}
-          </IssueContents>
-        </IssueContainer>
-      )
-    })
-  }
-
-  _renderErrorsButton = () => {
-    const { errors } = this.props
-    if (errors.length === 0) return null
-    return (
-      <IssueButton onClick={this._toggleShowErrors}>
-        <Icon type='warning' />
-        <span>{errors.length} issues</span>
-      </IssueButton>
-    )
-  }
-
-  _renderHeader = () => {
-    const {
-      errors,
-      itineraries,
-      itineraryIsExpanded,
-      pending,
-      sort
-    } = this.props
-    const { showingErrors } = this.state
-
-    let resultText, titleText
-    if (pending) {
-      resultText = 'Finding your options...'
-      titleText = 'Finding your options...'
-    } else {
-      const itineraryPlural = itineraries.length === 1
-        ? 'itinerary'
-        : 'itineraries'
-      const issuePlural = errors.length === 1
-        ? 'issue'
-        : 'issues'
-      resultText = `${itineraries.length} ${itineraryPlural} found.`
-      titleText = errors.length > 0
-        ? `${itineraries.length} ${itineraryPlural} (and ${errors.length} ${issuePlural}) found`
-        : resultText
-    }
-
-    let content
-
-    if (itineraryIsExpanded || showingErrors) {
-      content = (
-        <>
-          <button
-            className='clear-button-formatting'
-            onClick={itineraryIsExpanded
-              ? this._toggleDetailedItinerary
-              : this._toggleShowErrors
-            }
-          >
-            <Icon type='arrow-left' /> View all options
-          </button>
-
-          {itineraryIsExpanded && <SaveTripButton />}
-        </>
-      )
-    } else {
-      content = (
-        <>
-          <div
-            style={{flexGrow: 1}}
-            title={titleText}
-          >
-            <span style={{
-              marginRight: '10px'
-            }}>
-              {resultText}
-            </span>
-            {this._renderErrorsButton()}
-          </div>
-          <div style={{display: 'flex', float: 'right'}}>
-            <button
-              className='clear-button-formatting'
-              onClick={this._onSortDirChange}
-              style={{marginRight: '5px'}}
-            >
-              <Icon type={`sort-amount-${sort.direction.toLowerCase()}`} />
-            </button>
-            <select
-              onBlur={this._onSortChange}
-              onChange={this._onSortChange}
-              value={sort.value}
-            >
-              <option value='BEST'>Best option</option>
-              <option value='DURATION'>Duration</option>
-              <option value='ARRIVALTIME'>Arrival time</option>
-              <option value='DEPARTURETIME'>Departure time</option>
-              <option value='WALKTIME'>Walk time</option>
-              <option value='COST'>Cost</option>
-            </select>
-          </div>
-        </>
-      )
-    }
-
-    return (
-      <div
-        className='options header'
-        style={{
-          alignItems: 'end',
-          display: 'flex'
-        }}
-      >
-        {content}
-      </div>
-    )
   }
 
   _renderLoadingDivs = () => {
@@ -279,8 +116,11 @@ class NarrativeItineraries extends Component {
       activeSearch,
       activeStep,
       containerStyle,
+      errorMessages,
+      errors,
       itineraries,
       itineraryIsExpanded,
+      pending,
       realtimeEffects,
       setActiveItinerary,
       setActiveStep,
@@ -302,48 +142,20 @@ class NarrativeItineraries extends Component {
       !useRealtime
     )
 
-    let content
-
-    if (showingErrors) {
-      content = this._renderErrors()
-    } else {
-      content = (
-        <>
-          {itineraries.map((itinerary, index) => {
-            const active = index === activeItinerary
-            // Hide non-active itineraries.
-            if (!active && itineraryIsExpanded) return null
-            return (
-              <ItineraryBody
-                active={active}
-                activeLeg={activeLeg}
-                activeStep={activeStep}
-                expanded={showDetails}
-                index={index}
-                itinerary={itinerary}
-                key={index}
-                LegIcon={LegIcon}
-                onClick={active ? this._toggleDetailedItinerary : undefined}
-                routingType='ITINERARY'
-                setActiveItinerary={setActiveItinerary}
-                setActiveLeg={this._setActiveLeg}
-                setActiveStep={setActiveStep}
-                setVisibleItinerary={setVisibleItinerary}
-                showRealtimeAnnotation={showRealtimeAnnotation}
-                sort={sort}
-                timeFormat={timeFormat}
-                visibleItinerary={visibleItinerary}
-              />
-            )
-          })}
-          {this._renderLoadingDivs()}
-        </>
-      )
-    }
-
     return (
       <div className='options itinerary' style={containerStyle}>
-        {this._renderHeader()}
+        <NarrativeItinerariesHeader
+          errors={errors}
+          itineraries={itineraries}
+          itineraryIsExpanded={itineraryIsExpanded}
+          onSortChange={this._onSortChange}
+          onSortDirChange={this._onSortDirChange}
+          onToggleShowErrors={this._toggleShowErrors}
+          onViewAllOptions={this._onViewAllOptions}
+          pending={pending}
+          showingErrors={showingErrors}
+          sort={sort}
+        />
         <div
           // FIXME: Change to a ul with li children?
           className='list'
@@ -352,7 +164,44 @@ class NarrativeItineraries extends Component {
             overflowY: 'auto'
           }}
         >
-          {content}
+          {showingErrors
+            ? (
+              <NarrativeItinerariesErrors
+                errorMessages={errorMessages}
+                errors={errors}
+              />
+            )
+            : <>
+              {itineraries.map((itinerary, index) => {
+                const active = index === activeItinerary
+                // Hide non-active itineraries.
+                if (!active && itineraryIsExpanded) return null
+                return (
+                  <ItineraryBody
+                    active={active}
+                    activeLeg={activeLeg}
+                    activeStep={activeStep}
+                    expanded={showDetails}
+                    index={index}
+                    itinerary={itinerary}
+                    key={index}
+                    LegIcon={LegIcon}
+                    onClick={active ? this._toggleDetailedItinerary : undefined}
+                    routingType='ITINERARY'
+                    setActiveItinerary={setActiveItinerary}
+                    setActiveLeg={this._setActiveLeg}
+                    setActiveStep={setActiveStep}
+                    setVisibleItinerary={setVisibleItinerary}
+                    showRealtimeAnnotation={showRealtimeAnnotation}
+                    sort={sort}
+                    timeFormat={timeFormat}
+                    visibleItinerary={visibleItinerary}
+                  />
+                )
+              })}
+              {this._renderLoadingDivs()}
+            </>
+          }
         </div>
       </div>
     )

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -1,8 +1,16 @@
 import coreUtils from '@opentripplanner/core-utils'
+import { getCompanyIcon } from '@opentripplanner/icons/lib/companies'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import {
+  ListGroup,
+  ListGroupItem,
+  OverlayTrigger,
+  Tooltip
+} from 'react-bootstrap'
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton'
 import { connect } from 'react-redux'
+import styled from 'styled-components'
 
 import {
   setActiveItinerary,
@@ -18,6 +26,7 @@ import { ComponentContext } from '../../util/contexts'
 import {
   getActiveItineraries,
   getActiveSearch,
+  getFeedWideRentalErrors,
   getRealtimeEffects,
   getResponsesWithErrors
 } from '../../util/state'
@@ -37,6 +46,36 @@ function humanReadableMode (modeStr) {
     return arr.join(' and ')
   }
 }
+
+const IssueContainer = styled.div`
+  display: flex;
+  padding: 5px;
+`
+
+const IssueIconContainer = styled.div`
+  font-size: 18px;
+  height: 24px;
+  width: 24px;
+`
+
+const IssueContents = styled.div`
+  font-size: 12px;
+  margin-left: 10px;
+  text-align: left;
+`
+
+const IssueWell = styled.div`
+  background-color: #ECBE03;
+  border-radius: 5px;
+  display: inline-block;
+  font-size: 12px;
+  margin-left: 10px;
+  padding: 4px;
+
+  span {
+    margin-left: 4px;
+  }
+`
 
 class NarrativeItineraries extends Component {
   static propTypes = {
@@ -69,16 +108,9 @@ class NarrativeItineraries extends Component {
     }
   }
 
-  _isShowingDetails = () => {
-    const { itineraryView } = this.props
-    return itineraryView === ItineraryView.FULL ||
-            itineraryView === ItineraryView.LEG ||
-            itineraryView === ItineraryView.LEG_HIDDEN
-  }
-
   _toggleDetailedItinerary = () => {
-    const { setActiveLeg, setItineraryView } = this.props
-    const newView = this._isShowingDetails() ? ItineraryView.LIST : ItineraryView.FULL
+    const { setActiveLeg, setItineraryView, showDetails } = this.props
+    const newView = showDetails ? ItineraryView.LIST : ItineraryView.FULL
     setItineraryView(newView)
     // Reset the active leg.
     setActiveLeg(null, null)
@@ -99,6 +131,148 @@ class NarrativeItineraries extends Component {
   _toggleRealtimeItineraryClick = (e) => {
     const {setUseRealtimeResponse, useRealtime} = this.props
     setUseRealtimeResponse({useRealtime: !useRealtime})
+  }
+
+  _renderHeader = () => {
+    const {
+      errors,
+      itineraries,
+      itineraryIsExpanded,
+      pending,
+      sort
+    } = this.props
+
+    const issues = []
+    const networksWithFeedWideErrors = {}
+    errors.forEach(error => {
+      // first check if there were feed-wide network errors associated with the
+      // response
+      const feedWideRentalErrors = getFeedWideRentalErrors(error)
+      if (feedWideRentalErrors.length > 0) {
+        // there were errors, add issues for each network that had a feed-wide
+        // error
+        feedWideRentalErrors.forEach(networkWithFeedWideError => {
+          const { network } = networkWithFeedWideError
+          if (!networksWithFeedWideErrors[network]) {
+            const CompanyIcon = getCompanyIcon(network)
+            issues.push({
+              contents: `The ${network} network is unavailable at this moment.`,
+              icon: <CompanyIcon />
+            })
+            networksWithFeedWideErrors[network] = true
+          }
+        })
+
+        // don't continue to next part which would be overall errors with
+        // planning a trip with a certain mode combination
+        return
+      }
+
+      // At this point, an error response involved an error with  planning a
+      // trip with a certain mode combination
+      const mode = humanReadableMode(error.requestParameters.mode)
+      issues.push({
+        contents: `No trip found for ${mode}. ${error.error.msg}`,
+        icon: <Icon className='text-warning' type='exclamation-triangle' />
+      })
+    })
+
+    let resultText, titleText
+    if (pending) {
+      resultText = 'Finding your options...'
+      titleText = 'Finding your options...'
+    } else {
+      const itineraryPlural = itineraries.length === 1
+        ? 'itinerary'
+        : 'itineraries'
+      const issuePlural = issues.length === 1
+        ? 'issue'
+        : 'issues'
+      resultText = `${itineraries.length} ${itineraryPlural} found.`
+      titleText = issues.length > 0
+        ? `${itineraries.length} ${itineraryPlural} (and ${issues.length} ${issuePlural}) found`
+        : resultText
+    }
+
+    return (
+      <div
+        className='options header'
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          flexGrow: '0'
+        }}
+      >
+        {itineraryIsExpanded
+          ? <>
+            <button
+              className='clear-button-formatting'
+              onClick={this._toggleDetailedItinerary}>
+              <i className='fa fa-arrow-left' /> View all options
+            </button>
+
+            <SaveTripButton />
+          </>
+          : <>
+            <div
+              title={titleText}
+              style={{
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis'
+              }}>
+              <span>{resultText}</span>
+              {issues.length > 0 && (
+                <OverlayTrigger
+                  overlay={(
+                    <Tooltip id='narrative-issues-tooltip'>
+                      <ListGroup>
+                        {issues.map((issue, i) => (
+                          <ListGroupItem key={i}>
+                            <IssueContainer>
+                              <IssueIconContainer>
+                                {issue.icon}
+                              </IssueIconContainer>
+                              <IssueContents>
+                                {issue.contents}
+                              </IssueContents>
+                            </IssueContainer>
+                          </ListGroupItem>
+                        ))}
+                      </ListGroup>
+                    </Tooltip>
+                  )}
+                  placement='bottom'
+                >
+                  <IssueWell>
+                    <i className='fa fa-warning' />
+                    <span>{issues.length} issues</span>
+                  </IssueWell>
+                </OverlayTrigger>
+              )}
+            </div>
+            <div style={{display: 'inherit'}} className='sort-options'>
+              <button
+                onClick={this._onSortDirChange} className='clear-button-formatting'
+                style={{marginRight: '5px'}}>
+                <i className={`fa fa-sort-amount-${sort.direction.toLowerCase()}`} />
+              </button>
+              <select
+                onBlur={this._onSortChange}
+                onChange={this._onSortChange}
+                value={sort.value}>
+                <option value='BEST'>Best option</option>
+                <option value='DURATION'>Duration</option>
+                <option value='ARRIVALTIME'>Arrival time</option>
+                <option value='DEPARTURETIME'>Departure time</option>
+                <option value='WALKTIME'>Walk time</option>
+                <option value='COST'>Cost</option>
+              </select>
+            </div>
+          </>
+        }
+      </div>
+    )
   }
 
   _renderLoadingDivs = () => {
@@ -126,13 +300,13 @@ class NarrativeItineraries extends Component {
       activeSearch,
       activeStep,
       containerStyle,
-      errors,
       itineraries,
-      pending,
+      itineraryIsExpanded,
       realtimeEffects,
       setActiveItinerary,
       setActiveStep,
       setVisibleItinerary,
+      showDetails,
       sort,
       timeFormat,
       useRealtime,
@@ -141,69 +315,16 @@ class NarrativeItineraries extends Component {
     const { ItineraryBody, LegIcon } = this.context
 
     if (!activeSearch) return null
-    const showDetails = this._isShowingDetails()
-    const itineraryIsExpanded = activeItinerary !== undefined && activeItinerary !== null && showDetails
 
     const showRealtimeAnnotation = realtimeEffects.isAffectedByRealtimeData && (
       realtimeEffects.exceedsThreshold ||
       realtimeEffects.routesDiffer ||
       !useRealtime
     )
-    const resultText = pending
-      ? 'Finding your options...'
-      : `${itineraries.length} itineraries found.`
 
     return (
       <div className='options itinerary' style={containerStyle}>
-        <div
-          className='options header'
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            flexGrow: '0'
-          }}
-        >
-          {itineraryIsExpanded
-            ? <>
-              <button
-                className='clear-button-formatting'
-                onClick={this._toggleDetailedItinerary}>
-                <i className='fa fa-arrow-left' /> View all options
-              </button>
-
-              <SaveTripButton />
-            </>
-            : <>
-              <div
-                title={resultText}
-                style={{
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis'
-                }}>
-                {resultText}
-              </div>
-              <div style={{display: 'inherit'}} className='sort-options'>
-                <button
-                  onClick={this._onSortDirChange} className='clear-button-formatting'
-                  style={{marginRight: '5px'}}>
-                  <i className={`fa fa-sort-amount-${sort.direction.toLowerCase()}`} />
-                </button>
-                <select
-                  onBlur={this._onSortChange}
-                  onChange={this._onSortChange}
-                  value={sort.value}>
-                  <option value='BEST'>Best option</option>
-                  <option value='DURATION'>Duration</option>
-                  <option value='ARRIVALTIME'>Arrival time</option>
-                  <option value='DEPARTURETIME'>Departure time</option>
-                  <option value='WALKTIME'>Walk time</option>
-                  <option value='COST'>Cost</option>
-                </select>
-              </div>
-            </>
-          }
-        </div>
+        {this._renderHeader()}
         <div
           // FIXME: Change to a ul with li children?
           className='list'
@@ -239,20 +360,6 @@ class NarrativeItineraries extends Component {
               />
             )
           })}
-          {/* Don't show errors if an itinerary is expanded. */}
-          {/* FIXME: Flesh out error design/move to component? */}
-          {!itineraryIsExpanded && errors.map((e, i) => {
-            const mode = humanReadableMode(e.requestParameters.mode)
-            return (
-              <div key={i} className='option default-itin'>
-                <h4>
-                  <Icon className='text-warning' type='exclamation-triangle' />{' '}
-                  No trip found for {mode}
-                </h4>
-                <div>{e.error.msg}</div>
-              </div>
-            )
-          })}
           {this._renderLoadingDivs()}
         </div>
       </div>
@@ -264,6 +371,7 @@ class NarrativeItineraries extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   const activeSearch = getActiveSearch(state.otp)
+  const activeItinerary = activeSearch && activeSearch.activeItinerary
   const {modes} = state.otp.config
   const {sort} = state.otp.filter
   const pending = activeSearch ? Boolean(activeSearch.pending) : false
@@ -271,19 +379,28 @@ const mapStateToProps = (state, ownProps) => {
   const realtimeEffects = getRealtimeEffects(state.otp)
   const useRealtime = state.otp.useRealtime
   const urlParams = coreUtils.query.getUrlParams()
+  const itineraryView = urlParams.ui_itineraryView || ItineraryView.DEFAULT
+  const showDetails = itineraryView === ItineraryView.FULL ||
+          itineraryView === ItineraryView.LEG ||
+          itineraryView === ItineraryView.LEG_HIDDEN
+  const itineraryIsExpanded = activeItinerary !== undefined &&
+    activeItinerary !== null &&
+    showDetails
 
   return {
     // swap out realtime itineraries with non-realtime depending on boolean
-    activeItinerary: activeSearch && activeSearch.activeItinerary,
+    activeItinerary,
     activeLeg: activeSearch && activeSearch.activeLeg,
     activeSearch,
     activeStep: activeSearch && activeSearch.activeStep,
     errors: getResponsesWithErrors(state.otp),
     itineraries,
-    itineraryView: urlParams.ui_itineraryView || ItineraryView.DEFAULT,
+    itineraryIsExpanded,
+    itineraryView,
     modes,
     pending,
     realtimeEffects,
+    showDetails,
     sort,
     timeFormat: coreUtils.time.getTimeFormat(state.otp.config),
     useRealtime,

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -158,7 +158,7 @@ class NarrativeItineraries extends Component {
     )
   }
 
-  _renderDesktopErrorsButtonp = () => {
+  _renderDesktopErrorsButton = () => {
     if (coreUtils.ui.isMobile()) return null
     return this._renderErrorsButton()
   }

--- a/lib/components/narrative/narrative.css
+++ b/lib/components/narrative/narrative.css
@@ -7,6 +7,22 @@
   font-size: 16px;
 }
 
+#narrative-issues-tooltip {
+  opacity: 1;
+}
+
+#narrative-issues-tooltip .tooltip-inner {
+  background-color: #fff;
+  border: 1px solid black;
+  color: #000;
+  max-width: 350px;
+  padding: 0;
+}
+
+#narrative-issues-tooltip .list-group-item {
+  padding: 5px;
+}
+
 /* Options scroll bar  */
 .otp .options > .list::-webkit-scrollbar {
   width: 10px;

--- a/lib/components/narrative/narrative.css
+++ b/lib/components/narrative/narrative.css
@@ -7,22 +7,6 @@
   font-size: 16px;
 }
 
-#narrative-issues-tooltip {
-  opacity: 1;
-}
-
-#narrative-issues-tooltip .tooltip-inner {
-  background-color: #fff;
-  border: 1px solid black;
-  color: #000;
-  max-width: 350px;
-  padding: 0;
-}
-
-#narrative-issues-tooltip .list-group-item {
-  padding: 5px;
-}
-
 /* Options scroll bar  */
 .otp .options > .list::-webkit-scrollbar {
   width: 10px;

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -69,9 +69,7 @@ function humanReadableMode (modeStr) {
 }
 
 /**
- * Generates a list of issues with a list of OTP responses. For batch routing
- * this could be an array of multiple responses, but for standard itinerary
- * routing it will be at most an array with one response.
+ * Generates a list of issues/errors from a list of OTP responses.
  *
  * @param {Object} otpState the OTP state object
  * @return {Array} An array of objects describing the errors seen. These will at
@@ -122,11 +120,12 @@ export function getResponsesWithErrors (otpState) {
 }
 
 /**
- * Gets the active error (first OTP plan response that contains an error). This
+ * Gets the active error (eiter a planning error or a rental feed error). This
  * should only be used with itinerary routing, not batch routing.
  */
 export function getActiveError (otpState) {
-  return getResponsesWithErrors(otpState)[0]
+  const errors = getResponsesWithErrors(otpState)
+  return errors[errors.length - 1]
 }
 
 /**

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -25,6 +25,45 @@ export function getTimestamp (time = moment()) {
 }
 
 /**
+ * Analyzes all rental networks provided in the response and returns a list of
+ * those that have a FEED_WIDE error.
+ */
+export function getFeedWideRentalErrors (response) {
+  // return empty array if the plan key is not available in the response
+  if (!response) return []
+
+  const networksWithFeedWideErrors = []
+
+  // get first available rental info (this assumes that there won't be
+  // 2 rental info types (for example car rental access and vehicle
+  // rental egress))
+  const rentalInfo = response.bikeRentalInfo ||
+    response.carRentalInfo ||
+    response.vehicleRentalInfo
+  if (!rentalInfo) return networksWithFeedWideErrors
+
+  // iterate through all networks to deter
+  Object.keys(rentalInfo).forEach(network => {
+    const networkRentalInfo = rentalInfo[network]
+    if (
+      networkRentalInfo.errors &&
+        networkRentalInfo.errors.length > 0
+    ) {
+      if (networkRentalInfo.errors.some(
+        error => error.severity === 'FEED_WIDE'
+      )) {
+        networksWithFeedWideErrors.push({
+          network,
+          networkRentalInfo
+        })
+      }
+    }
+  })
+
+  return networksWithFeedWideErrors
+}
+
+/**
  * Gets the OTP responses that contain errors. For batch routing this could be
  * an array of multiple responses, but for standard itinerary routing it will be
  * at most an array with one response.
@@ -33,14 +72,24 @@ export function getTimestamp (time = moment()) {
  */
 export function getResponsesWithErrors (otpState) {
   const search = getActiveSearch(otpState)
-  const errorResponses = []
+  const responsesWithRentalFeedErrors = []
+  const responsesWithTripPlanningErrors = []
   const response = !search ? null : search.response
   if (response) {
     response.forEach(res => {
-      if (res && res.error) errorResponses.push(res)
+      if (res) {
+        if (res.error) {
+          responsesWithTripPlanningErrors.push(res)
+        }
+        if (getFeedWideRentalErrors(res).length > 0) {
+          responsesWithRentalFeedErrors.push(res)
+        }
+      }
     })
   }
-  return errorResponses
+
+  // generate list so rental errors show up first
+  return [...responsesWithRentalFeedErrors, ...responsesWithTripPlanningErrors]
 }
 
 /**

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -120,7 +120,7 @@ export function getResponsesWithErrors (otpState) {
 }
 
 /**
- * Gets the active error (eiter a planning error or a rental feed error). This
+ * Gets the active error (either a planning error or a rental feed error). This
  * should only be used with itinerary routing, not batch routing.
  */
 export function getActiveError (otpState) {

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -63,43 +63,104 @@ export function getFeedWideRentalErrors (response) {
   return networksWithFeedWideErrors
 }
 
+function humanReadableMode (modeStr) {
+  if (!modeStr) return 'N/A'
+  const arr = modeStr.toLowerCase().replace(/_/g, ' ').split(',')
+  if (arr.length > 2) {
+    const last = arr.pop()
+    return arr.join(', ') + ' and ' + last
+  } else {
+    return arr.join(' and ')
+  }
+}
+
 /**
- * Gets the OTP responses that contain errors. For batch routing this could be
- * an array of multiple responses, but for standard itinerary routing it will be
- * at most an array with one response.
+ * Generates a list of issues with a list of OTP responses. For batch routing
+ * this could be an array of multiple responses, but for standard itinerary
+ * routing it will be at most an array with one response.
+ *
  * @param {Object} otpState the OTP state object
- * @return {Array}      array of OTP plan responses that contain errors
+ * @return {Array} An array of objects describing the errors seen. These will at
+ *   a minimum contain the `msg` object describing the error, but could also
+ *   include an `id` and `modes` key for trip planning errors or `network` for
+ *   errors with vehicle rentals
  */
 export function getResponsesWithErrors (otpState) {
   const search = getActiveSearch(otpState)
-  const responsesWithRentalFeedErrors = []
-  const responsesWithTripPlanningErrors = []
+  const rentalFeedErrors = []
+  const networksWithFeedWideErrors = {}
+  const tripPlanningErrors = []
   const response = !search ? null : search.response
   if (response) {
+    const showModes = response.length > 1
     response.forEach(res => {
       if (res) {
         if (res.error) {
-          responsesWithTripPlanningErrors.push(res)
+          let msg = res.error.msg
+          // include the modes if doing batch routing
+          if (showModes) {
+            const mode = humanReadableMode(res.requestParameters.mode)
+            msg = `No trip found for ${mode}. ${msg.replace(/^No trip found. /, '')}`
+          }
+          tripPlanningErrors.push({
+            id: res.error.id,
+            modes: res.requestParameters.mode.split(','),
+            msg
+          })
         }
-        if (getFeedWideRentalErrors(res).length > 0) {
-          responsesWithRentalFeedErrors.push(res)
-        }
+        const feedWideRentalErrors = getFeedWideRentalErrors(res)
+        feedWideRentalErrors.forEach(networkWithFeedWideError => {
+          const { network } = networkWithFeedWideError
+          if (!networksWithFeedWideErrors[network]) {
+            rentalFeedErrors.push({
+              msg: `The ${network} network is unavailable at this moment.`,
+              network
+            })
+            networksWithFeedWideErrors[network] = true
+          }
+        })
       }
     })
   }
 
   // generate list so rental errors show up first
-  return [...responsesWithRentalFeedErrors, ...responsesWithTripPlanningErrors]
+  return [...rentalFeedErrors, ...tripPlanningErrors]
 }
 
 /**
- * Gets the active error (first OTP plan response that contains an error). Only
- * one OTP response is expected in itinerary routing, but if batch routing is
- * enabled, multiple responses with errors should be handled.
+ * Gets the active error (first OTP plan response that contains an error). This
+ * should only be used with itinerary routing, not batch routing.
  */
 export function getActiveError (otpState) {
-  const errorResponse = getResponsesWithErrors(otpState)[0]
-  if (errorResponse && errorResponse.error) return errorResponse.error
+  return getResponsesWithErrors(otpState)[0]
+}
+
+/**
+ * Get the appropriate message for a trip planning error given possibly pre-
+ * configured message overrides form the config.
+ */
+export function getErrorMessage (error, errorMessages) {
+  if (!error) return null
+
+  // use the message provided by OTP by default
+  let message = error.msg
+
+  // check for configuration-defined message override
+  if (errorMessages) {
+    const msgConfig = errorMessages.find(m => m.id === error.id)
+    if (msgConfig) {
+      if (error.modes && msgConfig.modes) {
+        for (const mode of msgConfig.modes) {
+          if (error.modes.includes(mode)) {
+            message = msgConfig.msg
+            break
+          }
+        }
+      } else message = msgConfig.msg
+    }
+  }
+
+  return message
 }
 
 /**

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -32,37 +32,31 @@ export function getFeedWideRentalErrors (response) {
   // return empty array if the plan key is not available in the response
   if (!response) return []
 
-  const networksWithFeedWideErrors = []
-
   // get first available rental info (this assumes that there won't be
   // 2 rental info types (for example car rental access and vehicle
   // rental egress))
   const rentalInfo = response.bikeRentalInfo ||
     response.carRentalInfo ||
     response.vehicleRentalInfo
-  if (!rentalInfo) return networksWithFeedWideErrors
+  if (!rentalInfo) return []
 
-  // iterate through all networks to deter
-  Object.keys(rentalInfo).forEach(network => {
-    const networkRentalInfo = rentalInfo[network]
-    if (
+  // iterate through all networks and collect a list of feeds that have a feed-
+  // wide error
+  return Object.entries(rentalInfo)
+    .filter(([network, networkRentalInfo]) =>
       networkRentalInfo.errors &&
-        networkRentalInfo.errors.length > 0
-    ) {
-      if (networkRentalInfo.errors.some(
-        error => error.severity === 'FEED_WIDE'
-      )) {
-        networksWithFeedWideErrors.push({
-          network,
-          networkRentalInfo
-        })
-      }
-    }
-  })
-
-  return networksWithFeedWideErrors
+        networkRentalInfo.errors.some(error => error.severity === 'FEED_WIDE')
+    )
+    .map(([network, networkRentalInfo]) => ({
+      network,
+      networkRentalInfo
+    }))
 }
 
+/**
+ * Converts a comma-separated list of OTP mode values into a human-readable
+ * string
+ */
 function humanReadableMode (modeStr) {
   if (!modeStr) return 'N/A'
   const arr = modeStr.toLowerCase().replace(/_/g, ' ').split(',')

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -131,7 +131,7 @@ export function getActiveError (otpState) {
 
 /**
  * Get the appropriate message for a trip planning error given possibly pre-
- * configured message overrides form the config.
+ * configured message overrides from the config.
  */
 export function getErrorMessage (error, errorMessages) {
   if (!error) return null


### PR DESCRIPTION
This PR changes how error responses are shown in the narrative-itineraries (batch routing).

![Screen Recording 2021-04-19 at 11 31 33 PM](https://user-images.githubusercontent.com/3112493/115348649-bb3d6b00-a167-11eb-8ef2-9e6a9a130d60.gif)

The highlights are as follows:

- Consolidates all batch routing error messages into a list of errors
- Refactors some error display to share common code
- Has the ability to toggle between errors and plannable itineraries
- Has the ability to show feed-wide rental errors (requires https://github.com/ibi-group/OpenTripPlanner/pull/53).

