### PR TITLE
update focus point based on geolocation

### DIFF
--- a/lib/components/form/connect-location-field.js
+++ b/lib/components/form/connect-location-field.js
@@ -24,8 +24,8 @@ export default function connectLocationField (StyledLocationField, options = {})
     const query = activeSearch ? activeSearch.query : currentQuery
 
     const geocoderConfig = config.geocoder
-    if (state.otp.location.currentPosition.coords) {
-      const {latitude: lat, longitude: lon} = state.otp.location.currentPosition.coords
+    if (currentPosition?.coords) {
+      const {latitude: lat, longitude: lon} = currentPosition.coords
       geocoderConfig.focusPoint = {lat, lon}
     }
 

--- a/lib/components/form/connect-location-field.js
+++ b/lib/components/form/connect-location-field.js
@@ -23,9 +23,15 @@ export default function connectLocationField (StyledLocationField, options = {})
     const activeSearch = getActiveSearch(state)
     const query = activeSearch ? activeSearch.query : currentQuery
 
+    const geocoderConfig = config.geocoder
+    if (state.otp.location.currentPosition.coords) {
+      const {latitude: lat, longitude: lon} = state.otp.location.currentPosition.coords
+      geocoderConfig.focusPoint = {lat, lon}
+    }
+
     const stateToProps = {
       currentPosition,
-      geocoderConfig: config.geocoder,
+      geocoderConfig,
       layerColorMap: config.geocoder?.resultsColors || {},
       nearbyStops,
       sessionSearches,


### PR DESCRIPTION
This PR adjusts the geocoder focus point when the user's geolocation is updated. This means that mobile users will get results based on where they are! 

The standard focus point is preserved if geolocation is not present/permitted.