### PR TITLE
Transitive styles

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -71,8 +71,10 @@ map:
       attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
   ### Optional transitive.js (route rendering) properties:
   ### - labeledModes: an array of OTP modes for which the route label should be
-  ###                 rendered on the map, under the condition that a route_short_name is provided
-  ###                 in the GTFS feed for those routes. Example of OTP modes: BUS, RAIL, ...
+  ###                 rendered on the map. Example of OTP modes: BUS, RAIL, ...
+  ###                 The label is rendered under the condition that a route_short_name is provided
+  ###                 in the GTFS feed for those routes, or that a getTransitiveRouteLabel function is defined
+  ###                 in the ComponentContext (see example.js for more).
   ### - styles.labels,
   ###   styles.segment_labels: styles attributes recognized by transitive.js. 
   ###                         For examples of applicable style attributes, see

--- a/example-config.yml
+++ b/example-config.yml
@@ -69,6 +69,29 @@ map:
     - name: Stamen Toner Lite
       url: http://tile.stamen.com/toner-lite/{z}/{x}/{y}.png
       attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
+  ### Optional transitive.js (route rendering) properties:
+  ### - labeledModes: an array of OTP modes for which the route label should be
+  ###                 rendered on the map, under the condition that a route_short_name is provided
+  ###                 in the GTFS feed for those routes. Example of OTP modes: BUS, RAIL, ...
+  ### - styles.labels,
+  ###   styles.segment_labels: styles attributes recognized by transitive.js. 
+  ###                         For examples of applicable style attributes, see
+  ###                         https://github.com/conveyal/transitive.js/blob/master/stories/Transitive.stories.js#L47.
+  # transitive:
+  #   labeledModes:
+  #     - BUS
+  #     - RAIL
+  #   styles:
+  #     labels:
+  #       font-size: 14px
+  #       font-family: Hind, sans-serif
+  #     segment_labels:
+  #       border-color: "#FFFFFF"
+  #       border-radius: 6
+  #       border-width: 2
+  #       color: "#FFE0D0"
+  #       font-family: Hind, sans-serif
+  #       font-size: 18px
 
 # it is possible to leave out a geocoder config entirely. In that case only
 # GPS coordinates will be used when finding the origin/destination.

