### PR TITLE
fix: remove dead links

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -42,6 +42,10 @@ api:
 persistence:
   enabled: true
   strategy: localStorage
+  ### This variable hides the "more info" link when accepting the terms of storage.
+  ### If no terms of storage page content is set, this removes an otherwise dead link
+  ### False is default in that if the value isn't set, the link isn't shown
+  # terms_of_storage: true
 
 ### If using the OTP Middleware to store user profiles
 ### with Auth0 as the authentication mechanism,

--- a/lib/components/user/terms-of-use-pane.js
+++ b/lib/components/user/terms-of-use-pane.js
@@ -54,13 +54,9 @@ const TermsOfUsePane = ({
     </div>
   )
 }
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   return {
     termsOfStorageSet: state.otp.config.persistence?.terms_of_storage
   }
 }
-
-const mapDispatchToProps = {
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(TermsOfUsePane)
+export default connect(mapStateToProps)(TermsOfUsePane)

--- a/lib/components/user/terms-of-use-pane.js
+++ b/lib/components/user/terms-of-use-pane.js
@@ -11,15 +11,13 @@ const TermsOfUsePane = ({
   disableCheckTerms,
   handleBlur,
   handleChange,
-  otpConfig,
+  termsOfStorageSet,
   values: userData
 }) => {
   const {
     hasConsentedToTerms,
     storeTripHistory
   } = userData
-  const { persistence } = otpConfig
-  const { terms_of_storage: termsOfStorageSet } = persistence
 
   return (
     <div>
@@ -58,7 +56,7 @@ const TermsOfUsePane = ({
 }
 const mapStateToProps = (state, ownProps) => {
   return {
-    otpConfig: state.otp.config
+    termsOfStorageSet: state.otp.config.persistence?.terms_of_storage
   }
 }
 

--- a/lib/components/user/terms-of-use-pane.js
+++ b/lib/components/user/terms-of-use-pane.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { connect } from 'react-redux'
 import { Checkbox, ControlLabel, FormGroup } from 'react-bootstrap'
 
 import { TERMS_OF_SERVICE_PATH, TERMS_OF_STORAGE_PATH } from '../../util/constants'
@@ -10,12 +11,15 @@ const TermsOfUsePane = ({
   disableCheckTerms,
   handleBlur,
   handleChange,
+  otpConfig,
   values: userData
 }) => {
   const {
     hasConsentedToTerms,
     storeTripHistory
   } = userData
+  const { persistence } = otpConfig
+  const { terms_of_storage: termsOfStorageSet } = persistence
 
   return (
     <div>
@@ -46,11 +50,19 @@ const TermsOfUsePane = ({
         >
           {/* TODO: Implement the link */}
             Optional: I consent to the Trip Planner storing my historical planned trips in order to
-            improve transit services in my area. <a href={`/#${TERMS_OF_STORAGE_PATH}`} target='_blank'>More info...</a>
+            improve transit services in my area. {termsOfStorageSet && <a href={`/#${TERMS_OF_STORAGE_PATH}`} target='_blank'>More info...</a>}
         </Checkbox>
       </FormGroup>
     </div>
   )
 }
+const mapStateToProps = (state, ownProps) => {
+  return {
+    otpConfig: state.otp.config
+  }
+}
 
-export default TermsOfUsePane
+const mapDispatchToProps = {
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(TermsOfUsePane)

--- a/lib/util/auth.js
+++ b/lib/util/auth.js
@@ -8,13 +8,6 @@ export const accountLinks = [
   {
     text: 'My account',
     url: ACCOUNT_PATH
-  },
-  {
-    // Add a target attribute if you need the link to open in a new window, etc.
-    // (supports the same values as <a target=... >).
-    // target: '_blank',
-    text: 'Help',
-    url: '/help'
   }
 ]
 


### PR DESCRIPTION
Removes help link that doesn't contain content and makes terms of storage more info link hidden by default unless explicitly enabled in the config.