### PR TITLE
Calltaker: Print group itineraries

### DIFF
--- a/lib/actions/field-trip.js
+++ b/lib/actions/field-trip.js
@@ -5,22 +5,22 @@ import { serialize } from 'object-to-formdata'
 import qs from 'qs'
 import { createAction } from 'redux-actions'
 
+import {getGroupSize, getTripFromRequest, sessionIsInvalid} from '../util/call-taker'
+
 import {routingQuery} from './api'
 import {toggleCallHistory} from './call-taker'
 import {resetForm, setQueryParam} from './form'
-import {getGroupSize, getTripFromRequest, sessionIsInvalid} from '../util/call-taker'
 
 if (typeof (fetch) === 'undefined') require('isomorphic-fetch')
 
 /// PRIVATE ACTIONS
 
-const receivedFieldTrips = createAction('RECEIVED_FIELD_TRIPS')
-const requestingFieldTrips = createAction('REQUESTING_FIELD_TRIPS')
 const receivedFieldTripDetails = createAction('RECEIVED_FIELD_TRIP_DETAILS')
+const requestingFieldTrips = createAction('REQUESTING_FIELD_TRIPS')
 const requestingFieldTripDetails = createAction('REQUESTING_FIELD_TRIP_DETAILS')
 
 // PUBLIC ACTIONS
-
+export const receivedFieldTrips = createAction('RECEIVED_FIELD_TRIPS')
 export const setFieldTripFilter = createAction('SET_FIELD_TRIP_FILTER')
 export const setActiveFieldTrip = createAction('SET_ACTIVE_FIELD_TRIP')
 export const setGroupSize = createAction('SET_GROUP_SIZE')

