### PR TITLE
Replace Colors to Meet A11y Requirements

### DIFF
--- a/lib/components/app/app.css
+++ b/lib/components/app/app.css
@@ -77,7 +77,7 @@
   border-radius: 15px;
 }
 .view-switcher button.btn-link.active {
-  background: rgba(255, 255, 255, 0.15);
+  background: rgba(0, 0, 0, 0.15);
 }
 .view-switcher button.btn-link:hover,
 .view-switcher button.btn-link:focus {

--- a/lib/components/form/batch-styled.js
+++ b/lib/components/form/batch-styled.js
@@ -94,7 +94,7 @@ export const StyledBatchPreferences = styled(SettingsSelectorPanel)`
   ${modeButtonButtonCss}
 
   ${TripFormClasses.SettingLabel} {
-    color: #808080;
+    color: #686868;
     font-size: 14px;
     font-weight: 100;
     letter-spacing: 1px;

--- a/lib/components/form/form.css
+++ b/lib/components/form/form.css
@@ -37,6 +37,9 @@
 .otp .plan-trip-button, .view-results-button {
   width: 100%;
 }
+.otp .plan-trip-button[disabled] {
+  opacity: 0.75;
+}
 
 .otp .bottom-fixed {
   position: absolute;

--- a/lib/components/form/styled.js
+++ b/lib/components/form/styled.js
@@ -57,7 +57,7 @@ export const StyledSettingsSelectorPanel = styled(SettingsSelectorPanel)`
   ${modeButtonButtonCss}
 
   ${TripFormClasses.SettingLabel} {
-    color: #808080;
+    color: #686868;
     font-size: 14px;
     font-weight: 100;
     letter-spacing: 1px;


### PR DESCRIPTION
Some forms and buttons weren't being tested by the accessibility tests (they require interaction to open). These colors have been corrected in this PR.