--- a/example.js
+++ b/example.js
@@ -72,6 +72,7 @@ const TermsOfStorage = () => (
 // define some application-wide components that should be used in
 // various places. The following components can be provided here:
 // - defaultMobileTitle (required)
+// - getTransitiveRouteLabel (optional, with signature itineraryLeg => string)
 // - ItineraryBody (required)
 // - ItineraryFooter (optional)
 // - LegIcon (required)
@@ -84,7 +85,18 @@ const TermsOfStorage = () => (
 // - TermsOfService (required if otpConfig.persistence.strategy === 'otp_middleware')
 // - TermsOfStorage (required if otpConfig.persistence.strategy === 'otp_middleware')
 const components = {
+
   defaultMobileTitle: () => <div className='navbar-title'>OpenTripPlanner</div>,
+  /**
+   * Example of a custom route label provider to pass to @opentripplanner/core-utils/map#itineraryToTransitive.
+   * @param {*} itineraryLeg The OTP itinerary leg for which to obtain a custom route label.
+   * @returns A string with the custom label to display for the given leg, or null to render no label.
+   */
+  getTransitiveRouteLabel: itineraryLeg => {
+    if (itineraryLeg.mode === 'RAIL') return 'Train'
+    if (itineraryLeg.mode === 'BUS') return itineraryLeg.routeShortName
+    return null // null or undefined or empty string will tell transitive-js to not render a route label.
+  },
   ItineraryBody: DefaultItinerary,
   LegIcon: MyLegIcon,
   MainControls: isCallTakerModuleEnabled ? CallTakerControls : null,

--- a/lib/components/map/connected-transitive-overlay.js
+++ b/lib/components/map/connected-transitive-overlay.js
@@ -31,14 +31,16 @@ const mapStateToProps = (state, ownProps) => {
     transitiveData = activeSearch.response.otp
   }
 
+  const { labeledModes, styles } = state.otp.config.map.transitive || {}
+
   return {
     activeItinerary: activeSearch && activeSearch.activeItinerary,
+    labeledModes,
     routingType: activeSearch && activeSearch.query && activeSearch.query.routingType,
+    styles,
     transitiveData,
     visible: true
   }
 }
 
-const mapDispatchToProps = {}
-
-export default connect(mapStateToProps, mapDispatchToProps)(TransitiveCanvasOverlay)
+export default connect(mapStateToProps)(TransitiveCanvasOverlay)

--- a/lib/components/map/connected-transitive-overlay.js
+++ b/lib/components/map/connected-transitive-overlay.js
@@ -1,3 +1,4 @@
+import isEqual from 'lodash.isequal'
 import coreUtils from '@opentripplanner/core-utils'
 import TransitiveCanvasOverlay from '@opentripplanner/transitive-overlay'
 import React, { Component } from 'react'
@@ -12,9 +13,18 @@ import { getActiveItinerary, getActiveItineraries, getActiveSearch } from '../..
 class TransitiveCanvasOverlayWithContext extends Component {
   static contextType = ComponentContext
 
+  shouldComponentUpdate (nextProps) {
+    return (
+      !isEqual(nextProps.activeSearchVisibleItinerary, this.props.activeSearchVisibleItinerary) ||
+      !isEqual(nextProps.activeSearchResponseOtp, this.props.activeSearchResponseOtp)
+    )
+  }
+
   render () {
     const { activeSearchResponseOtp, activeSearchVisibleItinerary, ...otherProps } = this.props
     let transitiveData = null
+    // TODO: prevent itineraryToTransitive() from being called more than needed
+    //       (partially addressed by shouldComponentUpdate)
     if (activeSearchVisibleItinerary) {
       transitiveData = coreUtils.map.itineraryToTransitive(activeSearchVisibleItinerary, null, this.context.getTransitiveRouteLabel)
     } else if (activeSearchResponseOtp) {
@@ -41,7 +51,6 @@ const mapStateToProps = (state, ownProps) => {
       const visibleIndex = visibleItinerary !== undefined && visibleItinerary !== null
         ? visibleItinerary
         : activeItinerary
-      // TODO: prevent itineraryToTransitive() from being called more than needed
       activeSearchVisibleItinerary = itins[visibleIndex] || getActiveItinerary(state.otp)
     } else if (response.otp) {
       activeSearchResponseOtp = response.otp

--- a/lib/components/map/connected-transitive-overlay.js
+++ b/lib/components/map/connected-transitive-overlay.js
@@ -1,35 +1,12 @@
-import TransitiveOverlay from '@opentripplanner/transitive-overlay'
-import React, { Component } from 'react'
+import TransitiveCanvasOverlay from '@opentripplanner/transitive-overlay'
 import { connect } from 'react-redux'
 
 import { getTransitiveData } from '../../util/state'
-
-/**
- * Wrapper for TransitiveOverlay that avoids rerenders by checking transitive
- * data computed from redux store.
- */
-class TransitiveCanvasOverlay extends Component {
-  shouldComponentUpdate (nextProps) {
-    return nextProps.transitiveData !== this.props.transitiveData
-  }
-
-  render () {
-    const { labeledModes, styles, transitiveData } = this.props
-    return (
-      <TransitiveOverlay
-        labeledModes={labeledModes}
-        styles={styles}
-        transitiveData={transitiveData}
-      />
-    )
-  }
-}
 
 // connect to the redux store
 
 const mapStateToProps = (state, ownProps) => {
   const { labeledModes, styles } = state.otp.config.map.transitive || {}
-
   return {
     labeledModes,
     styles,

--- a/lib/components/map/connected-transitive-overlay.js
+++ b/lib/components/map/connected-transitive-overlay.js
@@ -1,46 +1,62 @@
 import coreUtils from '@opentripplanner/core-utils'
 import TransitiveCanvasOverlay from '@opentripplanner/transitive-overlay'
+import React, { Component } from 'react'
 import { connect } from 'react-redux'
 
-import { getActiveSearch, getActiveItinerary, getActiveItineraries } from '../../util/state'
+import { ComponentContext } from '../../util/contexts'
+import { getActiveItinerary, getActiveItineraries, getActiveSearch } from '../../util/state'
+
+/**
+ * Wrapper for TransitiveCanvasOverlay that passes getTransitiveRouteLabel defined in ComponentContext.
+ */
+class TransitiveCanvasOverlayWithContext extends Component {
+  static contextType = ComponentContext
+
+  render () {
+    const { activeSearchResponseOtp, activeSearchVisibleItinerary, ...otherProps } = this.props
+    let transitiveData = null
+    if (activeSearchVisibleItinerary) {
+      transitiveData = coreUtils.map.itineraryToTransitive(activeSearchVisibleItinerary, null, this.context.getTransitiveRouteLabel)
+    } else if (activeSearchResponseOtp) {
+      transitiveData = activeSearchResponseOtp
+    }
+
+    return <TransitiveCanvasOverlay {...otherProps} transitiveData={transitiveData} />
+  }
+}
 
 // connect to the redux store
 
 const mapStateToProps = (state, ownProps) => {
   const activeSearch = getActiveSearch(state.otp)
-  let transitiveData = null
-  if (
-    activeSearch &&
-    activeSearch.query.routingType === 'ITINERARY' &&
-    activeSearch.response &&
-    activeSearch.response.length > 0
-  ) {
-    // FIXME: This may need some simplification.
-    const itins = getActiveItineraries(state.otp)
-    const visibleIndex = activeSearch.visibleItinerary !== undefined && activeSearch.visibleItinerary !== null
-      ? activeSearch.visibleItinerary
-      : activeSearch.activeItinerary
-    // TODO: prevent itineraryToTransitive() from being called more than needed
-    const visibleItinerary = itins[visibleIndex] ? itins[visibleIndex] : getActiveItinerary(state.otp)
-    if (visibleItinerary) transitiveData = coreUtils.map.itineraryToTransitive(visibleItinerary)
-  } else if (
-    activeSearch &&
-    activeSearch.response &&
-    activeSearch.response.otp
-  ) {
-    transitiveData = activeSearch.response.otp
+  const { activeItinerary, query, response, visibleItinerary } = activeSearch || {}
+  const { labeledModes, styles } = state.otp.config.map.transitive || {}
+  let activeSearchVisibleItinerary = null
+  let activeSearchResponseOtp = null
+
+  if (response) {
+    if (query.routingType === 'ITINERARY' && response.length > 0) {
+      // FIXME: This may need some simplification.
+      const itins = getActiveItineraries(state.otp)
+      const visibleIndex = visibleItinerary !== undefined && visibleItinerary !== null
+        ? visibleItinerary
+        : activeItinerary
+      // TODO: prevent itineraryToTransitive() from being called more than needed
+      activeSearchVisibleItinerary = itins[visibleIndex] || getActiveItinerary(state.otp)
+    } else if (response.otp) {
+      activeSearchResponseOtp = response.otp
+    }
   }
 
-  const { labeledModes, styles } = state.otp.config.map.transitive || {}
-
   return {
-    activeItinerary: activeSearch && activeSearch.activeItinerary,
+    activeItinerary,
+    activeSearchResponseOtp,
+    activeSearchVisibleItinerary,
     labeledModes,
-    routingType: activeSearch && activeSearch.query && activeSearch.query.routingType,
+    routingType: query && query.routingType,
     styles,
-    transitiveData,
     visible: true
   }
 }
 
-export default connect(mapStateToProps)(TransitiveCanvasOverlay)
+export default connect(mapStateToProps)(TransitiveCanvasOverlayWithContext)

--- a/lib/components/map/default-map.js
+++ b/lib/components/map/default-map.js
@@ -158,13 +158,6 @@ class DefaultMap extends Component {
           <EndpointsOverlay />
           <RouteViewerOverlay />
           <StopViewerOverlay />
-          {/*
-              HACK: Use the key prop to force a remount and full resizing of transitive
-              if the map container size changes,
-              per https://linguinecode.com/post/4-methods-to-re-render-react-component
-              Without it, transitive resolution will not match the map,
-              and transitive will appear blurry after e.g. the narrative is expanded.
-           */}
           <TransitiveOverlay
             getTransitiveRouteLabel={this.context.getTransitiveRouteLabel}
           />

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -20,7 +20,7 @@ import {
   getActiveSearch,
   getRealtimeEffects,
   getResponsesWithErrors,
-  getVisibleItinerary
+  getVisibleItineraryIndex
 } from '../../util/state'
 
 import SaveTripButton from './save-trip-button'
@@ -288,7 +288,7 @@ const mapStateToProps = (state, ownProps) => {
     sort,
     timeFormat: coreUtils.time.getTimeFormat(state.otp.config),
     useRealtime,
-    visibleItinerary: getVisibleItinerary(state)
+    visibleItinerary: getVisibleItineraryIndex(state)
   }
 }
 

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -19,7 +19,8 @@ import {
   getActiveItineraries,
   getActiveSearch,
   getRealtimeEffects,
-  getResponsesWithErrors
+  getResponsesWithErrors,
+  getVisibleItinerary
 } from '../../util/state'
 
 import SaveTripButton from './save-trip-button'
@@ -287,7 +288,7 @@ const mapStateToProps = (state, ownProps) => {
     sort,
     timeFormat: coreUtils.time.getTimeFormat(state.otp.config),
     useRealtime,
-    visibleItinerary: activeSearch && activeSearch.visibleItinerary
+    visibleItinerary: getVisibleItinerary(state)
   }
 }
 

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -304,21 +304,37 @@ export function getActiveItinerary (otpState) {
     : null
 }
 
+/**
+ * Returns true if the OTP state contains a response within the current active search.
+ * @param {*} state The entire redux state used to obtain the response.
+ */
 function hasResponse (state) {
   const activeSearch = getActiveSearch(state.otp)
   return !!(activeSearch && activeSearch.response)
 }
 
+/**
+ * Returns true if the OTP state contains one or more OTP responses for the current active search.
+ * @param {*} state The entire redux state used to obtain the responses.
+ */
 function hasAtLeastOneResponse (state) {
   const activeSearch = getActiveSearch(state.otp)
   return activeSearch && activeSearch.response && activeSearch.response.length > 0
 }
 
+/**
+ * Returns the raw OTP response for the current active search.
+ * @param {*} state The entire redux state used to obtain the response.
+ */
 function getOtpResponse (state) {
   const activeSearch = getActiveSearch(state.otp)
   return activeSearch && activeSearch.response && activeSearch.response.otp
 }
 
+/**
+ * Returns true if the query routing type specifies 'ITINERARY'.
+ * @param {*} state The entire redux state in which the query is stored.
+ */
 function queryIsItineraryRouting (state) {
   const activeSearch = getActiveSearch(state.otp)
   return activeSearch &&
@@ -326,11 +342,19 @@ function queryIsItineraryRouting (state) {
     activeSearch.query.routingType === 'ITINERARY'
 }
 
-function getVisibleItinerary (state) {
+/**
+ * Returns the visible itinerary to render on the map and in narrative components.
+ * @param {*} state The entire redux state from which to retrieve the itinerary.
+ */
+export function getVisibleItinerary (state) {
   const activeSearch = getActiveSearch(state.otp)
   return activeSearch && activeSearch.visibleItinerary
 }
 
+/**
+ * Returns the itinerary to be passed to the transitive overlay for rendering.
+ * @param {*} state The entire redux state from which to derive the itinerary.
+ */
 function getItineraryToRender (state) {
   const visibleItinerary = getVisibleItinerary(state)
   const activeItinerary = getActiveItinerary(state.otp)
@@ -342,6 +366,10 @@ function getItineraryToRender (state) {
   return itins[visibleIndex] || activeItinerary
 }
 
+/**
+ * Converts an OTP itinerary to the transitive.js format,
+ * using a selector to prevent unnecessary re-renderings of the transitive overlay.
+ */
 export const getTransitiveData = createSelector(
   hasResponse,
   hasAtLeastOneResponse,

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -336,8 +336,7 @@ function itineraryResponseExists (state) {
  * @param {*} state The entire redux state from which to retrieve the itinerary.
  */
 export function getVisibleItineraryIndex (state) {
-  const activeSearch = getActiveSearch(state.otp)
-  return activeSearch && activeSearch.visibleItinerary
+  return getActiveSearch(state.otp)?.visibleItinerary
 }
 
 /**

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -308,18 +308,9 @@ export function getActiveItinerary (otpState) {
  * Returns true if the OTP state contains a response within the current active search.
  * @param {*} state The entire redux state used to obtain the response.
  */
-function hasResponse (state) {
+function activeSearchHasResponse (state) {
   const activeSearch = getActiveSearch(state.otp)
   return !!(activeSearch && activeSearch.response)
-}
-
-/**
- * Returns true if the OTP state contains one or more OTP responses for the current active search.
- * @param {*} state The entire redux state used to obtain the responses.
- */
-function hasAtLeastOneResponse (state) {
-  const activeSearch = getActiveSearch(state.otp)
-  return activeSearch && activeSearch.response && activeSearch.response.length > 0
 }
 
 /**
@@ -327,26 +318,24 @@ function hasAtLeastOneResponse (state) {
  * @param {*} state The entire redux state used to obtain the response.
  */
 function getOtpResponse (state) {
-  const activeSearch = getActiveSearch(state.otp)
-  return activeSearch && activeSearch.response && activeSearch.response.otp
+  return getActiveSearch(state.otp)?.response?.otp
 }
 
 /**
- * Returns true if the query routing type specifies 'ITINERARY'.
+ * Returns true if the query routing type specifies 'ITINERARY' and an OTP response is available.
  * @param {*} state The entire redux state in which the query is stored.
  */
-function queryIsItineraryRouting (state) {
+function itineraryResponseExists (state) {
   const activeSearch = getActiveSearch(state.otp)
-  return activeSearch &&
-    activeSearch.query &&
-    activeSearch.query.routingType === 'ITINERARY'
+  return activeSearch?.response?.length > 0 &&
+    activeSearch?.query?.routingType === 'ITINERARY'
 }
 
 /**
- * Returns the visible itinerary to render on the map and in narrative components.
+ * Returns the visible itinerary index to render on the map and in narrative components.
  * @param {*} state The entire redux state from which to retrieve the itinerary.
  */
-export function getVisibleItinerary (state) {
+export function getVisibleItineraryIndex (state) {
   const activeSearch = getActiveSearch(state.otp)
   return activeSearch && activeSearch.visibleItinerary
 }
@@ -356,14 +345,10 @@ export function getVisibleItinerary (state) {
  * @param {*} state The entire redux state from which to derive the itinerary.
  */
 function getItineraryToRender (state) {
-  const visibleItinerary = getVisibleItinerary(state)
+  const visibleItineraryIndex = getVisibleItineraryIndex(state)
   const activeItinerary = getActiveItinerary(state.otp)
   const itins = getActiveItineraries(state.otp)
-
-  const visibleIndex = visibleItinerary !== undefined && visibleItinerary !== null
-    ? visibleItinerary
-    : activeItinerary
-  return itins[visibleIndex] || activeItinerary
+  return itins[visibleItineraryIndex] || activeItinerary
 }
 
 /**
@@ -371,22 +356,20 @@ function getItineraryToRender (state) {
  * using a selector to prevent unnecessary re-renderings of the transitive overlay.
  */
 export const getTransitiveData = createSelector(
-  hasResponse,
-  hasAtLeastOneResponse,
+  activeSearchHasResponse,
   getOtpResponse,
-  queryIsItineraryRouting,
+  itineraryResponseExists,
   getItineraryToRender,
   (state, props) => props.getTransitiveRouteLabel,
   (
     hasResponse,
-    hasAtLeastOneResponse,
     otpResponse,
-    queryIsItineraryRouting,
+    hasItineraryResponse,
     itineraryToRender,
     getTransitiveRouteLabel
   ) => {
     if (hasResponse) {
-      if (queryIsItineraryRouting && hasAtLeastOneResponse) {
+      if (hasItineraryResponse) {
         return itineraryToRender
           ? coreUtils.map.itineraryToTransitive(
             itineraryToRender,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@auth0/auth0-react": "^1.1.0",
     "@opentripplanner/base-map": "^1.0.5",
-    "@opentripplanner/core-utils": "^3.1.0",
+    "@opentripplanner/core-utils": "^3.1.1",
     "@opentripplanner/endpoints-overlay": "^1.0.6",
     "@opentripplanner/from-to-location-picker": "^1.0.4",
     "@opentripplanner/geocoder": "^1.0.2",
@@ -44,7 +44,7 @@
     "@opentripplanner/route-viewer-overlay": "^1.0.4",
     "@opentripplanner/stop-viewer-overlay": "^1.0.4",
     "@opentripplanner/stops-overlay": "^3.0.2",
-    "@opentripplanner/transitive-overlay": "^1.0.6",
+    "@opentripplanner/transitive-overlay": "^1.0.7",
     "@opentripplanner/trip-details": "^1.1.4",
     "@opentripplanner/trip-form": "^1.0.5",
     "@opentripplanner/trip-viewer-overlay": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@opentripplanner/route-viewer-overlay": "^1.0.4",
     "@opentripplanner/stop-viewer-overlay": "^1.0.4",
     "@opentripplanner/stops-overlay": "^3.0.2",
-    "@opentripplanner/transitive-overlay": "^1.0.5",
+    "@opentripplanner/transitive-overlay": "^1.0.6",
     "@opentripplanner/trip-details": "^1.1.4",
     "@opentripplanner/trip-form": "^1.0.5",
     "@opentripplanner/trip-viewer-overlay": "^1.0.4",
@@ -96,7 +96,7 @@
     "reselect": "^4.0.0",
     "seamless-immutable": "^7.1.3",
     "styled-components": "^5.0.0",
-    "transitive-js": "^0.13.4",
+    "transitive-js": "^0.13.7",
     "velocity-react": "^1.3.3",
     "yup": "^0.29.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,7 +60,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.11.5", "@babel/generator@^7.11.6", "@babel/generator@^7.12.11", "@babel/generator@^7.4.0", "@babel/generator@^7.9.4":
+"@babel/generator@^7.11.6", "@babel/generator@^7.12.11", "@babel/generator@^7.4.0", "@babel/generator@^7.9.4":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.11.tgz#98a7df7b8c358c9a37ab07a24056853016aba3af"
   integrity sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==
@@ -298,7 +298,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.2.tgz#871807f10442b92ff97e4783b9b54f6a0ca812d0"
   integrity sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.5", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.4.3":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.11.5", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.4.3":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.11.tgz#9ce3595bcd74bc5c466905e86c535b8b25011e79"
   integrity sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==
@@ -1631,14 +1631,14 @@
     "@opentripplanner/from-to-location-picker" "^1.0.3"
     "@opentripplanner/zoom-based-markers" "^1.0.1"
 
-"@opentripplanner/transitive-overlay@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/transitive-overlay/-/transitive-overlay-1.0.5.tgz#5dd99f6115acbd4a4e89f05c455a9980a007e973"
-  integrity sha512-2jDli1TFz1MBUx/em934R26OV9bA0wAlgJUL3MZIsLft+BsMf5oY/kVPqbfEMgEVZkPi8cFKJdrkOrLimoKJuA==
+"@opentripplanner/transitive-overlay@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/transitive-overlay/-/transitive-overlay-1.0.6.tgz#73a1cedbc1df897b950f172e4145924462e88217"
+  integrity sha512-JXRJWEhhwl3cYFJVO4EULaXQywHaAr2TtHnbCulCgc+jmKOHQTnyLx2son5OKo3NR8v5FIo2YaleoHczhLhnWA==
   dependencies:
     "@opentripplanner/core-utils" "^3.0.4"
     lodash.isequal "^4.5.0"
-    transitive-js "^0.13.3"
+    transitive-js "^0.13.7"
 
 "@opentripplanner/trip-details@^1.1.4":
   version "1.1.4"
@@ -14532,11 +14532,6 @@ resolve-options@^1.1.0:
   dependencies:
     value-or-function "^3.0.0"
 
-resolve-pathname@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
-  integrity sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==
-
 resolve-pathname@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
@@ -16092,10 +16087,10 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-transitive-js@^0.13.3, transitive-js@^0.13.4:
-  version "0.13.4"
-  resolved "https://registry.yarnpkg.com/transitive-js/-/transitive-js-0.13.4.tgz#2ef9b57f4c0f4ec594f84664300d91a46dfde820"
-  integrity sha512-26lcurtKYJAZJY0kWo3DelTO2ADIZz6uNxrCRUT0hvAcq/lnTLV3WR/vSmR8vsIWRQ10dokJ80VXK0Y3461Jag==
+transitive-js@^0.13.7:
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/transitive-js/-/transitive-js-0.13.7.tgz#d95f1ffa0dfac5c0daed5061db7b62c69062f1c0"
+  integrity sha512-eaHeP1SppQzhZHMYNd3wKf+PFBSYtUE7T89zNTvtbENOWzcIXvvoNBDs0FIs38av9qiv8OmmA/7nqVgNX1cy9A==
   dependencies:
     augment "4.3.0"
     component-each "0.2.6"
@@ -16709,11 +16704,6 @@ validate-npm-package-name@^3.0.0, validate-npm-package-name@~3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
-
-value-equal@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
-  integrity sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw==
 
 value-equal@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1495,10 +1495,25 @@
     "@opentripplanner/core-utils" "^3.0.4"
     prop-types "^15.7.2"
 
-"@opentripplanner/core-utils@^3.0.0", "@opentripplanner/core-utils@^3.0.4", "@opentripplanner/core-utils@^3.1.0":
+"@opentripplanner/core-utils@^3.0.0", "@opentripplanner/core-utils@^3.0.4":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-3.1.0.tgz#4626807893874503c5d365b05e5db4a1b3bf163c"
   integrity sha512-EYhIv6nQdmadmkQumuXGrEwvRrhUl8xDPckSv24y3o9FX7uk8h5Gqe4FPdjnBT1eOj/XUj0/fZzNcETHUvZvUg==
+  dependencies:
+    "@mapbox/polyline" "^1.1.0"
+    "@opentripplanner/geocoder" "^1.0.2"
+    "@turf/along" "^6.0.1"
+    bowser "^2.7.0"
+    lodash.isequal "^4.5.0"
+    moment "^2.24.0"
+    moment-timezone "^0.5.27"
+    prop-types "^15.7.2"
+    qs "^6.9.1"
+
+"@opentripplanner/core-utils@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-3.1.1.tgz#d3582cbfe7a84cd5370d63a857dd26dff17591e5"
+  integrity sha512-20uY3uh2TawPG9PWLLWi5TVJ8F1/bws6cRaRfRNwk11qtdeFQNnVqxZGEd8q1OQSW7UI15cM45SCrK7V7Kxn6A==
   dependencies:
     "@mapbox/polyline" "^1.1.0"
     "@opentripplanner/geocoder" "^1.0.2"
@@ -1631,12 +1646,12 @@
     "@opentripplanner/from-to-location-picker" "^1.0.3"
     "@opentripplanner/zoom-based-markers" "^1.0.1"
 
-"@opentripplanner/transitive-overlay@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/transitive-overlay/-/transitive-overlay-1.0.6.tgz#73a1cedbc1df897b950f172e4145924462e88217"
-  integrity sha512-JXRJWEhhwl3cYFJVO4EULaXQywHaAr2TtHnbCulCgc+jmKOHQTnyLx2son5OKo3NR8v5FIo2YaleoHczhLhnWA==
+"@opentripplanner/transitive-overlay@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/transitive-overlay/-/transitive-overlay-1.0.7.tgz#42706fea6ce3fd3c93b75d272c6da1c00e9044e4"
+  integrity sha512-2QgvfGgq/8B2EpzFAtaxrmexP/k97WHZwKMVho4ZNPiAYfcaE5kRsa1ifWy5A5hHXb36ixAgzfJYiVLeadWbQQ==
   dependencies:
-    "@opentripplanner/core-utils" "^3.0.4"
+    "@opentripplanner/core-utils" "^3.1.1"
     lodash.isequal "^4.5.0"
     transitive-js "^0.13.7"
 


### PR DESCRIPTION
This PR modifies code to use new styling props introduced in `@opentripplanner/core-utils/transitive-overlays` v 1.0.7 (see https://github.com/opentripplanner/otp-ui/pull/246):
- A new, optional section for transitive is added under `example-config.yml#map`.
- A new, optional `getTransitiveRouteLabel` function to render a route label is introduced in the `ComponentContext`,
- Rendering for `TransitiveCanvasOverlay` is updated accordingly.

EDIT: Example configuration for testing: see https://github.com/ibi-group/configurations/pull/141.

EDIT: This PR should fix #374.
