### PR TITLE
Added the reverse directions button to the Batch routing panel

### DIFF
--- a/lib/components/app/batch-routing-panel.js
+++ b/lib/components/app/batch-routing-panel.js
@@ -36,7 +36,7 @@ class BatchRoutingPanel extends Component {
     const {mobile} = this.props
     const actionText = mobile ? 'tap' : 'click'
     return (
-      <ViewerContainer>
+      <ViewerContainer className='batch-routing-panel'>
         <div className='locations'>
           <LocationField
             inputPlaceholder={`Enter start location or ${actionText} on map...`}

--- a/lib/components/app/batch-routing-panel.js
+++ b/lib/components/app/batch-routing-panel.js
@@ -9,6 +9,7 @@ import LocationField from '../form/connected-location-field'
 import NarrativeItineraries from '../narrative/narrative-itineraries'
 import { getActiveSearch, getShowUserSettings } from '../../util/state'
 import ViewerContainer from '../viewers/viewer-container'
+import switchButton from '../form/switch-button'
 
 // Style for setting the top of the narrative itineraries based on the width of the window.
 // If the window width is less than 1200px (Bootstrap's "large" size), the
@@ -46,6 +47,9 @@ class BatchRoutingPanel extends Component {
           locationType='to'
           showClearButton={!mobile}
         />
+        <div className='switch-button-container'>
+          <switchButton content={<i className='fa fa-exchange fa-rotate-90' />} />
+        </div>
         <BatchSettings />
         {/* FIXME: Add back user settings (home, work, etc.) once connected to
             the middleware persistence.

--- a/lib/components/app/batch-routing-panel.js
+++ b/lib/components/app/batch-routing-panel.js
@@ -9,7 +9,7 @@ import LocationField from '../form/connected-location-field'
 import NarrativeItineraries from '../narrative/narrative-itineraries'
 import { getActiveSearch, getShowUserSettings } from '../../util/state'
 import ViewerContainer from '../viewers/viewer-container'
-import switchButton from '../form/switch-button'
+import SwitchButton from '../form/switch-button'
 
 // Style for setting the top of the narrative itineraries based on the width of the window.
 // If the window width is less than 1200px (Bootstrap's "large" size), the
@@ -36,19 +36,21 @@ class BatchRoutingPanel extends Component {
     const {mobile} = this.props
     const actionText = mobile ? 'tap' : 'click'
     return (
-      <ViewerContainer className='batch-routing-panel'>
-        <LocationField
-          inputPlaceholder={`Enter start location or ${actionText} on map...`}
-          locationType='from'
-          showClearButton
-        />
-        <LocationField
-          inputPlaceholder={`Enter destination or ${actionText} on map...`}
-          locationType='to'
-          showClearButton={!mobile}
-        />
-        <div className='switch-button-container'>
-          <switchButton content={<i className='fa fa-exchange fa-rotate-90' />} />
+      <ViewerContainer>
+        <div className='locations'>
+          <LocationField
+            inputPlaceholder={`Enter start location or ${actionText} on map...`}
+            locationType='from'
+            showClearButton
+          />
+          <LocationField
+            inputPlaceholder={`Enter destination or ${actionText} on map...`}
+            locationType='to'
+            showClearButton={!mobile}
+          />
+          <div className='switch-button-container'>
+            <SwitchButton content={<i className='fa fa-exchange fa-rotate-90' />} />
+          </div>
         </div>
         <BatchSettings />
         {/* FIXME: Add back user settings (home, work, etc.) once connected to


### PR DESCRIPTION
Fix #371

The Batch routing panel was missing the reverse directions button (switchButton).  

It was present on any configuration that **didn't** require batch routing but not present on configurations that do require batch routine.

Here with the FDOT config the reverse direction button was not showing:
![image](https://user-images.githubusercontent.com/4264701/121053400-38be4880-c7b3-11eb-9463-17e75dbc8bab.png)

Where as here on the ATL Config that doesn't use batch routing it is present:
![image](https://user-images.githubusercontent.com/4264701/121050573-969d6100-c7b0-11eb-8022-350b2241f81e.png)

The files that include (or should include) the reverse directions button are: 

- batch-routing-panel.js
- default-main-panel.js

You may need to clear your cache to see the changes. 

I tested on the FDOT and Miami config and the button is now showing. 
![image](https://user-images.githubusercontent.com/4264701/121053132-f432ad00-c7b2-11eb-9f51-613a6ae626e7.png)
