### PR TITLE
Initialize trip monitored days using transit leg serviceDate

### DIFF
--- a/__tests__/util/itinerary.js
+++ b/__tests__/util/itinerary.js
@@ -1,7 +1,7 @@
 /* globals describe, expect, it */
 
 import {
-  getTransitItineraryDefaultMonitoredDays,
+  getItineraryDefaultMonitoredDays,
   itineraryCanBeMonitored
 } from '../../lib/util/itinerary'
 import { WEEKDAYS, WEEKEND_DAYS } from '../../lib/util/monitored-trip'
@@ -85,7 +85,7 @@ describe('util > itinerary', () => {
       })
     })
   })
-  describe('getTransitItineraryDefaultMonitoredDays', () => {
+  describe('getItineraryDefaultMonitoredDays', () => {
     const transitLegWeekday = {
       mode: 'BUS',
       serviceDate: '20210609', // Wednesday
@@ -121,16 +121,31 @@ describe('util > itinerary', () => {
       },
       title: 'should be [\'saturday\', \'sunday\'] for an itinerary starting on a Sunday.'
     }, {
-      expected: null,
+      expected: WEEKDAYS,
       itinerary: {
-        legs: [walkLeg]
+        legs: [walkLeg],
+        startTime: 1623341891000 // Thursday 2021-06-10 12:18 pm EDT
       },
-      title: 'should be null for an itinerary without transit.'
+      title: 'should be [\'monday\' thru \'friday\'] for an itinerary without transit starting on a weekday (fallback case).'
+    }, {
+      expected: WEEKEND_DAYS,
+      itinerary: {
+        legs: [walkLeg],
+        startTime: 1623514691000 // Saturday 2021-06-12 12:18 pm EDT
+      },
+      title: 'should be [\'saturday\', \'sunday\'] for an itinerary without transit starting on a Saturday (fallback case).'
+    }, {
+      expected: WEEKEND_DAYS,
+      itinerary: {
+        legs: [walkLeg],
+        startTime: 1623601091000 // Sunday 2021-06-13 12:18 pm EDT
+      },
+      title: 'should be [\'saturday\', \'sunday\'] for an itinerary without transit starting on a Sunday (fallback case).'
     }]
 
     testCases.forEach(({ expected, itinerary, title }) => {
       it(title, () => {
-        expect(getTransitItineraryDefaultMonitoredDays(itinerary)).toBe(expected)
+        expect(getItineraryDefaultMonitoredDays(itinerary)).toBe(expected)
       })
     })
   })

--- a/__tests__/util/itinerary.js
+++ b/__tests__/util/itinerary.js
@@ -1,6 +1,14 @@
 /* globals describe, expect, it */
 
-import { itineraryCanBeMonitored } from '../../lib/util/itinerary'
+import {
+  getTransitItineraryDefaultMonitoredDays,
+  itineraryCanBeMonitored
+} from '../../lib/util/itinerary'
+import { WEEKDAYS, WEEKEND_DAYS } from '../../lib/util/monitored-trip'
+
+const walkLeg = {
+  mode: 'WALK'
+}
 
 describe('util > itinerary', () => {
   describe('itineraryCanBeMonitored', () => {
@@ -19,9 +27,6 @@ describe('util > itinerary', () => {
     const rentalMicromobilityLeg = {
       mode: 'MICROMOBILITY_RENT',
       rentedVehicle: true
-    }
-    const walkLeg = {
-      mode: 'WALK'
     }
     const rideHailLeg = {
       mode: 'CAR_HAIL',
@@ -77,6 +82,55 @@ describe('util > itinerary', () => {
     testCases.forEach(({ expected, itinerary, title }) => {
       it(title, () => {
         expect(itineraryCanBeMonitored(itinerary)).toBe(expected)
+      })
+    })
+  })
+  describe('getTransitItineraryDefaultMonitoredDays', () => {
+    const transitLegWeekday = {
+      mode: 'BUS',
+      serviceDate: '20210609', // Wendesday
+      transitLeg: true
+    }
+    const transitLegSaturday = {
+      mode: 'BUS',
+      serviceDate: '20210612', // Saturday
+      transitLeg: true
+    }
+    const transitLegSunday = {
+      mode: 'BUS',
+      serviceDate: '20210613', // Sunday
+      transitLeg: true
+    }
+
+    const testCases = [{
+      expected: WEEKDAYS,
+      itinerary: {
+        legs: [walkLeg, transitLegWeekday]
+      },
+      title: 'should be [\'monday\' thru \'friday\'] for an itinerary starting on a weekday.'
+    }, {
+      expected: WEEKEND_DAYS,
+      itinerary: {
+        legs: [walkLeg, transitLegSaturday]
+      },
+      title: 'should be [\'saturday\', \'sunday\'] for an itinerary starting on a Saturday.'
+    }, {
+      expected: WEEKEND_DAYS,
+      itinerary: {
+        legs: [walkLeg, transitLegSunday]
+      },
+      title: 'should be [\'saturday\', \'sunday\'] for an itinerary starting on a Sunday.'
+    }, {
+      expected: null,
+      itinerary: {
+        legs: [walkLeg]
+      },
+      title: 'should be null for an itinerary without transit.'
+    }]
+
+    testCases.forEach(({ expected, itinerary, title }) => {
+      it(title, () => {
+        expect(getTransitItineraryDefaultMonitoredDays(itinerary)).toBe(expected)
       })
     })
   })

--- a/__tests__/util/itinerary.js
+++ b/__tests__/util/itinerary.js
@@ -88,7 +88,7 @@ describe('util > itinerary', () => {
   describe('getTransitItineraryDefaultMonitoredDays', () => {
     const transitLegWeekday = {
       mode: 'BUS',
-      serviceDate: '20210609', // Wendesday
+      serviceDate: '20210609', // Wednesday
       transitLeg: true
     }
     const transitLegSaturday = {

--- a/lib/components/user/monitored-trip/saved-trip-screen.js
+++ b/lib/components/user/monitored-trip/saved-trip-screen.js
@@ -14,7 +14,7 @@ import TripBasicsPane from './trip-basics-pane'
 import TripNotificationsPane from './trip-notifications-pane'
 import TripSummaryPane from './trip-summary-pane'
 import { TRIPS_PATH } from '../../../util/constants'
-import { getTransitItineraryDefaultMonitoredDays } from '../../../util/itinerary'
+import { getItineraryDefaultMonitoredDays } from '../../../util/itinerary'
 import { ALL_DAYS, arrayToDayFields } from '../../../util/monitored-trip'
 import { getActiveItineraries, getActiveSearch } from '../../../util/state'
 import { RETURN_TO_CURRENT_ROUTE } from '../../../util/ui'
@@ -61,7 +61,7 @@ class SavedTripScreen extends Component {
    */
   _createMonitoredTrip = () => {
     const { itinerary, loggedInUser, queryParams } = this.props
-    const monitoredDays = getTransitItineraryDefaultMonitoredDays(itinerary)
+    const monitoredDays = getItineraryDefaultMonitoredDays(itinerary)
     return {
       ...arrayToDayFields(monitoredDays),
       arrivalVarianceMinutesThreshold: 5,

--- a/lib/components/user/monitored-trip/saved-trip-screen.js
+++ b/lib/components/user/monitored-trip/saved-trip-screen.js
@@ -14,7 +14,8 @@ import TripBasicsPane from './trip-basics-pane'
 import TripNotificationsPane from './trip-notifications-pane'
 import TripSummaryPane from './trip-summary-pane'
 import { TRIPS_PATH } from '../../../util/constants'
-import { ALL_DAYS, arrayToDayFields, WEEKDAYS } from '../../../util/monitored-trip'
+import { getTransitItineraryDefaultMonitoredDays } from '../../../util/itinerary'
+import { ALL_DAYS, arrayToDayFields } from '../../../util/monitored-trip'
 import { getActiveItineraries, getActiveSearch } from '../../../util/state'
 import { RETURN_TO_CURRENT_ROUTE } from '../../../util/ui'
 import withLoggedInUserSupport from '../with-logged-in-user-support'
@@ -60,8 +61,9 @@ class SavedTripScreen extends Component {
    */
   _createMonitoredTrip = () => {
     const { itinerary, loggedInUser, queryParams } = this.props
+    const monitoredDays = getTransitItineraryDefaultMonitoredDays(itinerary)
     return {
-      ...arrayToDayFields(WEEKDAYS),
+      ...arrayToDayFields(monitoredDays),
       arrivalVarianceMinutesThreshold: 5,
       departureVarianceMinutesThreshold: 5,
       excludeFederalHolidays: true,

--- a/lib/util/itinerary.js
+++ b/lib/util/itinerary.js
@@ -58,18 +58,20 @@ function getFirstTransitLeg (itinerary) {
 
 /**
  * Returns the set of monitored days that will be initially shown to the user
- * for the given transit itinerary (itinerary with transit leg).
+ * for the given itinerary.
  * @param itinerary The itinerary from which the default monitored days are extracted.
  * @returns ['monday' thru 'friday'] if itinerary happens on a weekday(*),
  *          ['saturday', 'sunday'] if itinerary happens on a saturday/sunday(*).
- * (*) The first transit leg will be used to make the determination.
+ * (*) For transit itineraries, the first transit leg is used to make
+ * the determination. Otherwise, the itinerary startTime is used.
  */
-export function getTransitItineraryDefaultMonitoredDays (itinerary) {
+export function getItineraryDefaultMonitoredDays (itinerary) {
   const firstTransitLeg = getFirstTransitLeg(itinerary)
-  // Assume a transit leg exists.
-  if (!firstTransitLeg) return null
+  const startMoment = firstTransitLeg
+    ? moment(firstTransitLeg.serviceDate, 'YYYYMMDD')
+    : moment(itinerary.startTime)
+  const dayOfWeek = startMoment.day()
 
-  const dayOfWeek = moment(firstTransitLeg.serviceDate, 'YYYYMMDD').day()
   return (dayOfWeek === 0 || dayOfWeek === 6)
     ? WEEKEND_DAYS
     : WEEKDAYS

--- a/lib/util/itinerary.js
+++ b/lib/util/itinerary.js
@@ -1,6 +1,7 @@
 import { latLngBounds } from 'leaflet'
 import moment from 'moment'
 import coreUtils from '@opentripplanner/core-utils'
+import { WEEKDAYS, WEEKEND_DAYS } from './monitored-trip'
 
 export function getLeafletItineraryBounds (itinerary) {
   return latLngBounds(coreUtils.itinerary.getItineraryBounds(itinerary))
@@ -46,4 +47,30 @@ export function itineraryCanBeMonitored (itinerary) {
 
 export function getMinutesUntilItineraryStart (itinerary) {
   return moment(itinerary.startTime).diff(moment(), 'minutes')
+}
+
+/**
+ * Gets the first transit leg of the given itinerary, or null if none found.
+ */
+function getFirstTransitLeg (itinerary) {
+  return itinerary?.legs?.find(leg => leg.transitLeg)
+}
+
+/**
+ * Returns the set of monitored days that will be initially shown to the user
+ * for the given transit itinerary (itinerary with transit leg).
+ * @param itinerary The itinerary from which the default monitored days are extracted.
+ * @returns ['monday' thru 'friday'] if itinerary happens on a weekday(*),
+ *          ['saturday', 'sunday'] if itinerary happens on a saturday/sunday(*).
+ * (*) The first transit leg will be used to make the determination.
+ */
+export function getTransitItineraryDefaultMonitoredDays (itinerary) {
+  const firstTransitLeg = getFirstTransitLeg(itinerary)
+  // Assume a transit leg exists.
+  if (!firstTransitLeg) return null
+
+  const dayOfWeek = moment(firstTransitLeg.serviceDate, 'YYYYMMDD').day()
+  return (dayOfWeek === 0 || dayOfWeek === 6)
+    ? WEEKEND_DAYS
+    : WEEKDAYS
 }

--- a/lib/util/monitored-trip.js
+++ b/lib/util/monitored-trip.js
@@ -1,5 +1,6 @@
 export const WEEKDAYS = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday']
-export const ALL_DAYS = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
+export const WEEKEND_DAYS = ['saturday', 'sunday']
+export const ALL_DAYS = [...WEEKDAYS, ...WEEKEND_DAYS]
 
 /**
  * Extracts the day of week fields of an object (e.g. a monitoredTrip) to an array.


### PR DESCRIPTION
Fix #372.

Monitored days for a given itinerary are proposed to be initialized using the `serviceDate` field of the first transit leg as follows:

| If first transit leg happens on | Then initialize monitored days to | Remarks |
| --- | --- | --- |
| Weekday | Monday thru Friday | currently happens for all cases |
| Saturday | Saturday, Sunday | New case |
| Sunday | Saturday, Sunday | New case |

~(only itineraries with transit legs can be monitored).~ If an itinerary does not have transit, the determination above falls back using the itinerary `startTime`.