### PR TITLE
refactor(actions/form): Pass source to routing query.

### DIFF
--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -79,15 +79,17 @@ function getActiveItinerary (otpState) {
  * that are no longer contained in the state we don't confuse the search IDs
  * with search IDs from the new session. If we were to use sequential numbers
  * as IDs, we would run into this problem.
+ * A source argument is also used for other components to identify the originator
+ * of this request and respond accordingly.
  */
-export function routingQuery (searchId = null) {
+export function routingQuery (searchId = null, source) {
   return async function (dispatch, getState) {
     // FIXME: batchId is searchId for now.
     const state = getState()
     const otpState = state.otp
 
     const isNewSearch = !searchId
-    if (isNewSearch) searchId = randId()
+    if (isNewSearch) searchId = randId() + (source || '')
     // Don't permit a routing query if the query is invalid
     if (!queryIsValid(otpState)) {
       console.warn('Query is invalid. Aborting routing query', otpState.currentQuery)

--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -54,10 +54,10 @@ export function resetForm () {
  * parameter-specific actions. If a search ID is provided, a routing query (OTP
  * search) will be kicked off immediately.
  */
-export function setQueryParam (payload, searchId) {
+export function setQueryParam (payload, searchId, source) {
   return function (dispatch, getState) {
     dispatch(settingQueryParam(payload))
-    if (searchId) dispatch(routingQuery(searchId))
+    if (searchId) dispatch(routingQuery(searchId, source))
   }
 }
 
@@ -82,7 +82,7 @@ export function parseUrlQueryString (params = getUrlParams(), source) {
     if (source) searchId += source
     // Convert strings to numbers/objects and dispatch
     planParamsToQueryAsync(planParams, getState().otp.config)
-      .then(query => dispatch(setQueryParam(query, searchId)))
+      .then(query => dispatch(setQueryParam(query, searchId, source)))
   }
 }
 
@@ -98,7 +98,7 @@ let lastDebouncePlanTimeMs
 export function formChanged (oldQuery, newQuery) {
   return function (dispatch, getState) {
     const otpState = getState().otp
-    const { config, currentQuery, ui } = otpState
+    const { activeSearchId, config, currentQuery, ui } = otpState
     const { autoPlan, debouncePlanTimeMs } = config
     const isMobile = coreUtils.ui.isMobile()
     const {
@@ -131,10 +131,23 @@ export function formChanged (oldQuery, newQuery) {
         }
       }
     } else if (queryIsValid(otpState)) {
+      const source = activeSearchId ? activeSearchId.substring(activeSearchId.indexOf('_')) : null
+
       // If replanning trip and query is valid,
       // check if debouncing function needs to be (re)created.
       if (!debouncedPlanTrip || lastDebouncePlanTimeMs !== debouncePlanTimeMs) {
-        debouncedPlanTrip = debounce(() => dispatch(routingQuery()), debouncePlanTimeMs)
+        debouncedPlanTrip = debounce(() => {
+          console.log('Debounce run', activeSearchId)
+          if (source) {
+            // If a "source" is provided in the present search id,
+            // we might want to keep it and not trigger a new call.
+            // (We definitely want to keep it when switching between
+            // call taker call logs).
+            dispatch(routingQuery(activeSearchId, source))
+          } else {
+            dispatch(routingQuery())
+          }
+        }, debouncePlanTimeMs)
         lastDebouncePlanTimeMs = debouncePlanTimeMs
       }
       debouncedPlanTrip()


### PR DESCRIPTION
Introduce a fix to prevent starting Calltaker calls when clicking between itinerary searches in the call logs.