### PR TITLE
Trip page: Add warning about navigating away with unsaved changes

### DIFF
--- a/lib/components/user/monitored-trip/trip-basics-pane.js
+++ b/lib/components/user/monitored-trip/trip-basics-pane.js
@@ -89,8 +89,24 @@ class TripBasicsPane extends Component {
   }
 
   render () {
-    const { errors, isCreating, itineraryExistence, values: monitoredTrip } = this.props
+    const {
+      canceled,
+      dirty,
+      errors,
+      isCreating,
+      isSubmitting,
+      itineraryExistence,
+      values: monitoredTrip
+    } = this.props
     const { itinerary } = monitoredTrip
+
+    // Prevent user from leaving when form has been changed,
+    // but don't show it when they click submit or cancel.
+    const unsavedChanges = dirty && !isSubmitting && !canceled
+    // Message changes depending on if the new or existing trip is being edited
+    const unsavedChangesMessage = `You have haven't saved your ${
+      isCreating ? 'new ' : ''
+    }trip yet. If you leave, ${isCreating ? 'it' : 'changes'} will be lost.`
 
     if (!itinerary) {
       return <div>No itinerary to display.</div>
@@ -109,11 +125,9 @@ class TripBasicsPane extends Component {
 
       return (
         <div>
-          {/* Prevent user from leaving when form has been changed, but
-          don't show it when they click submit or cancel. */}
           <Prompt
-            when={this.props.dirty && !this.props.isSubmitting && !this.props.canceled}
-            message={`You have haven't saved your ${this.props.isCreating ? 'new ' : ''}trip yet. If you leave, ${this.props.isCreating ? 'it' : 'changes'} will be lost.`}
+            when={unsavedChanges}
+            message={unsavedChangesMessage}
           />
 
           {/* Do not show trip status when saving trip for the first time

--- a/lib/components/user/monitored-trip/trip-basics-pane.js
+++ b/lib/components/user/monitored-trip/trip-basics-pane.js
@@ -109,10 +109,11 @@ class TripBasicsPane extends Component {
 
       return (
         <div>
-          {/* Prevent user from leaving when form is dirty */}
+          {/* Prevent user from leaving when form has been changed, but
+          don't show it when they click submit.  */}
           <Prompt
-            when={this.props.dirty}
-            message="You have haven't saved your new trip yet. If you leave, it will be lost."
+            when={this.props.dirty && !this.props.isSubmitting}
+            message={`You have haven't saved your ${this.props.isCreating ? 'new ' : ''}trip yet. If you leave, ${this.props.isCreating ? 'it' : 'changes'} will be lost.`}
           />
 
           {/* Do not show trip status when saving trip for the first time

--- a/lib/components/user/monitored-trip/trip-basics-pane.js
+++ b/lib/components/user/monitored-trip/trip-basics-pane.js
@@ -110,7 +110,7 @@ class TripBasicsPane extends Component {
       return (
         <div>
           {/* Prevent user from leaving when form has been changed, but
-          don't show it when they click submit.  */}
+          don't show it when they click submit or cancel. */}
           <Prompt
             when={this.props.dirty && !this.props.isSubmitting && !this.props.canceled}
             message={`You have haven't saved your ${this.props.isCreating ? 'new ' : ''}trip yet. If you leave, ${this.props.isCreating ? 'it' : 'changes'} will be lost.`}

--- a/lib/components/user/monitored-trip/trip-basics-pane.js
+++ b/lib/components/user/monitored-trip/trip-basics-pane.js
@@ -125,6 +125,8 @@ class TripBasicsPane extends Component {
 
       return (
         <div>
+          {/* TODO: This component does not block navigation on reload or using the back button.
+          This will have to be done at a higher level. See #376 */}
           <Prompt
             when={unsavedChanges}
             message={unsavedChangesMessage}

--- a/lib/components/user/monitored-trip/trip-basics-pane.js
+++ b/lib/components/user/monitored-trip/trip-basics-pane.js
@@ -104,9 +104,9 @@ class TripBasicsPane extends Component {
     // but don't show it when they click submit or cancel.
     const unsavedChanges = dirty && !isSubmitting && !canceled
     // Message changes depending on if the new or existing trip is being edited
-    const unsavedChangesMessage = `You have haven't saved your ${
-      isCreating ? 'new ' : ''
-    }trip yet. If you leave, ${isCreating ? 'it' : 'changes'} will be lost.`
+    const unsavedChangesNewTripMessage = 'You haven\'t saved your new trip yet. If you leave, it will be lost.'
+    const unsavedChangesExistingTripMessage = 'You haven\'t saved your trip yet. If you leave, changes will be lost.'
+    const unsavedChangesMessage = isCreating ? unsavedChangesNewTripMessage : unsavedChangesExistingTripMessage
 
     if (!itinerary) {
       return <div>No itinerary to display.</div>

--- a/lib/components/user/monitored-trip/trip-basics-pane.js
+++ b/lib/components/user/monitored-trip/trip-basics-pane.js
@@ -10,10 +10,12 @@ import {
   ProgressBar
 } from 'react-bootstrap'
 import { connect } from 'react-redux'
+import { Prompt } from 'react-router'
 import styled from 'styled-components'
 
 import * as userActions from '../../../actions/user'
 import { getErrorStates } from '../../../util/ui'
+
 import TripStatus from './trip-status'
 import TripSummary from './trip-summary'
 
@@ -107,6 +109,12 @@ class TripBasicsPane extends Component {
 
       return (
         <div>
+          {/* Prevent user from leaving when form is dirty */}
+          <Prompt
+            when={this.props.dirty}
+            message="You have haven't saved your new trip yet. If you leave, it will be lost."
+          />
+
           {/* Do not show trip status when saving trip for the first time
               (it doesn't exist in backend yet). */}
           {!isCreating && <TripStatus monitoredTrip={monitoredTrip} />}

--- a/lib/components/user/monitored-trip/trip-basics-pane.js
+++ b/lib/components/user/monitored-trip/trip-basics-pane.js
@@ -112,7 +112,7 @@ class TripBasicsPane extends Component {
           {/* Prevent user from leaving when form has been changed, but
           don't show it when they click submit.  */}
           <Prompt
-            when={this.props.dirty && !this.props.isSubmitting}
+            when={this.props.dirty && !this.props.isSubmitting && !this.props.canceled}
             message={`You have haven't saved your ${this.props.isCreating ? 'new ' : ''}trip yet. If you leave, ${this.props.isCreating ? 'it' : 'changes'} will be lost.`}
           />
 

--- a/lib/components/user/stacked-pane-display.js
+++ b/lib/components/user/stacked-pane-display.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, {useState} from 'react'
 
 import FormNavigationButtons from './form-navigation-buttons'
 import { PageHeading, StackedPaneContainer } from './styled'
@@ -7,30 +7,33 @@ import { PageHeading, StackedPaneContainer } from './styled'
 /**
  * This component handles the flow between screens for new OTP user accounts.
  */
-const StackedPaneDisplay = ({ onCancel, paneSequence, title }) => (
-  <>
-    {title && <PageHeading>{title}</PageHeading>}
-    {
-      paneSequence.map(({ pane: Pane, props, title }, index) => (
-        <StackedPaneContainer key={index}>
-          <h3>{title}</h3>
-          <div><Pane {...props} /></div>
-        </StackedPaneContainer>
-      ))
-    }
+const StackedPaneDisplay = ({ onCancel, paneSequence, title }) => {
+  const [isBeingCanceled, updateBeingCanceled] = useState(false)
 
-    <FormNavigationButtons
-      backButton={{
-        onClick: onCancel,
-        text: 'Cancel'
-      }}
-      okayButton={{
-        text: 'Save Preferences',
-        type: 'submit'
-      }}
-    />
-  </>
-)
+  return (
+    <>
+      {title && <PageHeading>{title}</PageHeading>}
+      {
+        paneSequence.map(({ pane: Pane, props, title }, index) => (
+          <StackedPaneContainer key={index}>
+            <h3>{title}</h3>
+            <div><Pane canceled={isBeingCanceled} {...props} /></div>
+          </StackedPaneContainer>
+        ))
+      }
+
+      <FormNavigationButtons
+        backButton={{
+          onClick: () => { updateBeingCanceled(true); onCancel() },
+          text: 'Cancel'
+        }}
+        okayButton={{
+          text: 'Save Preferences',
+          type: 'submit'
+        }}
+      />
+    </>)
+}
 
 StackedPaneDisplay.propTypes = {
   onCancel: PropTypes.func.isRequired,

--- a/lib/components/user/stacked-pane-display.js
+++ b/lib/components/user/stacked-pane-display.js
@@ -8,6 +8,7 @@ import { PageHeading, StackedPaneContainer } from './styled'
  * This component handles the flow between screens for new OTP user accounts.
  */
 const StackedPaneDisplay = ({ onCancel, paneSequence, title }) => {
+  // Create indicator of if cancel button was clicked so that child components can know
   const [isBeingCanceled, updateBeingCanceled] = useState(false)
 
   return (

--- a/lib/components/user/stacked-pane-display.js
+++ b/lib/components/user/stacked-pane-display.js
@@ -14,18 +14,21 @@ const StackedPaneDisplay = ({ onCancel, paneSequence, title }) => {
   return (
     <>
       {title && <PageHeading>{title}</PageHeading>}
-      {
-        paneSequence.map(({ pane: Pane, props, title }, index) => (
-          <StackedPaneContainer key={index}>
-            <h3>{title}</h3>
-            <div><Pane canceled={isBeingCanceled} {...props} /></div>
-          </StackedPaneContainer>
-        ))
-      }
+      {paneSequence.map(({ pane: Pane, props, title }, index) => (
+        <StackedPaneContainer key={index}>
+          <h3>{title}</h3>
+          <div>
+            <Pane canceled={isBeingCanceled} {...props} />
+          </div>
+        </StackedPaneContainer>
+      ))}
 
       <FormNavigationButtons
         backButton={{
-          onClick: () => { updateBeingCanceled(true); onCancel() },
+          onClick: () => {
+            updateBeingCanceled(true)
+            onCancel()
+          },
           text: 'Cancel'
         }}
         okayButton={{
@@ -33,7 +36,8 @@ const StackedPaneDisplay = ({ onCancel, paneSequence, title }) => {
           type: 'submit'
         }}
       />
-    </>)
+    </>
+  )
 }
 
 StackedPaneDisplay.propTypes = {


### PR DESCRIPTION
When a user is adding or editing a trip, they will now be prompted to confirm they really want to leave if they try to navigate away. 

If they haven't made any changes or if they haven't made any changes, they aren't prompted.