### PR TITLE
Avoid unnecessary rerenders

### DIFF
--- a/lib/components/map/connected-transitive-overlay.js
+++ b/lib/components/map/connected-transitive-overlay.js
@@ -2,7 +2,7 @@ import TransitiveOverlay from '@opentripplanner/transitive-overlay'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 
-import { getActiveSearch, getTransitiveData } from '../../util/state'
+import { getTransitiveData } from '../../util/state'
 
 /**
  * Wrapper for TransitiveOverlay that avoids rerenders by checking transitive
@@ -14,10 +14,11 @@ class TransitiveCanvasOverlay extends Component {
   }
 
   render () {
-    const { transitiveData, ...otherProps } = this.props
+    const { labeledModes, styles, transitiveData } = this.props
     return (
       <TransitiveOverlay
-        {...otherProps}
+        labeledModes={labeledModes}
+        styles={styles}
         transitiveData={transitiveData}
       />
     )
@@ -27,14 +28,10 @@ class TransitiveCanvasOverlay extends Component {
 // connect to the redux store
 
 const mapStateToProps = (state, ownProps) => {
-  const activeSearch = getActiveSearch(state.otp)
-  const { activeItinerary, query } = activeSearch || {}
   const { labeledModes, styles } = state.otp.config.map.transitive || {}
 
   return {
-    activeItinerary,
     labeledModes,
-    routingType: query && query.routingType,
     styles,
     transitiveData: getTransitiveData(state, ownProps)
   }

--- a/lib/components/map/default-map.js
+++ b/lib/components/map/default-map.js
@@ -1,5 +1,4 @@
 import BaseMap from '@opentripplanner/base-map'
-import coreUtils from '@opentripplanner/core-utils'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
@@ -123,7 +122,6 @@ class DefaultMap extends Component {
       bikeRentalStations,
       carRentalQuery,
       carRentalStations,
-      itineraryView,
       mapConfig,
       mapPopupLocation,
       vehicleRentalQuery,
@@ -169,9 +167,6 @@ class DefaultMap extends Component {
            */}
           <TransitiveOverlay
             getTransitiveRouteLabel={this.context.getTransitiveRouteLabel}
-            key={itineraryView
-              ? `transitive-${itineraryView}`
-              : 'transitive-default'}
           />
           <TripViewerOverlay />
           <ElevationPointMarker />
@@ -223,12 +218,10 @@ const mapStateToProps = (state, ownProps) => {
   const overlays = state.otp.config.map && state.otp.config.map.overlays
     ? state.otp.config.map.overlays
     : []
-  const urlParams = coreUtils.query.getUrlParams()
 
   return {
     bikeRentalStations: state.otp.overlay.bikeRental.stations,
     carRentalStations: state.otp.overlay.carRental.stations,
-    itineraryView: urlParams.ui_itineraryView,
     mapConfig: state.otp.config.map,
     mapPopupLocation: state.otp.ui.mapPopupLocation,
     overlays,


### PR DESCRIPTION
This should fix #374 as extra renders were occurring whenever a new connected-transitive-overlay component was being created each time this UI state changed even though it doesn't appear this needs to happen.

Also, this addresses this comment https://github.com/opentripplanner/otp-react-redux/pull/366#discussion_r640956563.