### PR TITLE
Tweak TOS consent label text

### DIFF
--- a/lib/components/user/terms-of-use-pane.js
+++ b/lib/components/user/terms-of-use-pane.js
@@ -29,8 +29,11 @@ const TermsOfUsePane = ({
           onBlur={disableCheckTerms ? null : handleBlur}
           onChange={disableCheckTerms ? null : handleChange}
         >
-          {/* TODO: Implement the link */}
-            I have read and consent to the <a href={`/#${TERMS_OF_SERVICE_PATH}`} target='_blank'>Terms of Service</a> for using the Trip Planner.
+          I confirm that I am at least 18 years old, and I have read and{' '}
+          consent to the{' '}
+          <a href={`/#${TERMS_OF_SERVICE_PATH}`} target='_blank'>
+            Terms of Service
+          </a> for using the Trip Planner.
         </Checkbox>
       </FormGroup>
 


### PR DESCRIPTION
Change TOS checkbox label to:

```
I confirm that I am at least 18 years old, and I have read and consent to the Terms of Service for using the Trip Planner.
```

per FDOT request.

To test:

1. run `./run-otp-rr.js fdot`
2. Click `Sign in` in navbar, create new account.
3. Verify email, confirm in otp UI that email is confirmed and view new checkbox label.