### PR TITLE
Reset form when switching between call/field trip modules

### DIFF
--- a/lib/actions/call-taker.js
+++ b/lib/actions/call-taker.js
@@ -3,6 +3,8 @@ import { serialize } from 'object-to-formdata'
 import qs from 'qs'
 import { createAction } from 'redux-actions'
 
+import {toggleFieldTrips} from './field-trip'
+import {resetForm} from './form'
 import {searchToQuery, sessionIsInvalid} from '../util/call-taker'
 import {URL_ROOT} from '../util/constants'
 import {getTimestamp} from '../util/state'
@@ -22,6 +24,14 @@ const storeSession = createAction('STORE_SESSION')
 
 export const beginCall = createAction('BEGIN_CALL')
 export const toggleCallHistory = createAction('TOGGLE_CALL_HISTORY')
+
+export function resetAndToggleCallHistory () {
+  return function (dispatch, getState) {
+    dispatch(resetForm(true))
+    dispatch(toggleCallHistory())
+    if (getState().callTaker.fieldTrip.visible) dispatch(toggleFieldTrips())
+  }
+}
 
 /**
  * End the active call and store the queries made during the call.

--- a/lib/actions/call-taker.js
+++ b/lib/actions/call-taker.js
@@ -25,6 +25,9 @@ const storeSession = createAction('STORE_SESSION')
 export const beginCall = createAction('BEGIN_CALL')
 export const toggleCallHistory = createAction('TOGGLE_CALL_HISTORY')
 
+/**
+ * Fully reset form and toggle call history (and close field trips if open).
+ */
 export function resetAndToggleCallHistory () {
   return function (dispatch, getState) {
     dispatch(resetForm(true))

--- a/lib/actions/field-trip.js
+++ b/lib/actions/field-trip.js
@@ -26,6 +26,9 @@ export const setActiveFieldTrip = createAction('SET_ACTIVE_FIELD_TRIP')
 export const setGroupSize = createAction('SET_GROUP_SIZE')
 export const toggleFieldTrips = createAction('TOGGLE_FIELD_TRIPS')
 
+/**
+ * Fully reset form and toggle field trips (and close call history if open).
+ */
 export function resetAndToggleFieldTrips () {
   return async function (dispatch, getState) {
     dispatch(resetForm(true))

--- a/lib/actions/field-trip.js
+++ b/lib/actions/field-trip.js
@@ -6,7 +6,8 @@ import qs from 'qs'
 import { createAction } from 'redux-actions'
 
 import {routingQuery} from './api'
-import {setQueryParam} from './form'
+import {toggleCallHistory} from './call-taker'
+import {resetForm, setQueryParam} from './form'
 import {getGroupSize, getTripFromRequest, sessionIsInvalid} from '../util/call-taker'
 
 if (typeof (fetch) === 'undefined') require('isomorphic-fetch')
@@ -24,6 +25,14 @@ export const setFieldTripFilter = createAction('SET_FIELD_TRIP_FILTER')
 export const setActiveFieldTrip = createAction('SET_ACTIVE_FIELD_TRIP')
 export const setGroupSize = createAction('SET_GROUP_SIZE')
 export const toggleFieldTrips = createAction('TOGGLE_FIELD_TRIPS')
+
+export function resetAndToggleFieldTrips () {
+  return async function (dispatch, getState) {
+    dispatch(resetForm(true))
+    dispatch(toggleFieldTrips())
+    if (getState().callTaker.callHistory.visible) dispatch(toggleCallHistory())
+  }
+}
 
 /**
  * Fetch all field trip requests (as summaries).

--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -1,20 +1,19 @@
+import coreUtils from '@opentripplanner/core-utils'
 import debounce from 'lodash.debounce'
 import isEqual from 'lodash.isequal'
 import moment from 'moment'
 import qs from 'qs'
-import coreUtils from '@opentripplanner/core-utils'
 import { createAction } from 'redux-actions'
 
-import { queryIsValid } from '../util/state'
+import { routingQuery } from './api'
+import { setLocation } from './map'
 import {
   MobileScreens,
   routeTo,
   setMainPanelContent,
   setMobileScreen
-} from '../actions/ui'
-
-import { routingQuery } from './api'
-import { setLocation } from './map'
+} from './ui'
+import { queryIsValid } from '../util/state'
 
 const {
   getDefaultQuery,
@@ -29,6 +28,11 @@ export const setActiveSearch = createAction('SET_ACTIVE_SEARCH')
 export const clearDefaultSettings = createAction('CLEAR_DEFAULT_SETTINGS')
 export const storeDefaultSettings = createAction('STORE_DEFAULT_SETTINGS')
 
+/**
+ * Reset the trip form parameters to their default values.
+ * @param {Boolean} [full=false] if set to true, the from/to locations and URL
+ *  query parameters will also be reset.
+ */
 export function resetForm (full = false) {
   return function (dispatch, getState) {
     const otpState = getState().otp

--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -1,17 +1,20 @@
 import debounce from 'lodash.debounce'
 import isEqual from 'lodash.isequal'
 import moment from 'moment'
+import qs from 'qs'
 import coreUtils from '@opentripplanner/core-utils'
 import { createAction } from 'redux-actions'
 
 import { queryIsValid } from '../util/state'
 import {
   MobileScreens,
+  routeTo,
   setMainPanelContent,
   setMobileScreen
 } from '../actions/ui'
 
 import { routingQuery } from './api'
+import { setLocation } from './map'
 
 const {
   getDefaultQuery,
@@ -26,7 +29,7 @@ export const setActiveSearch = createAction('SET_ACTIVE_SEARCH')
 export const clearDefaultSettings = createAction('CLEAR_DEFAULT_SETTINGS')
 export const storeDefaultSettings = createAction('STORE_DEFAULT_SETTINGS')
 
-export function resetForm () {
+export function resetForm (full = false) {
   return function (dispatch, getState) {
     const otpState = getState().otp
     const { transitModes } = otpState.config.modes
@@ -45,6 +48,19 @@ export function resetForm () {
       // here to match the list of modes, otherwise the form will break.
       options.mode = ['WALK', ...transitModes.map(m => m.mode)].join(',')
       dispatch(settingQueryParam(options))
+    }
+    if (full) {
+      // If fully resetting form, also clear the active search, from/to
+      // locations, and query params.
+      dispatch(clearActiveSearch())
+      dispatch(setLocation({location: null, locationType: 'from'}))
+      dispatch(setLocation({location: null, locationType: 'to'}))
+      // Get query params. Delete everything except sessionId.
+      const params = getUrlParams()
+      for (const key in params) {
+        if (key !== 'sessionId') delete params[key]
+      }
+      dispatch(routeTo('/', qs.stringify(params)))
     }
   }
 }

--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -64,7 +64,7 @@ export function resetForm (full = false) {
       for (const key in params) {
         if (key !== 'sessionId') delete params[key]
       }
-      dispatch(routeTo('/', qs.stringify(params)))
+      dispatch(routeTo('/', qs.stringify(params, { addQueryPrefix: true })))
     }
   }
 }

--- a/lib/components/admin/call-taker-controls.js
+++ b/lib/components/admin/call-taker-controls.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux'
 import * as apiActions from '../../actions/api'
 import * as callTakerActions from '../../actions/call-taker'
 import * as fieldTripActions from '../../actions/field-trip'
+import * as formActions from '../../actions/form'
 import * as uiActions from '../../actions/ui'
 import Icon from '../narrative/icon'
 import {
@@ -64,11 +65,21 @@ class CallTakerControls extends Component {
     )
   }
 
-  _onToggleCallHistory = () => this.props.toggleCallHistory()
+  _onToggleCallHistory = () => {
+    const {callTaker, resetForm, toggleCallHistory, toggleFieldTrips} = this.props
+    resetForm(true)
+    toggleCallHistory()
+    if (callTaker.fieldTrip.visible) toggleFieldTrips()
+  }
 
-  _onToggleFieldTrips = () => this.props.toggleFieldTrips()
+  _onToggleFieldTrips = () => {
+    const {callTaker, resetForm, toggleCallHistory, toggleFieldTrips} = this.props
+    resetForm(true)
+    toggleFieldTrips()
+    if (callTaker.callHistory.visible) toggleCallHistory()
+  }
 
-  _callInProgress = () => Boolean(this.props.activeCall)
+  _callInProgress = () => Boolean(this.props.callTaker.activeCall)
 
   render () {
     const {callTakerEnabled, fieldTripEnabled, session} = this.props
@@ -123,7 +134,7 @@ class CallTakerControls extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    activeCall: state.callTaker.activeCall,
+    callTaker: state.callTaker,
     callTakerEnabled: Boolean(state.otp.config.modules.find(m => m.id === 'call')),
     fieldTripEnabled: Boolean(state.otp.config.modules.find(m => m.id === 'ft')),
     session: state.callTaker.session
@@ -135,6 +146,7 @@ const mapDispatchToProps = {
   endCall: callTakerActions.endCall,
   fetchCalls: callTakerActions.fetchCalls,
   fetchFieldTrips: fieldTripActions.fetchFieldTrips,
+  resetForm: formActions.resetForm,
   routingQuery: apiActions.routingQuery,
   setMainPanelContent: uiActions.setMainPanelContent,
   toggleCallHistory: callTakerActions.toggleCallHistory,

--- a/lib/components/admin/call-taker-controls.js
+++ b/lib/components/admin/call-taker-controls.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux'
 import * as apiActions from '../../actions/api'
 import * as callTakerActions from '../../actions/call-taker'
 import * as fieldTripActions from '../../actions/field-trip'
-import * as formActions from '../../actions/form'
 import * as uiActions from '../../actions/ui'
 import Icon from '../narrative/icon'
 import {
@@ -65,24 +64,16 @@ class CallTakerControls extends Component {
     )
   }
 
-  _onToggleCallHistory = () => {
-    const {callTaker, resetForm, toggleCallHistory, toggleFieldTrips} = this.props
-    resetForm(true)
-    toggleCallHistory()
-    if (callTaker.fieldTrip.visible) toggleFieldTrips()
-  }
-
-  _onToggleFieldTrips = () => {
-    const {callTaker, resetForm, toggleCallHistory, toggleFieldTrips} = this.props
-    resetForm(true)
-    toggleFieldTrips()
-    if (callTaker.callHistory.visible) toggleCallHistory()
-  }
-
   _callInProgress = () => Boolean(this.props.callTaker.activeCall)
 
   render () {
-    const {callTakerEnabled, fieldTripEnabled, session} = this.props
+    const {
+      callTakerEnabled,
+      fieldTripEnabled,
+      session,
+      resetAndToggleCallHistory,
+      resetAndToggleFieldTrips
+    } = this.props
     // If no valid session is found, do not show calltaker controls.
     if (!session) return null
     return (
@@ -105,7 +96,7 @@ class CallTakerControls extends Component {
         {callTakerEnabled &&
           <CallHistoryButton
             className='call-taker-button'
-            onClick={this._onToggleCallHistory}
+            onClick={resetAndToggleCallHistory}
           >
             <Icon
               className='fa-2x'
@@ -118,7 +109,7 @@ class CallTakerControls extends Component {
         {fieldTripEnabled &&
           <FieldTripsButton
             className='call-taker-button'
-            onClick={this._onToggleFieldTrips}
+            onClick={resetAndToggleFieldTrips}
           >
             <Icon
               className='fa-2x'
@@ -146,11 +137,10 @@ const mapDispatchToProps = {
   endCall: callTakerActions.endCall,
   fetchCalls: callTakerActions.fetchCalls,
   fetchFieldTrips: fieldTripActions.fetchFieldTrips,
-  resetForm: formActions.resetForm,
   routingQuery: apiActions.routingQuery,
   setMainPanelContent: uiActions.setMainPanelContent,
-  toggleCallHistory: callTakerActions.toggleCallHistory,
-  toggleFieldTrips: fieldTripActions.toggleFieldTrips
+  resetAndToggleCallHistory: callTakerActions.resetAndToggleCallHistory,
+  resetAndToggleFieldTrips: fieldTripActions.resetAndToggleFieldTrips
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(CallTakerControls)

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,7 +60,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.11.5", "@babel/generator@^7.11.6", "@babel/generator@^7.12.11", "@babel/generator@^7.4.0", "@babel/generator@^7.9.4":
+"@babel/generator@^7.11.6", "@babel/generator@^7.12.11", "@babel/generator@^7.4.0", "@babel/generator@^7.9.4":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.11.tgz#98a7df7b8c358c9a37ab07a24056853016aba3af"
   integrity sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==
@@ -298,7 +298,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.2.tgz#871807f10442b92ff97e4783b9b54f6a0ca812d0"
   integrity sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.5", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.4.3":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.11.5", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.4.3":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.11.tgz#9ce3595bcd74bc5c466905e86c535b8b25011e79"
   integrity sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==
@@ -14527,11 +14527,6 @@ resolve-options@^1.1.0:
   dependencies:
     value-or-function "^3.0.0"
 
-resolve-pathname@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
-  integrity sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==
-
 resolve-pathname@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
@@ -16704,11 +16699,6 @@ validate-npm-package-name@^3.0.0, validate-npm-package-name@~3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
-
-value-equal@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
-  integrity sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw==
 
 value-equal@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR addresses TriMet feedback requesting to reset the trip plan form when switching between the calltaker and field trip modules. To test:
1. Run `yarn start` with TriMet call config.
2. Plan a trip with non-default setting (e.g., walk only as mode).
2. Click the call history button to view the call module.
3. Click the field trip button to switch modules.
4. Observe hidden call module and cleared active search/form.