--- a/lib/components/admin/field-trip-details.js
+++ b/lib/components/admin/field-trip-details.js
@@ -60,9 +60,9 @@ class FieldTripDetails extends Component {
   }
 
   _renderFooter = () => {
-    const { request, session } = this.props
+    const { request, sessionId } = this.props
     const cancelled = request.status === 'cancelled'
-    const printFieldTripLink = `/#/printFieldTrip/?requestId=${request.id}&sessionId=${session.sessionId}`
+    const printFieldTripLink = `/#/printFieldTrip/?requestId=${request.id}&sessionId=${sessionId}`
     return (
       <div style={{padding: '5px 10px 0px 10px'}}>
         <DropdownButton
@@ -224,7 +224,7 @@ const mapStateToProps = (state, ownProps) => {
     datastoreUrl: state.otp.config.datastoreUrl,
     dateFormat: getDateFormat(state.otp.config),
     request,
-    session: state.callTaker.session
+    sessionId: state.callTaker.session.sessionId
   }
 }
 

--- a/lib/components/admin/field-trip-details.js
+++ b/lib/components/admin/field-trip-details.js
@@ -6,10 +6,17 @@ import { connect } from 'react-redux'
 import styled from 'styled-components'
 
 import * as fieldTripActions from '../../actions/field-trip'
+import Icon from '../narrative/icon'
+import {
+  getGroupSize,
+  GROUP_FIELDS,
+  PAYMENT_FIELDS,
+  TICKET_TYPES
+} from '../../util/call-taker'
+
 import DraggableWindow from './draggable-window'
 import EditableSection from './editable-section'
 import FieldTripNotes from './field-trip-notes'
-import Icon from '../narrative/icon'
 import {
   Bold,
   Button,
@@ -25,12 +32,6 @@ import {
 } from './styled'
 import TripStatus from './trip-status'
 import Updatable from './updatable'
-import {
-  getGroupSize,
-  GROUP_FIELDS,
-  PAYMENT_FIELDS,
-  TICKET_TYPES
-} from '../../util/call-taker'
 
 const WindowHeader = styled(DefaultWindowHeader)`
   margin-bottom: 0px;
@@ -59,7 +60,9 @@ class FieldTripDetails extends Component {
   }
 
   _renderFooter = () => {
-    const cancelled = this.props.request.status === 'cancelled'
+    const { request, session } = this.props
+    const cancelled = request.status === 'cancelled'
+    const printFieldTripLink = `/#/printFieldTrip/?requestId=${request.id}&sessionId=${session.sessionId}`
     return (
       <div style={{padding: '5px 10px 0px 10px'}}>
         <DropdownButton
@@ -80,6 +83,12 @@ class FieldTripDetails extends Component {
             target='_blank'
           >
             <Icon type='file-text-o' /> Receipt link
+          </MenuItem>
+          <MenuItem
+            href={printFieldTripLink}
+            target='_blank'
+          >
+            <Icon type='print' /> Printable trip plan
           </MenuItem>
         </DropdownButton>
         <Button
@@ -214,7 +223,8 @@ const mapStateToProps = (state, ownProps) => {
     currentQuery: state.otp.currentQuery,
     datastoreUrl: state.otp.config.datastoreUrl,
     dateFormat: getDateFormat(state.otp.config),
-    request
+    request,
+    session: state.callTaker.session
   }
 }
 

--- a/lib/components/admin/print-field-trip-layout.js
+++ b/lib/components/admin/print-field-trip-layout.js
@@ -2,87 +2,26 @@ import PrintableItinerary from '@opentripplanner/printable-itinerary'
 import React, { Component } from 'react'
 import { Button } from 'react-bootstrap'
 import { connect } from 'react-redux'
-import styled from 'styled-components'
 
 import * as callTakerActions from '../../actions/call-taker'
 import * as fieldTripActions from '../../actions/field-trip'
-import TripDetails from '../narrative/connected-trip-details'
 import { getTripFromRequest, lzwDecode } from '../../util/call-taker'
 import { ComponentContext } from '../../util/contexts'
 import { addPrintViewClassToRootHtml, clearClassFromRootHtml } from '../../util/print'
 import { getTitle } from '../../util/state'
 
-// Styles specific for rendering PrintFieldTripLayout.
-const PrintLayout = styled.div`
-  font-size: 16px;
-  line-height: 115%;
-  margin: 8px;
-`
-
-const Header = styled.div``
-
-const TripTitle = styled.h1`
-  border-bottom: 3px solid gray;
-  font-size: 30px;
-  font-weight: bold;
-`
-
-const TripInfoList = styled.ul`
-  font-size: 16px;
-  list-style: none;
-  margin-top: 1em;
-  padding: 0;
-`
-
-export const Val = styled.span`
-  :empty:before {
-    content: 'N/A';
-  }
-`
-
-// The styles below mirror those found in OTP native client.
-const TripContainer = styled.div`
-  background: #ddd;
-  margin-top: 1em;
-
-  & > h2 {
-    font-size: 20px;
-    font-weight: bold;    
-    margin: 0;
-    padding: 4px;
-  }
-`
-
-const TripBody = styled.div`
-  padding: 8px;
-`
-
-const ItineraryContainer = styled.div`
-  border: 3px solid #444;
-  margin-top: .5em;
-
-  & > h3 {
-    background: #444;
-    color: white;    
-    font-size: 18px;
-    font-weight: bold;
-    margin: 0;
-    padding: 4px;
-  }
-`
-
-const ItineraryBody = styled.div`
-  background: white;
-  padding: 12px;
-`
-
-const TripSummary = styled(TripDetails)`
-  background: #eee;
-  border: 1px solid #bbb;
-  border-radius: 0;
-  margin-top: 15px;
-  padding: 5px;
-`
+import {
+  Header,
+  ItineraryBody,
+  ItineraryContainer,
+  PrintLayout,
+  TripBody,
+  TripContainer,
+  TripInfoList,
+  TripSummary,
+  TripTitle,
+  Val
+} from './print-styled'
 
 /**
  * Component that renders the print version of field trip itineraries.

--- a/lib/components/admin/print-field-trip-layout.js
+++ b/lib/components/admin/print-field-trip-layout.js
@@ -2,31 +2,91 @@ import PrintableItinerary from '@opentripplanner/printable-itinerary'
 import React, { Component } from 'react'
 import { Button } from 'react-bootstrap'
 import { connect } from 'react-redux'
+import styled from 'styled-components'
 
 import * as callTakerActions from '../../actions/call-taker'
 import * as fieldTripActions from '../../actions/field-trip'
-import DefaultMap from '../map/default-map'
 import TripDetails from '../narrative/connected-trip-details'
 import { getTripFromRequest, lzwDecode } from '../../util/call-taker'
 import { ComponentContext } from '../../util/contexts'
 
-import {
-  Val
-} from './styled'
+// Styles specific for rendering PrintFieldTripLayout.
+const PrintLayout = styled.div`
+  font-size: 16px;
+  line-height: 115%;
+  margin: 8px;
+`
 
+const Header = styled.div``
+
+const TripTitle = styled.h1`
+  border-bottom: 3px solid gray;
+  font-size: 30px;
+  font-weight: bold;
+`
+
+const TripInfoList = styled.ul`
+  font-size: 16px;
+  list-style: none;
+  margin-top: 1em;
+  padding: 0;
+`
+
+export const Val = styled.span`
+  :empty:before {
+    content: 'N/A';
+  }
+`
+
+// The styles below mirror those found in OTP native client.
+const TripContainer = styled.div`
+  background: #ddd;
+  margin-top: 1em;
+
+  & > h2 {
+    font-size: 20px;
+    font-weight: bold;    
+    margin: 0;
+    padding: 4px;
+  }
+`
+
+const TripBody = styled.div`
+  padding: 8px;
+`
+
+const ItineraryContainer = styled.div`
+  border: 3px solid #444;
+  margin-top: .5em;
+
+  & > h3 {
+    background: #444;
+    color: white;    
+    font-size: 18px;
+    font-weight: bold;
+    margin: 0;
+    padding: 4px;
+  }
+`
+
+const ItineraryBody = styled.div`
+  background: white;
+  padding: 12px;
+`
+
+const TripSummary = styled(TripDetails)`
+  background: #eee;
+  border: 1px solid #bbb;
+  border-radius: 0;
+  margin-top: 15px;
+  padding: 5px;
+`
+
+/**
+ * Component that renders the print version of field trip itineraries.
+ */
 class PrintFieldTripLayout extends Component {
   static contextType = ComponentContext
-
-  constructor (props) {
-    super(props)
-    this.state = {
-      mapVisible: true
-    }
-  }
-
-  _toggleMap = () => {
-    this.setState({ mapVisible: !this.state.mapVisible })
-  }
 
   _print = () => {
     window.print()
@@ -46,10 +106,9 @@ class PrintFieldTripLayout extends Component {
   async componentDidUpdate (prevProps) {
     const { fetchFieldTrips, fetchFieldTripDetails, requestId, session } = this.props
     if (!prevProps.session && session) {
-      // When session is set
-      // Load all field trips
+      // When session is set, load all field trips,
+      // then load details for field trip per request id.
       await fetchFieldTrips()
-      // Load details for field trip per request id.
       fetchFieldTripDetails(requestId)
     }
   }
@@ -69,6 +128,7 @@ class PrintFieldTripLayout extends Component {
 
     const {
       address,
+      classpassId,
       emailAddress,
       endLocation,
       faxNumber,
@@ -82,71 +142,67 @@ class PrintFieldTripLayout extends Component {
       timeStamp
     } = request
 
-    const outboundTrip = getTripFromRequest(request, true)
-    // const inboundTrip = getTripFromRequest(request, false)
+    // Outbound/inbound template
+    const tripStructure = [
+      {
+        title: 'Outbound Trip (to Destination)',
+        trip: getTripFromRequest(request, true),
+        tripAbsentMessage: 'No Outbound Trip Planned'
+      },
+      {
+        title: 'Inbound Trip (from Destination)',
+        trip: getTripFromRequest(request, false),
+        tripAbsentMessage: 'No Inbound Trip Planned'
+      }
+    ]
 
     return (
-      <div className='otp print-layout'>
-        {/* The header bar, including the Toggle Map and Print buttons */}
-        <div className='header'>
-          <div style={{ float: 'right' }}>
-            <Button bsSize='small' onClick={this._toggleMap}>
-              <i className='fa fa-map' /> Toggle Map
-            </Button>
-            {' '}
-            <Button bsSize='small' onClick={this._print}>
-              <i className='fa fa-print' /> Print
-            </Button>
-          </div>
-          <h1>Field Trip Plan: {schoolName} to {endLocation}</h1>
-        </div>
-        <div>
-          <ul style={{ listStyle: 'none', padding: 0 }}>
-            <li><b>Teacher</b>: <Val>{teacherName}</Val> ({schoolName}, Grade: <Val>{grade}</Val>)</li>
-            <li><b>Teacher Address</b>: <Val>{address}</Val></li>
-            <li><b>Phone</b>: <Val>{phoneNumber}</Val> / Fax: <Val>{faxNumber}</Val></li>
-            <li><b>Email</b>: <Val>{emailAddress}</Val></li>
-            <li><b>Students Age 7 and Over</b>: {numStudents || 0}</li>
-            <li><b>Students Age 6 and Under</b>: {numFreeStudents || 0}</li>
-            <li><b>Chaperones</b>: {numChaperones || 0}</li>
-            <li><i>Request submitted: {timeStamp}</i></li>
-          </ul>
-        </div>
+      <PrintLayout>
+        <Header>
+          <Button bsSize='small' onClick={this._print} style={{ float: 'right' }}>
+            <i className='fa fa-print' /> Print
+          </Button>
+          <TripTitle>Field Trip Plan: {schoolName} to {endLocation}</TripTitle>
+        </Header>
+        <TripInfoList>
+          <li><b>Teacher</b>: <Val>{teacherName}</Val> ({schoolName}, Grade: <Val>{grade}</Val>)</li>
+          <li><b>Teacher Address</b>: <Val>{address}</Val></li>
+          <li><b>Phone</b>: <Val>{phoneNumber}</Val> / <b>Fax</b>: <Val>{faxNumber}</Val></li>
+          <li><b>Email</b>: <Val>{emailAddress}</Val></li>
+          <li><b>Students Age 7 and Over</b>: {numStudents || 0}</li>
+          <li><b>Students Age 6 and Under</b>: {numFreeStudents || 0}</li>
+          <li><b>Chaperones</b>: {numChaperones || 0}</li>
+          {classpassId && <li><b>Class Pass Hop Card #</b>: {classpassId}</li>}
+          <li><i>Request submitted: {timeStamp}</i></li>
+        </TripInfoList>
 
-        <div>
-          <h2>Outbound Trip (to Destination)</h2>
-          {/*
-          <p><i>No Outbound Trip Planned</i></p>
-          */}
-          {outboundTrip
-            ? outboundTrip.groupItineraries?.map((groupItin, i) => {
-              const itinerary = JSON.parse(lzwDecode(groupItin.itinData))
-              return (
-                <div key={i}>
-                  <PrintableItinerary
-                    config={config}
-                    itinerary={itinerary}
-                    LegIcon={LegIcon}
-                  />
-                  <TripDetails itinerary={itinerary} />
-                </div>
-              )
-            })
-            : <p><i>No Outbound Trip Planned</i></p>
-          }
-        </div>
-        <div>
-          <h2>Inbound Trip (to Destination)</h2>
-          <p><i>No Inbound Trip Planned</i></p>
-        </div>
-
-        {/* The map, if visible */}
-        {this.state.mapVisible &&
-          <div className='map-container'>
-            <DefaultMap />
-          </div>
-        }
-      </div>
+        {tripStructure.map(({ title, trip, tripAbsentMessage }) => (
+          <TripContainer>
+            <h2>{title}</h2>
+            {trip
+              ? trip.groupItineraries?.map((groupItin, i) => {
+                const itinerary = JSON.parse(lzwDecode(groupItin.itinData))
+                return (
+                  <TripBody key={i}>
+                    <ItineraryContainer>
+                      <h3>{groupItin.passengers} passengers on following itinerary:</h3>
+                      <ItineraryBody>
+                        <PrintableItinerary
+                          config={config}
+                          itinerary={itinerary}
+                          LegIcon={LegIcon}
+                        />
+                        <TripSummary itinerary={itinerary} />
+                      </ItineraryBody>
+                    </ItineraryContainer>
+                  </TripBody>
+                )
+              })
+              : <TripBody><i>{tripAbsentMessage}</i></TripBody>
+            }
+          </TripContainer>
+        ))}
+      </PrintLayout>
     )
   }
 }

--- a/lib/components/admin/print-field-trip-layout.js
+++ b/lib/components/admin/print-field-trip-layout.js
@@ -11,8 +11,8 @@ import { addPrintViewClassToRootHtml, clearClassFromRootHtml } from '../../util/
 
 import {
   Header,
-  ItineraryBody,
   ItineraryContainer,
+  PrintableItineraryContainer,
   PrintLayout,
   TripBody,
   TripContainer,
@@ -140,14 +140,14 @@ class PrintFieldTripLayout extends Component {
                   <TripBody key={i}>
                     <ItineraryContainer>
                       <h3>{groupItin.passengers} passengers on following itinerary:</h3>
-                      <ItineraryBody>
+                      <PrintableItineraryContainer>
                         <PrintableItinerary
                           config={config}
                           itinerary={itinerary}
                           LegIcon={LegIcon}
                         />
                         <TripSummary itinerary={itinerary} />
-                      </ItineraryBody>
+                      </PrintableItineraryContainer>
                     </ItineraryContainer>
                   </TripBody>
                 )

--- a/lib/components/admin/print-field-trip-layout.js
+++ b/lib/components/admin/print-field-trip-layout.js
@@ -1,0 +1,171 @@
+// import PrintableItinerary from '@opentripplanner/printable-itinerary'
+import React, { Component } from 'react'
+import { Button } from 'react-bootstrap'
+import { connect } from 'react-redux'
+
+import * as callTakerActions from '../../actions/call-taker'
+import * as fieldTripActions from '../../actions/field-trip'
+import DefaultMap from '../map/default-map'
+// import TripDetails from '../narrative/connected-trip-details'
+// import { getTripFromRequest } from '../../util/call-taker'
+import { ComponentContext } from '../../util/contexts'
+
+import {
+  Val
+} from './styled'
+
+class PrintFieldTripLayout extends Component {
+  static contextType = ComponentContext
+
+  constructor (props) {
+    super(props)
+    this.state = {
+      mapVisible: true
+    }
+  }
+
+  _toggleMap = () => {
+    this.setState({ mapVisible: !this.state.mapVisible })
+  }
+
+  _print = () => {
+    window.print()
+  }
+
+  componentDidMount () {
+    const { initializeModules } = this.props
+    // Add print-view class to html tag to ensure that iOS scroll fix only applies
+    // to non-print views.
+    const root = document.getElementsByTagName('html')[0]
+    root.setAttribute('class', 'print-view')
+
+    // Load call-taker/field-trip functionality (performs a fetch).
+    initializeModules()
+  }
+
+  async componentDidUpdate (prevProps) {
+    const { fetchFieldTrips, fetchFieldTripDetails, requestId, session } = this.props
+    if (!prevProps.session && session) {
+      // When session is set
+      // Load all field trips
+      await fetchFieldTrips()
+      // Load details for field trip per request id.
+      fetchFieldTripDetails(requestId)
+    }
+  }
+
+  /**
+   * Remove class attribute from html tag on clean up.
+   */
+  componentWillUnmount () {
+    const root = document.getElementsByTagName('html')[0]
+    root.removeAttribute('class')
+  }
+
+  render () {
+    const { request } = this.props
+    // const { LegIcon } = this.context
+    if (!request) return null
+
+    const {
+      address,
+      emailAddress,
+      endLocation,
+      faxNumber,
+      grade,
+      numChaperones,
+      numFreeStudents,
+      numStudents,
+      phoneNumber,
+      schoolName,
+      teacherName,
+      timeStamp
+    } = request
+
+    // const outboundTrip = getTripFromRequest(request, true)
+    // const inboundTrip = getTripFromRequest(request, false)
+
+    return (
+      <div className='otp print-layout'>
+        {/* The header bar, including the Toggle Map and Print buttons */}
+        <div className='header'>
+          <div style={{ float: 'right' }}>
+            <Button bsSize='small' onClick={this._toggleMap}>
+              <i className='fa fa-map' /> Toggle Map
+            </Button>
+            {' '}
+            <Button bsSize='small' onClick={this._print}>
+              <i className='fa fa-print' /> Print
+            </Button>
+          </div>
+          <h1>Field Trip Plan: {schoolName} to {endLocation}</h1>
+        </div>
+        <div>
+          <ul style={{ listStyle: 'none', padding: 0 }}>
+            <li><b>Teacher</b>: <Val>{teacherName}</Val> ({schoolName}, Grade: <Val>{grade}</Val>)</li>
+            <li><b>Teacher Address</b>: <Val>{address}</Val></li>
+            <li><b>Phone</b>: <Val>{phoneNumber}</Val> / Fax: <Val>{faxNumber}</Val></li>
+            <li><b>Email</b>: <Val>{emailAddress}</Val></li>
+            <li><b>Students Age 7 and Over</b>: {numStudents || 0}</li>
+            <li><b>Students Age 6 and Under</b>: {numFreeStudents || 0}</li>
+            <li><b>Chaperones</b>: {numChaperones || 0}</li>
+            <li><i>Request submitted: {timeStamp}</i></li>
+          </ul>
+        </div>
+
+        <div>
+          <h2>Outbound Trip (to Destination)</h2>
+          <p><i>No Outbound Trip Planned</i></p>
+          {/* outboundTrip
+            ? outboundTrip.groupItineraries?.map((groupItin, i) => {
+              //const itinerary = JSON.parse(groupItin.itinData)
+              return (
+                <div key={i}>
+                  <PrintableItinerary
+                    config={config}
+                    //itinerary={itinerary}
+                    LegIcon={LegIcon}
+                  />
+                  <TripDetails itinerary={itinerary} />
+                </div>
+              )
+            })
+            : <p><i>No Outbound Trip Planned</i></p>
+          */}
+        </div>
+        <div>
+          <h2>Inbound Trip (to Destination)</h2>
+          <p><i>No Inbound Trip Planned</i></p>
+        </div>
+
+        {/* The map, if visible */}
+        {this.state.mapVisible &&
+          <div className='map-container'>
+            <DefaultMap />
+          </div>
+        }
+      </div>
+    )
+  }
+}
+
+// connect to the redux store
+
+const mapStateToProps = (state, ownProps) => {
+  const requestId = parseInt(state.router.location.query.requestId)
+  const { requests } = state.callTaker.fieldTrip
+  const request = requests.data.find(req => req.id === requestId)
+  return {
+    request,
+    requestId,
+    session: state.callTaker.session
+  }
+}
+
+const mapDispatchToProps = {
+  fetchFieldTripDetails: fieldTripActions.fetchFieldTripDetails,
+  fetchFieldTrips: fieldTripActions.fetchFieldTrips,
+  initializeModules: callTakerActions.initializeModules
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(PrintFieldTripLayout)

--- a/lib/components/admin/print-field-trip-layout.js
+++ b/lib/components/admin/print-field-trip-layout.js
@@ -8,7 +8,6 @@ import * as fieldTripActions from '../../actions/field-trip'
 import { getTripFromRequest, lzwDecode } from '../../util/call-taker'
 import { ComponentContext } from '../../util/contexts'
 import { addPrintViewClassToRootHtml, clearClassFromRootHtml } from '../../util/print'
-import { getTitle } from '../../util/state'
 
 import {
   Header,
@@ -34,20 +33,23 @@ class PrintFieldTripLayout extends Component {
   }
 
   componentDidMount () {
-    const { initializeModules, title } = this.props
+    const { initializeModules } = this.props
     // Add print-view class to html tag to ensure that iOS scroll fix only applies
     // to non-print views.
     addPrintViewClassToRootHtml()
-
-    // Set window title (appears in print headings)
-    document.title = title
 
     // Load call-taker/field-trip functionality (performs a fetch).
     initializeModules()
   }
 
   componentDidUpdate (prevProps) {
-    const { fetchFieldTripDetails, receivedFieldTrips, requestId, session } = this.props
+    const {
+      fetchFieldTripDetails,
+      receivedFieldTrips,
+      request,
+      requestId,
+      session
+    } = this.props
     if (!prevProps.session && session) {
       // When session is set,
       // create a placeholder in the calltaker redux state that has just one request
@@ -59,6 +61,13 @@ class PrintFieldTripLayout extends Component {
         }]
       })
       fetchFieldTripDetails(requestId)
+    }
+
+    if (request && request !== prevProps.request) {
+      // Set window title when request has fully loaded
+      // (appears in print headings)
+      const { endLocation, schoolName } = request
+      document.title = `Field Trip: ${schoolName} to ${endLocation}`
     }
   }
 
@@ -162,8 +171,7 @@ const mapStateToProps = (state, ownProps) => {
     config: state.otp.config,
     request,
     requestId,
-    session: state.callTaker.session,
-    title: getTitle(state)
+    session: state.callTaker.session
   }
 }
 

--- a/lib/components/admin/print-field-trip-layout.js
+++ b/lib/components/admin/print-field-trip-layout.js
@@ -9,6 +9,7 @@ import * as fieldTripActions from '../../actions/field-trip'
 import TripDetails from '../narrative/connected-trip-details'
 import { getTripFromRequest, lzwDecode } from '../../util/call-taker'
 import { ComponentContext } from '../../util/contexts'
+import { addPrintViewClassToRootHtml, clearClassFromRootHtml } from '../../util/print'
 import { getTitle } from '../../util/state'
 
 // Styles specific for rendering PrintFieldTripLayout.
@@ -97,8 +98,7 @@ class PrintFieldTripLayout extends Component {
     const { initializeModules, title } = this.props
     // Add print-view class to html tag to ensure that iOS scroll fix only applies
     // to non-print views.
-    const root = document.getElementsByTagName('html')[0]
-    root.setAttribute('class', 'print-view')
+    addPrintViewClassToRootHtml()
 
     // Set window title (appears in print headings)
     document.title = title
@@ -117,12 +117,8 @@ class PrintFieldTripLayout extends Component {
     }
   }
 
-  /**
-   * Remove class attribute from html tag on clean up.
-   */
   componentWillUnmount () {
-    const root = document.getElementsByTagName('html')[0]
-    root.removeAttribute('class')
+    clearClassFromRootHtml()
   }
 
   render () {

--- a/lib/components/admin/print-field-trip-layout.js
+++ b/lib/components/admin/print-field-trip-layout.js
@@ -107,12 +107,18 @@ class PrintFieldTripLayout extends Component {
     initializeModules()
   }
 
-  async componentDidUpdate (prevProps) {
-    const { fetchFieldTrips, fetchFieldTripDetails, requestId, session } = this.props
+  componentDidUpdate (prevProps) {
+    const { fetchFieldTripDetails, receivedFieldTrips, requestId, session } = this.props
     if (!prevProps.session && session) {
-      // When session is set, load all field trips,
-      // then load details for field trip per request id.
-      await fetchFieldTrips()
+      // When session is set,
+      // create a placeholder in the calltaker redux state that has just one request
+      // for fetching/receiving the details of the field trip per request id.
+      receivedFieldTrips({
+        fieldTrips: [{
+          endTime: 0,
+          id: requestId
+        }]
+      })
       fetchFieldTripDetails(requestId)
     }
   }
@@ -176,8 +182,8 @@ class PrintFieldTripLayout extends Component {
           <li><i>Request submitted: {timeStamp}</i></li>
         </TripInfoList>
 
-        {tripStructure.map(({ title, trip, tripAbsentMessage }) => (
-          <TripContainer>
+        {tripStructure.map(({ title, trip, tripAbsentMessage }, i) => (
+          <TripContainer key={i}>
             <h2>{title}</h2>
             {trip
               ? trip.groupItineraries?.map((groupItin, i) => {
@@ -224,8 +230,8 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = {
   fetchFieldTripDetails: fieldTripActions.fetchFieldTripDetails,
-  fetchFieldTrips: fieldTripActions.fetchFieldTrips,
-  initializeModules: callTakerActions.initializeModules
+  initializeModules: callTakerActions.initializeModules,
+  receivedFieldTrips: fieldTripActions.receivedFieldTrips
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(PrintFieldTripLayout)

--- a/lib/components/admin/print-field-trip-layout.js
+++ b/lib/components/admin/print-field-trip-layout.js
@@ -9,6 +9,7 @@ import * as fieldTripActions from '../../actions/field-trip'
 import TripDetails from '../narrative/connected-trip-details'
 import { getTripFromRequest, lzwDecode } from '../../util/call-taker'
 import { ComponentContext } from '../../util/contexts'
+import { getTitle } from '../../util/state'
 
 // Styles specific for rendering PrintFieldTripLayout.
 const PrintLayout = styled.div`
@@ -93,11 +94,14 @@ class PrintFieldTripLayout extends Component {
   }
 
   componentDidMount () {
-    const { initializeModules } = this.props
+    const { initializeModules, title } = this.props
     // Add print-view class to html tag to ensure that iOS scroll fix only applies
     // to non-print views.
     const root = document.getElementsByTagName('html')[0]
     root.setAttribute('class', 'print-view')
+
+    // Set window title (appears in print headings)
+    document.title = title
 
     // Load call-taker/field-trip functionality (performs a fetch).
     initializeModules()
@@ -217,7 +221,8 @@ const mapStateToProps = (state, ownProps) => {
     config: state.otp.config,
     request,
     requestId,
-    session: state.callTaker.session
+    session: state.callTaker.session,
+    title: getTitle(state)
   }
 }
 

--- a/lib/components/admin/print-field-trip-layout.js
+++ b/lib/components/admin/print-field-trip-layout.js
@@ -1,4 +1,4 @@
-// import PrintableItinerary from '@opentripplanner/printable-itinerary'
+import PrintableItinerary from '@opentripplanner/printable-itinerary'
 import React, { Component } from 'react'
 import { Button } from 'react-bootstrap'
 import { connect } from 'react-redux'
@@ -6,8 +6,8 @@ import { connect } from 'react-redux'
 import * as callTakerActions from '../../actions/call-taker'
 import * as fieldTripActions from '../../actions/field-trip'
 import DefaultMap from '../map/default-map'
-// import TripDetails from '../narrative/connected-trip-details'
-// import { getTripFromRequest } from '../../util/call-taker'
+import TripDetails from '../narrative/connected-trip-details'
+import { getTripFromRequest, lzwDecode } from '../../util/call-taker'
 import { ComponentContext } from '../../util/contexts'
 
 import {
@@ -63,8 +63,8 @@ class PrintFieldTripLayout extends Component {
   }
 
   render () {
-    const { request } = this.props
-    // const { LegIcon } = this.context
+    const { config, request } = this.props
+    const { LegIcon } = this.context
     if (!request) return null
 
     const {
@@ -82,7 +82,7 @@ class PrintFieldTripLayout extends Component {
       timeStamp
     } = request
 
-    // const outboundTrip = getTripFromRequest(request, true)
+    const outboundTrip = getTripFromRequest(request, true)
     // const inboundTrip = getTripFromRequest(request, false)
 
     return (
@@ -115,15 +115,17 @@ class PrintFieldTripLayout extends Component {
 
         <div>
           <h2>Outbound Trip (to Destination)</h2>
+          {/*
           <p><i>No Outbound Trip Planned</i></p>
-          {/* outboundTrip
+          */}
+          {outboundTrip
             ? outboundTrip.groupItineraries?.map((groupItin, i) => {
-              //const itinerary = JSON.parse(groupItin.itinData)
+              const itinerary = JSON.parse(lzwDecode(groupItin.itinData))
               return (
                 <div key={i}>
                   <PrintableItinerary
                     config={config}
-                    //itinerary={itinerary}
+                    itinerary={itinerary}
                     LegIcon={LegIcon}
                   />
                   <TripDetails itinerary={itinerary} />
@@ -131,7 +133,7 @@ class PrintFieldTripLayout extends Component {
               )
             })
             : <p><i>No Outbound Trip Planned</i></p>
-          */}
+          }
         </div>
         <div>
           <h2>Inbound Trip (to Destination)</h2>
@@ -156,6 +158,7 @@ const mapStateToProps = (state, ownProps) => {
   const { requests } = state.callTaker.fieldTrip
   const request = requests.data.find(req => req.id === requestId)
   return {
+    config: state.otp.config,
     request,
     requestId,
     session: state.callTaker.session

--- a/lib/components/admin/print-styled.js
+++ b/lib/components/admin/print-styled.js
@@ -1,0 +1,77 @@
+import styled from 'styled-components'
+
+import TripDetails from '../narrative/connected-trip-details'
+
+// This file contains styles specific for rendering PrintFieldTripLayout.
+// They generally mimic the styles found in the OTP native client.
+
+export const PrintLayout = styled.div`
+  font-size: 16px;
+  line-height: 115%;
+  margin: 8px;
+`
+
+export const Header = styled.div``
+
+export const TripTitle = styled.h1`
+  border-bottom: 3px solid gray;
+  font-size: 30px;
+  font-weight: bold;
+`
+
+export const TripInfoList = styled.ul`
+  font-size: 16px;
+  list-style: none;
+  margin-top: 1em;
+  padding: 0;
+`
+
+export const Val = styled.span`
+  :empty:before {
+    content: 'N/A';
+  }
+`
+
+// The styles below mirror those found in OTP native client.
+export const TripContainer = styled.div`
+  background: #ddd;
+  margin-top: 1em;
+
+  & > h2 {
+    font-size: 20px;
+    font-weight: bold;    
+    margin: 0;
+    padding: 4px;
+  }
+`
+
+export const TripBody = styled.div`
+  padding: 8px;
+`
+
+export const ItineraryContainer = styled.div`
+  border: 3px solid #444;
+  margin-top: .5em;
+
+  & > h3 {
+    background: #444;
+    color: white;    
+    font-size: 18px;
+    font-weight: bold;
+    margin: 0;
+    padding: 4px;
+  }
+`
+
+export const ItineraryBody = styled.div`
+  background: white;
+  padding: 12px;
+`
+
+export const TripSummary = styled(TripDetails)`
+  background: #eee;
+  border: 1px solid #bbb;
+  border-radius: 0;
+  margin-top: 15px;
+  padding: 5px;
+`

--- a/lib/components/admin/print-styled.js
+++ b/lib/components/admin/print-styled.js
@@ -63,7 +63,7 @@ export const ItineraryContainer = styled.div`
   }
 `
 
-export const ItineraryBody = styled.div`
+export const PrintableItineraryContainer = styled.div`
   background: white;
   padding: 12px;
 `

--- a/lib/components/app/print-layout.js
+++ b/lib/components/app/print-layout.js
@@ -9,6 +9,7 @@ import { routingQuery } from '../../actions/api'
 import DefaultMap from '../map/default-map'
 import TripDetails from '../narrative/connected-trip-details'
 import { ComponentContext } from '../../util/contexts'
+import { addPrintViewClassToRootHtml, clearClassFromRootHtml } from '../../util/print'
 import { getActiveItinerary } from '../../util/state'
 
 class PrintLayout extends Component {
@@ -38,20 +39,15 @@ class PrintLayout extends Component {
     const { location, parseUrlQueryString } = this.props
     // Add print-view class to html tag to ensure that iOS scroll fix only applies
     // to non-print views.
-    const root = document.getElementsByTagName('html')[0]
-    root.setAttribute('class', 'print-view')
+    addPrintViewClassToRootHtml()
     // Parse the URL query parameters, if present
     if (location && location.search) {
       parseUrlQueryString()
     }
   }
 
-  /**
-   * Remove class attribute from html tag on clean up.
-   */
   componentWillUnmount () {
-    const root = document.getElementsByTagName('html')[0]
-    root.removeAttribute('class')
+    clearClassFromRootHtml()
   }
 
   render () {

--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -17,6 +17,7 @@ import * as formActions from '../../actions/form'
 import * as locationActions from '../../actions/location'
 import * as mapActions from '../../actions/map'
 import * as uiActions from '../../actions/ui'
+import PrintFieldTripLayout from '../admin/print-field-trip-layout'
 import { frame } from '../app/app-frame'
 import { RedirectWithQuery } from '../form/connected-links'
 import Map from '../map/map'
@@ -347,6 +348,10 @@ class RouterWrapperWithAuth0 extends Component {
             <Route
               component={PrintLayout}
               path='/print'
+            />
+            <Route
+              component={PrintFieldTripLayout}
+              path='/printFieldTrip'
             />
             {/* For any other route, simply return the web app. */}
             <Route

--- a/lib/util/call-taker.js
+++ b/lib/util/call-taker.js
@@ -3,6 +3,7 @@ import {randId} from '@opentripplanner/core-utils/lib/storage'
 import moment from 'moment'
 
 import {getRoutingParams} from '../actions/api'
+
 import {getTimestamp} from './state'
 
 export const TICKET_TYPES = {
@@ -268,4 +269,65 @@ function createItinerary (itinData, tripPlan) {
     if (leg.mode === 'WALK') itin.totalWalk += leg.distance
   })
   return itin
+}
+
+/**
+ * LZW-compress a string
+ *
+ * LZW functions adaped from jsolait library (LGPL)
+ * via http://stackoverflow.com/questions/294297/javascript-implementation-of-gzip
+ */
+export function lzwEncode (s) {
+  var dict = {}
+  var data = (s + '').split('')
+  var out = []
+  var currChar
+  var phrase = data[0]
+  var code = 256
+  let i
+  for (i = 1; i < data.length; i++) {
+    currChar = data[i]
+    if (dict[phrase + currChar] != null) {
+      phrase += currChar
+    } else {
+      out.push(phrase.length > 1 ? dict[phrase] : phrase.charCodeAt(0))
+      dict[phrase + currChar] = code
+      code++
+      phrase = currChar
+    }
+  }
+  out.push(phrase.length > 1 ? dict[phrase] : phrase.charCodeAt(0))
+  for (i = 0; i < out.length; i++) {
+    out[i] = String.fromCharCode(out[i])
+  }
+  return out.join('')
+}
+/**
+ * Decompress an LZW-encoded string
+ *
+ * LZW functions adaped from jsolait library (LGPL)
+ * via http://stackoverflow.com/questions/294297/javascript-implementation-of-gzip
+ */
+export function lzwDecode (s) {
+  var dict = {}
+  var data = (s + '').split('')
+  var currChar = data[0]
+  var oldPhrase = currChar
+  var out = [currChar]
+  var code = 256
+  var phrase
+  for (var i = 1; i < data.length; i++) {
+    var currCode = data[i].charCodeAt(0)
+    if (currCode < 256) {
+      phrase = data[i]
+    } else {
+      phrase = dict[currCode] ? dict[currCode] : (oldPhrase + currChar)
+    }
+    out.push(phrase)
+    currChar = phrase.charAt(0)
+    dict[code] = oldPhrase + currChar
+    code++
+    oldPhrase = phrase
+  }
+  return out.join('')
 }

--- a/lib/util/call-taker.js
+++ b/lib/util/call-taker.js
@@ -274,7 +274,7 @@ function createItinerary (itinData, tripPlan) {
 /**
  * LZW-compress a string
  *
- * LZW functions adaped from jsolait library (LGPL)
+ * LZW functions adapted from jsolait library (LGPL)
  * via http://stackoverflow.com/questions/294297/javascript-implementation-of-gzip
  */
 export function lzwEncode (s) {
@@ -305,7 +305,7 @@ export function lzwEncode (s) {
 /**
  * Decompress an LZW-encoded string
  *
- * LZW functions adaped from jsolait library (LGPL)
+ * LZW functions adapted from jsolait library (LGPL)
  * via http://stackoverflow.com/questions/294297/javascript-implementation-of-gzip
  */
 export function lzwDecode (s) {

--- a/lib/util/print.js
+++ b/lib/util/print.js
@@ -1,0 +1,22 @@
+/**
+ * @return the root <html> tag.
+ */
+function getRootHtmlTag () {
+  return document.getElementsByTagName('html')[0]
+}
+
+/**
+ * Add print-view class to the html tag on print layout components
+ * to ensure that iOS scroll fix only applies to non-print views.
+ */
+export function addPrintViewClassToRootHtml () {
+  getRootHtmlTag().setAttribute('class', 'print-view')
+}
+
+/**
+ * Remove class attribute from html tag,
+ * for print layout components when componentWillUnmount runs.
+ */
+export function clearClassFromRootHtml () {
+  getRootHtmlTag().removeAttribute('class')
+}


### PR DESCRIPTION
This PR adds functionality for printing Field Trip itineraries that were previously planned and saved in otp-datastore.

Print functionality uses existing renders for itinerary narratives and trip detail summaries (some items printed by the native OTP client are thus missing).

To print a Field Trip itinerary:
1. Open the details of a field trip request
2. Open the view dropup menu and click "Printable trip plan"

![image](https://user-images.githubusercontent.com/56846598/123994676-9a7d6700-d99b-11eb-9c63-2b2ac31c7638.png)

