### PR TITLE
Use import for pdfkit

### DIFF
--- a/lib/util/PDFDocumentWithTables.js
+++ b/lib/util/PDFDocumentWithTables.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const PDFDocument = require('pdfkit')
+import PDFDocument from 'pdfkit'
 
 /**
  * This class extends the pdfkit functionality to provide a tables method, which


### PR DESCRIPTION
Fix #403.

I tested that mailables still works with the trimet-call config.

I also attempted to use this branch in trimet-mod-otp (https://github.com/ibi-group/trimet-mod-otp/tree/otp-rr-3.1.0) with `./cpbuild.sh` (and it seemed to work).