### PR TITLE
Separate MailableOption into 2 components

### DIFF
--- a/lib/components/admin/mailables-window.js
+++ b/lib/components/admin/mailables-window.js
@@ -7,7 +7,13 @@ import Icon from '../narrative/icon'
 import {getModuleConfig, isModuleEnabled, Modules} from '../../util/config'
 import {createLetter, LETTER_FIELDS} from '../../util/mailables'
 
-import {MailablesList, WindowHeader} from './styled'
+import {
+  MailablesList,
+  SelectableMailableButton,
+  SelectedMailableContainer,
+  SelectedMailableOptionsContainer,
+  WindowHeader
+} from './styled'
 import DraggableWindow from './draggable-window'
 
 /**
@@ -108,7 +114,7 @@ class MailablesWindow extends Component {
             </h4>
             <MailablesList>
               {selectableMailables.map(mailable => (
-                <MailableOption
+                <SelectableMailable
                   key={mailable.name}
                   mailable={mailable}
                   onClick={this._addMailable} />
@@ -120,7 +126,7 @@ class MailablesWindow extends Component {
             <MailablesList>
               {selectedMailables.length > 0
                 ? selectedMailables.map((mailable, i) => (
-                  <MailableOption
+                  <SelectedMailable
                     index={i}
                     key={mailable.name}
                     mailable={mailable}
@@ -137,7 +143,23 @@ class MailablesWindow extends Component {
   }
 }
 
-class MailableOption extends Component {
+class SelectableMailable extends Component {
+  _onClick = () => this.props.onClick(this.props.mailable)
+
+  render () {
+    const {mailable} = this.props
+    return (
+      <SelectableMailableButton
+        className='clear-button-formatting'
+        onClick={this._onClick}
+      >
+        <MailableLabel mailable={mailable} />
+      </SelectableMailableButton>
+    )
+  }
+}
+
+class SelectedMailable extends Component {
   _changeLargeFormat = (evt) => {
     const {index, updateField} = this.props
     updateField(index, 'largeFormat', evt.target.checked)
@@ -148,74 +170,49 @@ class MailableOption extends Component {
     updateField(index, 'quantity', evt.target.value)
   }
 
-  _onRemove = () => this.props.onRemove && this.props.onRemove(this.props.mailable)
-
-  _onClick = () => this.props.onClick && this.props.onClick(this.props.mailable)
+  _onRemove = () => this.props.onRemove(this.props.mailable)
 
   render () {
-    const {index, mailable, onRemove} = this.props
-    const isSelected = Boolean(onRemove)
-    const containerStyle = {
-      backgroundColor: '#eaeaea',
-      display: 'block',
-      margin: '0px 0px 2px 0px',
-      maxWidth: '290px',
-      padding: '3px 2px',
-      width: '100%'
-    }
-    const label = (
-      <div className='overflow-ellipsis' title={mailable.name}>
-        {mailable.name}
-      </div>
-    )
-    if (isSelected) {
-      const id = `largeFormat-${index}`
-      return (
-        <div style={containerStyle}>
-          {label}
-          <div
-            style={{
-              alignItems: 'center',
-              display: 'flex',
-              justifyContent: 'space-between'
-            }}
-          >
-            <input
-              min={0}
-              onChange={this._changeQuantity}
-              step={1}
-              style={{marginRight: '5px', width: '50px'}}
-              type='number'
-              value={mailable.quantity} />
-            {mailable.largePrint &&
-              <div style={{marginTop: '5px'}}>
-                <input
-                  id={id}
-                  onChange={this._changeLargeFormat}
-                  type='checkbox'
-                  value={mailable.largeFormat} />
-                <label style={{marginLeft: '5px'}} htmlFor={id}>
-                  Large format?
-                </label>
-              </div>
-            }
-            <Button bsStyle='link' onClick={this._onRemove}>
-              Remove
-            </Button>
-          </div>
-        </div>
-      )
-    }
+    const {index, mailable} = this.props
+    const id = `largeFormat-${index}`
     return (
-      <button
-        className='clear-button-formatting'
-        onClick={this._onClick}
-        style={containerStyle}
-      >
-        {label}
-      </button>
+      <SelectedMailableContainer>
+        <MailableLabel mailable={mailable} />
+        <SelectedMailableOptionsContainer>
+          <input
+            min={0}
+            onChange={this._changeQuantity}
+            step={1}
+            style={{marginRight: '5px', width: '50px'}}
+            type='number'
+            value={mailable.quantity} />
+          {mailable.largePrint &&
+            <div style={{marginTop: '5px'}}>
+              <input
+                id={id}
+                onChange={this._changeLargeFormat}
+                type='checkbox'
+                value={mailable.largeFormat} />
+              <label style={{marginLeft: '5px'}} htmlFor={id}>
+                Large format?
+              </label>
+            </div>
+          }
+          <Button bsStyle='link' onClick={this._onRemove}>
+            Remove
+          </Button>
+        </SelectedMailableOptionsContainer>
+      </SelectedMailableContainer>
     )
   }
+}
+
+function MailableLabel ({ mailable }) {
+  return (
+    <div className='overflow-ellipsis' title={mailable.name}>
+      {mailable.name}
+    </div>
+  )
 }
 
 const mapStateToProps = (state, ownProps) => {

--- a/lib/components/admin/styled.js
+++ b/lib/components/admin/styled.js
@@ -163,7 +163,7 @@ export const MailablesList = styled.div`
   overflow-y: scroll;
 `
 
-export const MailableItem = css`
+const mailableItemCss = css`
   background-color: #eaeaea;
   display: block;
   margin: 0px 0px 2px 0px;
@@ -173,11 +173,11 @@ export const MailableItem = css`
 `
 
 export const SelectableMailableButton = styled.button`
-  ${MailableItem}
+  ${mailableItemCss}
 `
 
 export const SelectedMailableContainer = styled.div`
-  ${MailableItem}
+  ${mailableItemCss}
 `
 
 export const SelectedMailableOptionsContainer = styled.div`

--- a/lib/components/admin/styled.js
+++ b/lib/components/admin/styled.js
@@ -1,8 +1,9 @@
 import { Button as BsButton } from 'react-bootstrap'
 import styled, {css} from 'styled-components'
 
-import DefaultCounter from './call-time-counter'
 import Icon from '../narrative/icon'
+
+import DefaultCounter from './call-time-counter'
 
 // Call Taker Controls Components
 
@@ -160,4 +161,27 @@ export const WindowHeader = styled.h3`
 export const MailablesList = styled.div`
   max-height: 120px;
   overflow-y: scroll;
+`
+
+export const MailableItem = css`
+  background-color: #eaeaea;
+  display: block;
+  margin: 0px 0px 2px 0px;
+  max-width: 290px;
+  padding: 3px 2px;
+  width: 100%;
+`
+
+export const SelectableMailableButton = styled.button`
+  ${MailableItem}
+`
+
+export const SelectedMailableContainer = styled.div`
+  ${MailableItem}
+`
+
+export const SelectedMailableOptionsContainer = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
 `


### PR DESCRIPTION
Following up on https://github.com/opentripplanner/otp-react-redux/pull/378#discussion_r658287419, this PR proposes to use 2 separate components for the previous MailableOption. Also, it converts some inline styles to styled components.