### PR TITLE
Calltaker Recording Tweaks

### DIFF
--- a/example.js
+++ b/example.js
@@ -124,7 +124,7 @@ if (process.env.NODE_ENV === 'development') {
 // set up the Redux store
 const store = createStore(
   combineReducers({
-    callTaker: createCallTakerReducer(),
+    callTaker: createCallTakerReducer(otpConfig),
     otp: createOtpReducer(otpConfig),
     user: createUserReducer(),
     router: connectRouter(history)

--- a/lib/actions/call-taker.js
+++ b/lib/actions/call-taker.js
@@ -37,6 +37,22 @@ export function resetAndToggleCallHistory () {
 }
 
 /**
+ * Start a new call (and show the call history window) if
+ * - the call module is enabled, and
+ * - a call is not in progress, and
+ * - the field trip window is not visible.
+ */
+export function beginCallIfNeeded () {
+  return function (dispatch, getState) {
+    const {callTaker, otp} = getState()
+    const calltakerConfig = otp.config.modules.find(m => m.id === 'call')
+    if (calltakerConfig && !callTaker.activeCall && !callTaker.fieldTrip.visible) {
+      dispatch(beginCall())
+    }
+  }
+}
+
+/**
  * End the active call and store the queries made during the call.
  */
 export function endCall () {

--- a/lib/actions/call-taker.js
+++ b/lib/actions/call-taker.js
@@ -66,6 +66,8 @@ export function endCall () {
         console.error(err)
         alert(`Could not save call: ${JSON.stringify(err)}`)
       })
+    // Clear itineraries shown when ending call.
+    dispatch(resetForm(true))
     dispatch(endingCall())
   }
 }

--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -87,19 +87,15 @@ export function setQueryParam (payload, searchId) {
  * performed according to the behavior of setQueryParam (i.e., if the passed
  * searchId is not null).
  * @param  {Object} params an object containing URL query params
- * @param  {string} source optionally contains the source of the query params
- *                         (e.g., _CALL indicates that the source is from a past
- *                         query made during a call taker session)
  */
-export function parseUrlQueryString (params = getUrlParams(), source) {
+export function parseUrlQueryString (params = getUrlParams()) {
   return function (dispatch, getState) {
     // Filter out the OTP (i.e. non-UI) params and set the initial query
     const planParams = {}
     Object.keys(params).forEach(key => {
       if (!key.startsWith('ui_')) planParams[key] = params[key]
     })
-    let searchId = params.ui_activeSearch || coreUtils.storage.randId()
-    if (source) searchId += source
+    const searchId = params.ui_activeSearch || coreUtils.storage.randId()
     // Convert strings to numbers/objects and dispatch
     planParamsToQueryAsync(planParams, getState().otp.config)
       .then(query => dispatch(setQueryParam(query, searchId)))

--- a/lib/components/admin/query-record.js
+++ b/lib/components/admin/query-record.js
@@ -20,7 +20,7 @@ class QueryRecordLayout extends Component {
     const {parseUrlQueryString} = this.props
     const params = this._getParams()
     params.departArrive = params.arriveBy ? 'ARRIVE' : 'DEPART'
-    parseUrlQueryString(params, '_CALL')
+    parseUrlQueryString(params)
   }
 
   render () {

--- a/lib/components/app/call-taker-panel.js
+++ b/lib/components/app/call-taker-panel.js
@@ -5,6 +5,7 @@ import { Button } from 'react-bootstrap'
 import { connect } from 'react-redux'
 
 import * as apiActions from '../../actions/api'
+import * as callTakerActions from '../../actions/call-taker'
 import * as fieldTripActions from '../../actions/field-trip'
 import * as formActions from '../../actions/form'
 import AddPlaceButton from '../form/add-place-button'
@@ -35,7 +36,7 @@ class CallTakerPanel extends Component {
   }
 
   _planTrip = () => {
-    const {currentQuery, routingQuery} = this.props
+    const {beginCallIfNeeded, currentQuery, routingQuery} = this.props
     const issues = []
     if (!hasValidLocation(currentQuery, 'from')) issues.push('from')
     if (!hasValidLocation(currentQuery, 'to')) issues.push('to')
@@ -45,6 +46,8 @@ class CallTakerPanel extends Component {
       return
     }
     if (this.state.expandAdvanced) this.setState({expandAdvanced: false})
+    // Ensure call is started, or start a new one.
+    beginCallIfNeeded()
     routingQuery()
   }
 
@@ -288,6 +291,7 @@ const mapStateToProps = (state, ownProps) => {
 }
 
 const mapDispatchToProps = {
+  beginCallIfNeeded: callTakerActions.beginCallIfNeeded,
   findRoutes: apiActions.findRoutes,
   routingQuery: apiActions.routingQuery,
   setGroupSize: fieldTripActions.setGroupSize,

--- a/lib/reducers/call-taker.js
+++ b/lib/reducers/call-taker.js
@@ -4,7 +4,8 @@ import moment from 'moment'
 import {constructNewCall} from '../util/call-taker'
 import {FETCH_STATUS} from '../util/constants'
 
-function createCallTakerReducer () {
+function createCallTakerReducer (config) {
+  const calltakerConfig = config.modules.find(m => m.id === 'call')
   const initialState = {
     activeCall: null,
     callHistory: {
@@ -12,7 +13,9 @@ function createCallTakerReducer () {
         status: FETCH_STATUS.UNFETCHED,
         data: []
       },
-      visible: false
+      visible: calltakerConfig &&
+        calltakerConfig.options &&
+        calltakerConfig.options.showCallHistoryOnLoad
     },
     fieldTrip: {
       activeId: null,

--- a/lib/reducers/call-taker.js
+++ b/lib/reducers/call-taker.js
@@ -112,19 +112,6 @@ function createCallTakerReducer (config) {
           return update(state, {
             activeCall: { searches: { $push: [searchId] } }
           })
-        } else if (calltakerConfig && !state.fieldTrip.visible && searchId.indexOf('_CALL') === -1) {
-          // If
-          // - the call module is enabled, and
-          // - a call is not in progress, and
-          // - the field trip window is not visible, and
-          // - regardless of whether the call history is visible or not,
-          // construct new call and add search. Excepting the case where the
-          // searchId contains _CALL, which indicates that a user is viewing a
-          // past call record (and not intending to start a new call session).
-          const newCall = constructNewCall()
-          newCall.searches.push(searchId)
-          // Initialize new call and show call history window.
-          return update(state, { activeCall: { $set: newCall } })
         }
         // Otherwise, ignore.
         return state

--- a/lib/reducers/call-taker.js
+++ b/lib/reducers/call-taker.js
@@ -13,9 +13,7 @@ function createCallTakerReducer (config) {
         status: FETCH_STATUS.UNFETCHED,
         data: []
       },
-      visible: calltakerConfig &&
-        calltakerConfig.options &&
-        calltakerConfig.options.showCallHistoryOnLoad
+      visible: calltakerConfig?.options?.showCallHistoryOnLoad
     },
     fieldTrip: {
       activeId: null,

--- a/lib/reducers/call-taker.js
+++ b/lib/reducers/call-taker.js
@@ -114,8 +114,12 @@ function createCallTakerReducer (config) {
           return update(state, {
             activeCall: { searches: { $push: [searchId] } }
           })
-        } else if (state.callHistory.visible && searchId.indexOf('_CALL') === -1) {
-          // If call not in progress, but history is visible,
+        } else if (calltakerConfig && !state.fieldTrip.visible && searchId.indexOf('_CALL') === -1) {
+          // If
+          // - the call module is enabled, and
+          // - a call is not in progress, and
+          // - the field trip window is not visible, and
+          // - regardless of whether the call history is visible or not,
           // construct new call and add search. Excepting the case where the
           // searchId contains _CALL, which indicates that a user is viewing a
           // past call record (and not intending to start a new call session).


### PR DESCRIPTION
Co-authored with @robertgregg3.

This PR makes the following tweaks to the call UI:
- Clear the map/form when ending a call
- Add an optional config parameter to show the call history window on app load
- Start a call on clicking the Plan button when the call module is enabled, and the field trip window is not shown.
