### PR TITLE
Make Requests to Either OTP 1 or OTP 2 Depending on Request Type

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -2,6 +2,13 @@ api:
   host: http://localhost
   path: /otp/routers/default
   port: 8001
+
+# Support OTP-2 in parallel for certain requests
+# api_v2:
+#  host: http://localhost
+#  path: /otp/routers/default
+#  port: 8002
+
 # Add suggested locations to be shown as options in the form view.
 # locations:
 #   - id: 'airport'

--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -252,9 +252,15 @@ function getOtpFetchOptions (state, includeToken = false) {
 function constructRoutingQuery (state, ignoreRealtimeUpdates, injectedParams = {}) {
   const { config, currentQuery } = state.otp
   const routingType = currentQuery.routingType
+  const routingMode = injectedParams?.mode || currentQuery.mode
+
   // Check for routingType-specific API config; if none, use default API
   const rt = config.routingTypes && config.routingTypes.find(rt => rt.key === routingType)
-  const api = (rt && rt.api) || config.api
+
+  // Certain requests will require OTP-2. If an OTP-2 host is specified, set it to be used
+  const useOtp2 = !!config.api_v2 && routingMode.includes('FLEX')
+
+  const api = (rt && rt.api) || (useOtp2 && config.api_v2) || config.api
   const planEndpoint = `${api.host}${api.port
     ? ':' + api.port
     : ''}${api.path}/plan`


### PR DESCRIPTION
As OTP instances don't provide all functionality required by OTP-RR, this PR adds support for routing requests to different servers depending on mode. In this case, flex requests go to OTP-2 instances while non-flex requests go to the OTP-1 instance.

Piggyback PR of https://github.com/opentripplanner/otp-react-redux/pull/470. However, I think it should be merged into dev after #470 is merged.

The end result: flex and e-scooters in the same itinerary results!
![Screen Shot 2021-10-26 at 3 04 37 PM](https://user-images.githubusercontent.com/86619099/138895408-1bc70502-6ae7-4ddf-ba91-0c4965419886.png)

