### PR TITLE
fix(routingQuery): Properly revert to list view after planning trip.

### DIFF
--- a/__tests__/actions/__snapshots__/api.js.snap
+++ b/__tests__/actions/__snapshots__/api.js.snap
@@ -3,6 +3,9 @@
 exports[`actions > api routingQuery should gracefully handle bad response 1`] = `
 Array [
   Array [
+    [Function],
+  ],
+  Array [
     Object {
       "payload": Object {
         "activeItinerary": 0,
@@ -12,6 +15,9 @@ Array [
       },
       "type": "ROUTING_REQUEST",
     },
+  ],
+  Array [
+    [Function],
   ],
   Array [
     [Function],
@@ -35,6 +41,9 @@ Array [
 
 exports[`actions > api routingQuery should make a query to OTP 1`] = `
 Array [
+  Array [
+    [Function],
+  ],
   Array [
     Object {
       "payload": Object {

--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -95,7 +95,7 @@ export function routingQuery (searchId = null) {
       return
     }
     // Reset itinerary view to default (list view).
-    dispatch(setItineraryView(ItineraryView.DEFAULT))
+    dispatch(setItineraryView(ItineraryView.LIST))
     const activeItinerary = getActiveItinerary(otpState)
     const routingType = otpState.currentQuery.routingType
     // For multiple mode combinations, gather injected params from config/query.

--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -9,6 +9,7 @@ import { createAction } from 'redux-actions'
 import qs from 'qs'
 
 import { rememberPlace } from './map'
+import { ItineraryView, setItineraryView } from './ui'
 import { getStopViewerConfig, queryIsValid } from '../util/state'
 import { getSecureFetchOptions } from '../util/middleware'
 
@@ -93,6 +94,8 @@ export function routingQuery (searchId = null) {
       console.warn('Query is invalid. Aborting routing query', otpState.currentQuery)
       return
     }
+    // Reset itinerary view to default (list view).
+    dispatch(setItineraryView(ItineraryView.DEFAULT))
     const activeItinerary = getActiveItinerary(otpState)
     const routingType = otpState.currentQuery.routingType
     // For multiple mode combinations, gather injected params from config/query.

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -240,8 +240,6 @@ export const MobileScreens = {
  * (currently only used in batch results).
  */
 export const ItineraryView = {
-  /** FIXME: Duplicate value for 'list', DEFAULT and LIST */
-  DEFAULT: 'list',
   /** One itinerary is shown. (In mobile view, the map is hidden.) */
   FULL: 'full',
   /** One itinerary is shown, itinerary and map are focused on a leg. (The mobile view is split.) */
@@ -263,13 +261,13 @@ const setPreviousItineraryView = createAction('SET_PREVIOUS_ITINERARY_VIEW')
 export function setItineraryView (value) {
   return function (dispatch, getState) {
     const urlParams = coreUtils.query.getUrlParams()
-    const prevItineraryView = urlParams.ui_itineraryView || ItineraryView.DEFAULT
+    const prevItineraryView = urlParams.ui_itineraryView || ItineraryView.LIST
 
     // If the itinerary value is changed,
     // set the desired ui query param, or remove it if same as default,
     // and store the current view as previousItineraryView.
     if (value !== urlParams.ui_itineraryView) {
-      if (value !== ItineraryView.DEFAULT) {
+      if (value !== ItineraryView.LIST) {
         urlParams.ui_itineraryView = value
       } else if (urlParams.ui_itineraryView) {
         delete urlParams.ui_itineraryView
@@ -288,7 +286,7 @@ export function setItineraryView (value) {
 export function toggleBatchResultsMap () {
   return function (dispatch, getState) {
     const urlParams = coreUtils.query.getUrlParams()
-    const itineraryView = urlParams.ui_itineraryView || ItineraryView.DEFAULT
+    const itineraryView = urlParams.ui_itineraryView || ItineraryView.LIST
 
     if (itineraryView === ItineraryView.LEG) {
       dispatch(setItineraryView(ItineraryView.LEG_HIDDEN))

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -240,6 +240,7 @@ export const MobileScreens = {
  * (currently only used in batch results).
  */
 export const ItineraryView = {
+  /** FIXME: Duplicate value for 'list', DEFAULT and LIST */
   DEFAULT: 'list',
   /** One itinerary is shown. (In mobile view, the map is hidden.) */
   FULL: 'full',

--- a/lib/components/form/batch-settings.js
+++ b/lib/components/form/batch-settings.js
@@ -114,6 +114,7 @@ class BatchSettings extends Component {
     }
     // Close any expanded panels.
     this.setState({expanded: null})
+
     // Plan trip.
     routingQuery()
   }

--- a/lib/components/mobile/batch-results-screen.js
+++ b/lib/components/mobile/batch-results-screen.js
@@ -135,7 +135,7 @@ const mapStateToProps = (state, ownProps) => {
     activeLeg: activeSearch ? activeSearch.activeLeg : null,
     errors: getResponsesWithErrors(state.otp),
     itineraries: getActiveItineraries(state.otp),
-    itineraryView: urlParams.ui_itineraryView || AULT
+    itineraryView: urlParams.ui_itineraryView || ItineraryView.LIST
   }
 }
 

--- a/lib/components/mobile/batch-results-screen.js
+++ b/lib/components/mobile/batch-results-screen.js
@@ -135,7 +135,7 @@ const mapStateToProps = (state, ownProps) => {
     activeLeg: activeSearch ? activeSearch.activeLeg : null,
     errors: getResponsesWithErrors(state.otp),
     itineraries: getActiveItineraries(state.otp),
-    itineraryView: urlParams.ui_itineraryView || ItineraryView.DEFAULT
+    itineraryView: urlParams.ui_itineraryView || AULT
   }
 }
 

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -220,7 +220,7 @@ const mapStateToProps = (state, ownProps) => {
   const realtimeEffects = getRealtimeEffects(state.otp)
   const useRealtime = state.otp.useRealtime
   const urlParams = coreUtils.query.getUrlParams()
-  const itineraryView = urlParams.ui_itineraryView || ItineraryView.DEFAULT
+  const itineraryView = urlParams.ui_itineraryView || ItineraryView.LIST
   const showDetails = itineraryView === ItineraryView.FULL ||
           itineraryView === ItineraryView.LEG ||
           itineraryView === ItineraryView.LEG_HIDDEN


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description
fix #373 

Currently, if an option is selected, the batch trips Itinerary View will not revert to the default list view but will instead show the full expanded option. To duplicate these steps:
Plan trip: https://atl-rides.ibi-transit.com/#/?fromPlace=Peachtree%20Center&toPlace=Midtown
Select option.
Change date. Click plan button.
View that the first option is selected (we should return to list view).

To fix this, when a valid routingQuery is made, the itinerary view is now set to DEFAULT. Note the ItineraryView options include two options for 'list' view (DEFAULT and LIST). 