### PR TITLE
fix(deps): update otp-ui location field to 1.8.0

### DIFF
--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -369,7 +369,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                               size="0.9em"
                               title="From Location Icon"
                             >
-                              <Styled(Component)
+                              <StyledIconBase
                                 className="styled__FromIcon-n5xcvc-0 fTLtLq"
                                 iconAttrs={
                                   Object {
@@ -377,26 +377,26 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                     "xmlns": "http://www.w3.org/2000/svg",
                                   }
                                 }
-                                iconVerticalAlign="-.125em"
+                                iconVerticalAlign="middle"
                                 iconViewBox="0 0 512 512"
                                 size="0.9em"
                                 title="From Location Icon"
                               >
                                 <ForwardRef
-                                  className="sc-bdfBwQ eCizyM styled__FromIcon-n5xcvc-0 fTLtLq"
+                                  className="StyledIconBase-ea9ulj-0 cKCFNq styled__FromIcon-n5xcvc-0 fTLtLq"
                                   iconAttrs={
                                     Object {
                                       "fill": "currentColor",
                                       "xmlns": "http://www.w3.org/2000/svg",
                                     }
                                   }
-                                  iconVerticalAlign="-.125em"
+                                  iconVerticalAlign="middle"
                                   iconViewBox="0 0 512 512"
                                   size="0.9em"
                                   title="From Location Icon"
                                 >
                                   <svg
-                                    className="sc-bdfBwQ eCizyM styled__FromIcon-n5xcvc-0 fTLtLq"
+                                    className="StyledIconBase-ea9ulj-0 cKCFNq styled__FromIcon-n5xcvc-0 fTLtLq"
                                     fill="currentColor"
                                     focusable="false"
                                     height="0.9em"
@@ -413,11 +413,10 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                     <path
                                       d="M256 56c110.532 0 200 89.451 200 200 0 110.532-89.451 200-200 200-110.532 0-200-89.451-200-200 0-110.532 89.451-200 200-200m0-48C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 168c-44.183 0-80 35.817-80 80s35.817 80 80 80 80-35.817 80-80-35.817-80-80-80z"
                                       fill="currentColor"
-                                      key="k0"
                                     />
                                   </svg>
                                 </ForwardRef>
-                              </Styled(Component)>
+                              </StyledIconBase>
                             </DotCircle>
                           </styled__FromIcon>
                         </LocationIcon>
@@ -451,7 +450,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                               size="0.9em"
                               title="To Location Icon"
                             >
-                              <Styled(Component)
+                              <StyledIconBase
                                 className="styled__ToIcon-n5xcvc-2 jzAxgN"
                                 iconAttrs={
                                   Object {
@@ -459,26 +458,26 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                     "xmlns": "http://www.w3.org/2000/svg",
                                   }
                                 }
-                                iconVerticalAlign="-.125em"
+                                iconVerticalAlign="middle"
                                 iconViewBox="0 0 384 512"
                                 size="0.9em"
                                 title="To Location Icon"
                               >
                                 <ForwardRef
-                                  className="sc-bdfBwQ eCizyM styled__ToIcon-n5xcvc-2 jzAxgN"
+                                  className="StyledIconBase-ea9ulj-0 cKCFNq styled__ToIcon-n5xcvc-2 jzAxgN"
                                   iconAttrs={
                                     Object {
                                       "fill": "currentColor",
                                       "xmlns": "http://www.w3.org/2000/svg",
                                     }
                                   }
-                                  iconVerticalAlign="-.125em"
+                                  iconVerticalAlign="middle"
                                   iconViewBox="0 0 384 512"
                                   size="0.9em"
                                   title="To Location Icon"
                                 >
                                   <svg
-                                    className="sc-bdfBwQ eCizyM styled__ToIcon-n5xcvc-2 jzAxgN"
+                                    className="StyledIconBase-ea9ulj-0 cKCFNq styled__ToIcon-n5xcvc-2 jzAxgN"
                                     fill="currentColor"
                                     focusable="false"
                                     height="0.9em"
@@ -495,11 +494,10 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                     <path
                                       d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z"
                                       fill="currentColor"
-                                      key="k0"
                                     />
                                   </svg>
                                 </ForwardRef>
-                              </Styled(Component)>
+                              </StyledIconBase>
                             </MapMarkerAlt>
                           </styled__ToIcon>
                         </LocationIcon>
@@ -521,7 +519,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
             </div>
             <styled.div>
               <div
-                className="sc-iqHYGH RZjpG"
+                className="sc-kEjbxe ddEshv"
               >
                 <LiveStopTimes
                   autoRefreshStopTimes={true}
@@ -1871,7 +1869,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                   >
                                     <styled.div>
                                       <div
-                                        className="sc-dlfnbm eSOmhd"
+                                        className="sc-gsTCUz kuRGam"
                                       >
                                         P
                                       </div>
@@ -2171,7 +2169,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                               size="0.9em"
                               title="From Location Icon"
                             >
-                              <Styled(Component)
+                              <StyledIconBase
                                 className="styled__FromIcon-n5xcvc-0 fTLtLq"
                                 iconAttrs={
                                   Object {
@@ -2179,26 +2177,26 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                     "xmlns": "http://www.w3.org/2000/svg",
                                   }
                                 }
-                                iconVerticalAlign="-.125em"
+                                iconVerticalAlign="middle"
                                 iconViewBox="0 0 512 512"
                                 size="0.9em"
                                 title="From Location Icon"
                               >
                                 <ForwardRef
-                                  className="sc-bdfBwQ eCizyM styled__FromIcon-n5xcvc-0 fTLtLq"
+                                  className="StyledIconBase-ea9ulj-0 cKCFNq styled__FromIcon-n5xcvc-0 fTLtLq"
                                   iconAttrs={
                                     Object {
                                       "fill": "currentColor",
                                       "xmlns": "http://www.w3.org/2000/svg",
                                     }
                                   }
-                                  iconVerticalAlign="-.125em"
+                                  iconVerticalAlign="middle"
                                   iconViewBox="0 0 512 512"
                                   size="0.9em"
                                   title="From Location Icon"
                                 >
                                   <svg
-                                    className="sc-bdfBwQ eCizyM styled__FromIcon-n5xcvc-0 fTLtLq"
+                                    className="StyledIconBase-ea9ulj-0 cKCFNq styled__FromIcon-n5xcvc-0 fTLtLq"
                                     fill="currentColor"
                                     focusable="false"
                                     height="0.9em"
@@ -2215,11 +2213,10 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                     <path
                                       d="M256 56c110.532 0 200 89.451 200 200 0 110.532-89.451 200-200 200-110.532 0-200-89.451-200-200 0-110.532 89.451-200 200-200m0-48C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 168c-44.183 0-80 35.817-80 80s35.817 80 80 80 80-35.817 80-80-35.817-80-80-80z"
                                       fill="currentColor"
-                                      key="k0"
                                     />
                                   </svg>
                                 </ForwardRef>
-                              </Styled(Component)>
+                              </StyledIconBase>
                             </DotCircle>
                           </styled__FromIcon>
                         </LocationIcon>
@@ -2253,7 +2250,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                               size="0.9em"
                               title="To Location Icon"
                             >
-                              <Styled(Component)
+                              <StyledIconBase
                                 className="styled__ToIcon-n5xcvc-2 jzAxgN"
                                 iconAttrs={
                                   Object {
@@ -2261,26 +2258,26 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                     "xmlns": "http://www.w3.org/2000/svg",
                                   }
                                 }
-                                iconVerticalAlign="-.125em"
+                                iconVerticalAlign="middle"
                                 iconViewBox="0 0 384 512"
                                 size="0.9em"
                                 title="To Location Icon"
                               >
                                 <ForwardRef
-                                  className="sc-bdfBwQ eCizyM styled__ToIcon-n5xcvc-2 jzAxgN"
+                                  className="StyledIconBase-ea9ulj-0 cKCFNq styled__ToIcon-n5xcvc-2 jzAxgN"
                                   iconAttrs={
                                     Object {
                                       "fill": "currentColor",
                                       "xmlns": "http://www.w3.org/2000/svg",
                                     }
                                   }
-                                  iconVerticalAlign="-.125em"
+                                  iconVerticalAlign="middle"
                                   iconViewBox="0 0 384 512"
                                   size="0.9em"
                                   title="To Location Icon"
                                 >
                                   <svg
-                                    className="sc-bdfBwQ eCizyM styled__ToIcon-n5xcvc-2 jzAxgN"
+                                    className="StyledIconBase-ea9ulj-0 cKCFNq styled__ToIcon-n5xcvc-2 jzAxgN"
                                     fill="currentColor"
                                     focusable="false"
                                     height="0.9em"
@@ -2297,11 +2294,10 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                     <path
                                       d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z"
                                       fill="currentColor"
-                                      key="k0"
                                     />
                                   </svg>
                                 </ForwardRef>
-                              </Styled(Component)>
+                              </StyledIconBase>
                             </MapMarkerAlt>
                           </styled__ToIcon>
                         </LocationIcon>
@@ -2323,7 +2319,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
             </div>
             <styled.div>
               <div
-                className="sc-iqHYGH RZjpG"
+                className="sc-kEjbxe ddEshv"
               >
                 <LiveStopTimes
                   autoRefreshStopTimes={true}
@@ -3088,7 +3084,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                   >
                                     <styled.div>
                                       <div
-                                        className="sc-dlfnbm eSOmhd"
+                                        className="sc-gsTCUz kuRGam"
                                       >
                                         P
                                       </div>
@@ -3487,7 +3483,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                               size="0.9em"
                               title="From Location Icon"
                             >
-                              <Styled(Component)
+                              <StyledIconBase
                                 className="styled__FromIcon-n5xcvc-0 fTLtLq"
                                 iconAttrs={
                                   Object {
@@ -3495,26 +3491,26 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                     "xmlns": "http://www.w3.org/2000/svg",
                                   }
                                 }
-                                iconVerticalAlign="-.125em"
+                                iconVerticalAlign="middle"
                                 iconViewBox="0 0 512 512"
                                 size="0.9em"
                                 title="From Location Icon"
                               >
                                 <ForwardRef
-                                  className="sc-bdfBwQ eCizyM styled__FromIcon-n5xcvc-0 fTLtLq"
+                                  className="StyledIconBase-ea9ulj-0 cKCFNq styled__FromIcon-n5xcvc-0 fTLtLq"
                                   iconAttrs={
                                     Object {
                                       "fill": "currentColor",
                                       "xmlns": "http://www.w3.org/2000/svg",
                                     }
                                   }
-                                  iconVerticalAlign="-.125em"
+                                  iconVerticalAlign="middle"
                                   iconViewBox="0 0 512 512"
                                   size="0.9em"
                                   title="From Location Icon"
                                 >
                                   <svg
-                                    className="sc-bdfBwQ eCizyM styled__FromIcon-n5xcvc-0 fTLtLq"
+                                    className="StyledIconBase-ea9ulj-0 cKCFNq styled__FromIcon-n5xcvc-0 fTLtLq"
                                     fill="currentColor"
                                     focusable="false"
                                     height="0.9em"
@@ -3531,11 +3527,10 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                     <path
                                       d="M256 56c110.532 0 200 89.451 200 200 0 110.532-89.451 200-200 200-110.532 0-200-89.451-200-200 0-110.532 89.451-200 200-200m0-48C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 168c-44.183 0-80 35.817-80 80s35.817 80 80 80 80-35.817 80-80-35.817-80-80-80z"
                                       fill="currentColor"
-                                      key="k0"
                                     />
                                   </svg>
                                 </ForwardRef>
-                              </Styled(Component)>
+                              </StyledIconBase>
                             </DotCircle>
                           </styled__FromIcon>
                         </LocationIcon>
@@ -3569,7 +3564,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                               size="0.9em"
                               title="To Location Icon"
                             >
-                              <Styled(Component)
+                              <StyledIconBase
                                 className="styled__ToIcon-n5xcvc-2 jzAxgN"
                                 iconAttrs={
                                   Object {
@@ -3577,26 +3572,26 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                     "xmlns": "http://www.w3.org/2000/svg",
                                   }
                                 }
-                                iconVerticalAlign="-.125em"
+                                iconVerticalAlign="middle"
                                 iconViewBox="0 0 384 512"
                                 size="0.9em"
                                 title="To Location Icon"
                               >
                                 <ForwardRef
-                                  className="sc-bdfBwQ eCizyM styled__ToIcon-n5xcvc-2 jzAxgN"
+                                  className="StyledIconBase-ea9ulj-0 cKCFNq styled__ToIcon-n5xcvc-2 jzAxgN"
                                   iconAttrs={
                                     Object {
                                       "fill": "currentColor",
                                       "xmlns": "http://www.w3.org/2000/svg",
                                     }
                                   }
-                                  iconVerticalAlign="-.125em"
+                                  iconVerticalAlign="middle"
                                   iconViewBox="0 0 384 512"
                                   size="0.9em"
                                   title="To Location Icon"
                                 >
                                   <svg
-                                    className="sc-bdfBwQ eCizyM styled__ToIcon-n5xcvc-2 jzAxgN"
+                                    className="StyledIconBase-ea9ulj-0 cKCFNq styled__ToIcon-n5xcvc-2 jzAxgN"
                                     fill="currentColor"
                                     focusable="false"
                                     height="0.9em"
@@ -3613,11 +3608,10 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                     <path
                                       d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z"
                                       fill="currentColor"
-                                      key="k0"
                                     />
                                   </svg>
                                 </ForwardRef>
-                              </Styled(Component)>
+                              </StyledIconBase>
                             </MapMarkerAlt>
                           </styled__ToIcon>
                         </LocationIcon>
@@ -3639,7 +3633,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
             </div>
             <styled.div>
               <div
-                className="sc-iqHYGH RZjpG"
+                className="sc-kEjbxe ddEshv"
               >
                 <LiveStopTimes
                   autoRefreshStopTimes={true}
@@ -4998,7 +4992,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                   >
                                     <styled.div>
                                       <div
-                                        className="sc-dlfnbm eSOmhd"
+                                        className="sc-gsTCUz kuRGam"
                                       >
                                         P
                                       </div>
@@ -5655,7 +5649,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                               size="0.9em"
                               title="From Location Icon"
                             >
-                              <Styled(Component)
+                              <StyledIconBase
                                 className="styled__FromIcon-n5xcvc-0 fTLtLq"
                                 iconAttrs={
                                   Object {
@@ -5663,26 +5657,26 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     "xmlns": "http://www.w3.org/2000/svg",
                                   }
                                 }
-                                iconVerticalAlign="-.125em"
+                                iconVerticalAlign="middle"
                                 iconViewBox="0 0 512 512"
                                 size="0.9em"
                                 title="From Location Icon"
                               >
                                 <ForwardRef
-                                  className="sc-bdfBwQ eCizyM styled__FromIcon-n5xcvc-0 fTLtLq"
+                                  className="StyledIconBase-ea9ulj-0 cKCFNq styled__FromIcon-n5xcvc-0 fTLtLq"
                                   iconAttrs={
                                     Object {
                                       "fill": "currentColor",
                                       "xmlns": "http://www.w3.org/2000/svg",
                                     }
                                   }
-                                  iconVerticalAlign="-.125em"
+                                  iconVerticalAlign="middle"
                                   iconViewBox="0 0 512 512"
                                   size="0.9em"
                                   title="From Location Icon"
                                 >
                                   <svg
-                                    className="sc-bdfBwQ eCizyM styled__FromIcon-n5xcvc-0 fTLtLq"
+                                    className="StyledIconBase-ea9ulj-0 cKCFNq styled__FromIcon-n5xcvc-0 fTLtLq"
                                     fill="currentColor"
                                     focusable="false"
                                     height="0.9em"
@@ -5699,11 +5693,10 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     <path
                                       d="M256 56c110.532 0 200 89.451 200 200 0 110.532-89.451 200-200 200-110.532 0-200-89.451-200-200 0-110.532 89.451-200 200-200m0-48C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 168c-44.183 0-80 35.817-80 80s35.817 80 80 80 80-35.817 80-80-35.817-80-80-80z"
                                       fill="currentColor"
-                                      key="k0"
                                     />
                                   </svg>
                                 </ForwardRef>
-                              </Styled(Component)>
+                              </StyledIconBase>
                             </DotCircle>
                           </styled__FromIcon>
                         </LocationIcon>
@@ -5737,7 +5730,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                               size="0.9em"
                               title="To Location Icon"
                             >
-                              <Styled(Component)
+                              <StyledIconBase
                                 className="styled__ToIcon-n5xcvc-2 jzAxgN"
                                 iconAttrs={
                                   Object {
@@ -5745,26 +5738,26 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     "xmlns": "http://www.w3.org/2000/svg",
                                   }
                                 }
-                                iconVerticalAlign="-.125em"
+                                iconVerticalAlign="middle"
                                 iconViewBox="0 0 384 512"
                                 size="0.9em"
                                 title="To Location Icon"
                               >
                                 <ForwardRef
-                                  className="sc-bdfBwQ eCizyM styled__ToIcon-n5xcvc-2 jzAxgN"
+                                  className="StyledIconBase-ea9ulj-0 cKCFNq styled__ToIcon-n5xcvc-2 jzAxgN"
                                   iconAttrs={
                                     Object {
                                       "fill": "currentColor",
                                       "xmlns": "http://www.w3.org/2000/svg",
                                     }
                                   }
-                                  iconVerticalAlign="-.125em"
+                                  iconVerticalAlign="middle"
                                   iconViewBox="0 0 384 512"
                                   size="0.9em"
                                   title="To Location Icon"
                                 >
                                   <svg
-                                    className="sc-bdfBwQ eCizyM styled__ToIcon-n5xcvc-2 jzAxgN"
+                                    className="StyledIconBase-ea9ulj-0 cKCFNq styled__ToIcon-n5xcvc-2 jzAxgN"
                                     fill="currentColor"
                                     focusable="false"
                                     height="0.9em"
@@ -5781,11 +5774,10 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     <path
                                       d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z"
                                       fill="currentColor"
-                                      key="k0"
                                     />
                                   </svg>
                                 </ForwardRef>
-                              </Styled(Component)>
+                              </StyledIconBase>
                             </MapMarkerAlt>
                           </styled__ToIcon>
                         </LocationIcon>
@@ -5807,7 +5799,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
             </div>
             <styled.div>
               <div
-                className="sc-iqHYGH RZjpG"
+                className="sc-kEjbxe ddEshv"
               >
                 <LiveStopTimes
                   autoRefreshStopTimes={true}
@@ -9276,7 +9268,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   >
                                     <styled.div>
                                       <div
-                                        className="sc-dlfnbm eSOmhd"
+                                        className="sc-gsTCUz kuRGam"
                                       >
                                         P
                                       </div>
@@ -9928,7 +9920,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                               size="0.9em"
                               title="From Location Icon"
                             >
-                              <Styled(Component)
+                              <StyledIconBase
                                 className="styled__FromIcon-n5xcvc-0 fTLtLq"
                                 iconAttrs={
                                   Object {
@@ -9936,26 +9928,26 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                     "xmlns": "http://www.w3.org/2000/svg",
                                   }
                                 }
-                                iconVerticalAlign="-.125em"
+                                iconVerticalAlign="middle"
                                 iconViewBox="0 0 512 512"
                                 size="0.9em"
                                 title="From Location Icon"
                               >
                                 <ForwardRef
-                                  className="sc-bdfBwQ eCizyM styled__FromIcon-n5xcvc-0 fTLtLq"
+                                  className="StyledIconBase-ea9ulj-0 cKCFNq styled__FromIcon-n5xcvc-0 fTLtLq"
                                   iconAttrs={
                                     Object {
                                       "fill": "currentColor",
                                       "xmlns": "http://www.w3.org/2000/svg",
                                     }
                                   }
-                                  iconVerticalAlign="-.125em"
+                                  iconVerticalAlign="middle"
                                   iconViewBox="0 0 512 512"
                                   size="0.9em"
                                   title="From Location Icon"
                                 >
                                   <svg
-                                    className="sc-bdfBwQ eCizyM styled__FromIcon-n5xcvc-0 fTLtLq"
+                                    className="StyledIconBase-ea9ulj-0 cKCFNq styled__FromIcon-n5xcvc-0 fTLtLq"
                                     fill="currentColor"
                                     focusable="false"
                                     height="0.9em"
@@ -9972,11 +9964,10 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                     <path
                                       d="M256 56c110.532 0 200 89.451 200 200 0 110.532-89.451 200-200 200-110.532 0-200-89.451-200-200 0-110.532 89.451-200 200-200m0-48C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 168c-44.183 0-80 35.817-80 80s35.817 80 80 80 80-35.817 80-80-35.817-80-80-80z"
                                       fill="currentColor"
-                                      key="k0"
                                     />
                                   </svg>
                                 </ForwardRef>
-                              </Styled(Component)>
+                              </StyledIconBase>
                             </DotCircle>
                           </styled__FromIcon>
                         </LocationIcon>
@@ -10010,7 +10001,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                               size="0.9em"
                               title="To Location Icon"
                             >
-                              <Styled(Component)
+                              <StyledIconBase
                                 className="styled__ToIcon-n5xcvc-2 jzAxgN"
                                 iconAttrs={
                                   Object {
@@ -10018,26 +10009,26 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                     "xmlns": "http://www.w3.org/2000/svg",
                                   }
                                 }
-                                iconVerticalAlign="-.125em"
+                                iconVerticalAlign="middle"
                                 iconViewBox="0 0 384 512"
                                 size="0.9em"
                                 title="To Location Icon"
                               >
                                 <ForwardRef
-                                  className="sc-bdfBwQ eCizyM styled__ToIcon-n5xcvc-2 jzAxgN"
+                                  className="StyledIconBase-ea9ulj-0 cKCFNq styled__ToIcon-n5xcvc-2 jzAxgN"
                                   iconAttrs={
                                     Object {
                                       "fill": "currentColor",
                                       "xmlns": "http://www.w3.org/2000/svg",
                                     }
                                   }
-                                  iconVerticalAlign="-.125em"
+                                  iconVerticalAlign="middle"
                                   iconViewBox="0 0 384 512"
                                   size="0.9em"
                                   title="To Location Icon"
                                 >
                                   <svg
-                                    className="sc-bdfBwQ eCizyM styled__ToIcon-n5xcvc-2 jzAxgN"
+                                    className="StyledIconBase-ea9ulj-0 cKCFNq styled__ToIcon-n5xcvc-2 jzAxgN"
                                     fill="currentColor"
                                     focusable="false"
                                     height="0.9em"
@@ -10054,11 +10045,10 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                     <path
                                       d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z"
                                       fill="currentColor"
-                                      key="k0"
                                     />
                                   </svg>
                                 </ForwardRef>
-                              </Styled(Component)>
+                              </StyledIconBase>
                             </MapMarkerAlt>
                           </styled__ToIcon>
                         </LocationIcon>
@@ -10080,7 +10070,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
             </div>
             <styled.div>
               <div
-                className="sc-iqHYGH RZjpG"
+                className="sc-kEjbxe ddEshv"
               >
                 <LiveStopTimes
                   autoRefreshStopTimes={true}
@@ -12704,7 +12694,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                   >
                                     <styled.div>
                                       <div
-                                        className="sc-dlfnbm eSOmhd"
+                                        className="sc-gsTCUz kuRGam"
                                       >
                                         P
                                       </div>

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@opentripplanner/humanize-distance": "^1.1.0",
     "@opentripplanner/icons": "^1.2.0",
     "@opentripplanner/itinerary-body": "^2.5.0",
-    "@opentripplanner/location-field": "^1.7.1",
+    "@opentripplanner/location-field": "^1.8.0",
     "@opentripplanner/location-icon": "^1.4.0",
     "@opentripplanner/park-and-ride-overlay": "^1.2.2",
     "@opentripplanner/printable-itinerary": "^1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1112,14 +1112,6 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@conveyal/geocoder-arcgis-geojson@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@conveyal/geocoder-arcgis-geojson/-/geocoder-arcgis-geojson-0.0.2.tgz#19ddf10160a76aba2a669c0f13ac5c079ba48f6b"
-  integrity sha1-Gd3xAWCnaroqZpwPE6xcB5ukj2s=
-  dependencies:
-    "@conveyal/lonlat" "^1.3.0"
-    geocoder-arcgis "^2.0.4"
-
 "@conveyal/geocoder-arcgis-geojson@^0.0.3":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@conveyal/geocoder-arcgis-geojson/-/geocoder-arcgis-geojson-0.0.3.tgz#0d1381c1d4f0e18bcf0ab1958fc63d148e2d80da"
@@ -1129,7 +1121,7 @@
     eslint-config-standard-jsx "^10.0.0"
     geocoder-arcgis "^2.0.5"
 
-"@conveyal/lonlat@^1.1.2", "@conveyal/lonlat@^1.3.0", "@conveyal/lonlat@^1.4.0", "@conveyal/lonlat@^1.4.1":
+"@conveyal/lonlat@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@conveyal/lonlat/-/lonlat-1.4.1.tgz#9970f33a2dc810ac08e89c844901405f18da478b"
   integrity sha512-Z4W1NmvDsnkylhPMDWCk7kLaAjRtA9BVixASFxDPVkQwAiceOxaLEo4UVbZys4jNFzdtbcZ1UVPr6SQHBmEsrA==
@@ -1175,7 +1167,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@^0.8.6", "@emotion/is-prop-valid@^0.8.7", "@emotion/is-prop-valid@^0.8.8":
+"@emotion/is-prop-valid@^0.8.7", "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -1569,21 +1561,6 @@
     "@opentripplanner/core-utils" "^4.1.0"
     prop-types "^15.7.2"
 
-"@opentripplanner/core-utils@^3.0.4":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-3.2.3.tgz#dd8d9107c268308ea922220e843a491411b48100"
-  integrity sha512-c18qsVsPSCNjWmDaDCRgyZTuRWW7FfmHxI3EoOoasWCjJWhkuWdypWCzPjqPPTUXdOs835lPlw9BlkPadSIa0A==
-  dependencies:
-    "@mapbox/polyline" "^1.1.0"
-    "@opentripplanner/geocoder" "^1.0.2"
-    "@turf/along" "^6.0.1"
-    bowser "^2.7.0"
-    lodash.isequal "^4.5.0"
-    moment "^2.24.0"
-    moment-timezone "^0.5.27"
-    prop-types "^15.7.2"
-    qs "^6.9.1"
-
 "@opentripplanner/core-utils@^4.1.0", "@opentripplanner/core-utils@^4.2.0", "@opentripplanner/core-utils@^4.3.0", "@opentripplanner/core-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-4.4.0.tgz#3eb8f9718d32ce50e3b79d975d682559c5a7b0bf"
@@ -1621,7 +1598,7 @@
     "@opentripplanner/location-icon" "^1.3.0"
     prop-types "^15.7.2"
 
-"@opentripplanner/geocoder@^1.0.2", "@opentripplanner/geocoder@^1.1.0", "@opentripplanner/geocoder@^1.1.1":
+"@opentripplanner/geocoder@^1.1.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@opentripplanner/geocoder/-/geocoder-1.1.2.tgz#fb4c939f5746705d0bebd9791b3f9d9eb055ce8e"
   integrity sha512-XEHzueckoi6UM1wfgLj/VTjOilEoAj9WA5D26wAM992ItJfvlllis2XfSQecBHDAFc7YbRoKxT6IbsJOmqeMuQ==
@@ -1674,7 +1651,7 @@
     "@styled-icons/fa-solid" "^10.34.0"
     throttle-debounce "^2.1.0"
 
-"@opentripplanner/location-icon@^1.0.1", "@opentripplanner/location-icon@^1.3.0", "@opentripplanner/location-icon@^1.4.0":
+"@opentripplanner/location-icon@^1.3.0", "@opentripplanner/location-icon@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@opentripplanner/location-icon/-/location-icon-1.4.0.tgz#49f34b5e61d407a4a76a00922296b746efd41b2e"
   integrity sha512-HlQ2ddAXpgXVnlB0oe8Nz79PLz0+Ew98e7KrSU9PSq66i0IdR7GqAhDiEQfHbiMWeWVU+wXsJCiVwVmgAysXiA==
@@ -1940,14 +1917,6 @@
     "@babel/runtime" "^7.14.0"
     "@styled-icons/styled-icon" "^10.6.3"
 
-"@styled-icons/boxicons-logos@^9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/boxicons-logos/-/boxicons-logos-9.4.1.tgz#774e7f73839e834445dcc0ae4c0c356221767664"
-  integrity sha512-DN6Za9paJeWkoIXI1newSSfDALIR8ecaAsgzP3ZD+NRJHy6idW+1ouC5p3DlRM29+Cp4yJ/z3bH9whBDbd7YXQ==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
 "@styled-icons/boxicons-regular@^10.38.0":
   version "10.38.0"
   resolved "https://registry.yarnpkg.com/@styled-icons/boxicons-regular/-/boxicons-regular-10.38.0.tgz#1eb80b4f94a18a9b77b11dee5204aa23378d37ec"
@@ -1955,62 +1924,6 @@
   dependencies:
     "@babel/runtime" "^7.15.3"
     "@styled-icons/styled-icon" "^10.6.3"
-
-"@styled-icons/boxicons-regular@^9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/boxicons-regular/-/boxicons-regular-9.4.1.tgz#742a1d0b5798c54f189b9278810d8110df8f9754"
-  integrity sha512-910zIWCB0JkEgk9I7zIIEdPc8xibg3xrT4Wo7gIu4lGEr4u9OOQT3c0ajJD7F+JlhWcWBVumzjfjOT8A5UjPJw==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
-"@styled-icons/boxicons-solid@^9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/boxicons-solid/-/boxicons-solid-9.4.1.tgz#5219a0c900f2ccc5dc9056c4ee2d1c180d9dbdf1"
-  integrity sha512-7FvU6KSnxBprsidta3/0grTkimYWDUnSZCyLscT1OwjmfyFPpnLNmJASQDrEtORF2GPw5Y2gc/q6h2RI4OnYcA==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
-"@styled-icons/crypto@^9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/crypto/-/crypto-9.4.1.tgz#9abe2a3165f78a1592ea1d910aa1e1210b990fef"
-  integrity sha512-qIjzvaw0kFykDN7PTGD8d3HvFVoX7kW7nwlvvzW/pGhVzpUHE7Mh2Syc04HpoknCgO0fCjAzXaxi9Igu3nS9NA==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
-"@styled-icons/entypo-social@^9.5.0":
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/@styled-icons/entypo-social/-/entypo-social-9.5.0.tgz#d5c69c928dbcb83c39d8359e50c148bd497bcaff"
-  integrity sha512-yEpaJtTUriZSZPT/iqxgNONgxDYr0MHXANvoUW2CB0Ey4zTZst+2x7EJ9KgL2CjdBgA0bs8hnx5etGHUi8BtuA==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
-"@styled-icons/entypo@^9.5.0":
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/@styled-icons/entypo/-/entypo-9.5.0.tgz#170c484e53820ec683d338353e44bae71d773611"
-  integrity sha512-gy/CXs45g1o5c61BnSnpd/cb84sXIARPByOa354FkN0aUHqepbF2qtBjZ3Udho6zWpm1nGOOUiawQb53PnG9vg==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
-"@styled-icons/evil@^9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/evil/-/evil-9.4.1.tgz#159d5c026e7d0689b453684b719ecb13e4ea0fe5"
-  integrity sha512-ejCBH+aXrjtBM+iMJomYlZ/xiJ+NGHVlIfQmkgD6roxtJzMzAmhwXgC5S3p0no2n1EXluUdJiufrI/QtP7iNbA==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
-"@styled-icons/fa-brands@^9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/fa-brands/-/fa-brands-9.4.1.tgz#ad329324875bb7db00ff5fb68ce98203fbe03b7a"
-  integrity sha512-zqlS/Y3mQLdBgRhZo1op5+twKYYwfS7OjqL90N+etokIWPqv1b7nwPWzwKoRpqDfCt/gyqmgxXqWufFd0CAx7Q==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
 
 "@styled-icons/fa-regular@^10.34.0":
   version "10.34.0"
@@ -2020,14 +1933,6 @@
     "@babel/runtime" "^7.14.0"
     "@styled-icons/styled-icon" "^10.6.3"
 
-"@styled-icons/fa-regular@^9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/fa-regular/-/fa-regular-9.4.1.tgz#556b1840e97db031b5c07a7175b57103e3fd988b"
-  integrity sha512-tpgLOUPECtWNwVs7G82IaDkb1T13yNyDNZBB85sEO02ldHAZe6tt0Yi5gGCBExtU/p+4/jLTcU+pcoh/mySlVg==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
 "@styled-icons/fa-solid@^10.34.0":
   version "10.34.0"
   resolved "https://registry.yarnpkg.com/@styled-icons/fa-solid/-/fa-solid-10.34.0.tgz#315a6f6f25d38202d3387928191731e4c7a3bb18"
@@ -2035,22 +1940,6 @@
   dependencies:
     "@babel/runtime" "^7.14.0"
     "@styled-icons/styled-icon" "^10.6.3"
-
-"@styled-icons/fa-solid@^9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/fa-solid/-/fa-solid-9.4.1.tgz#d30de755f8fee6e932032e97fa592cb1eaa21d8e"
-  integrity sha512-ZyPxbCFmuuy3XotCI0SgHyUn3gTvQXm+iVnh+8r0gR8Kd88iTTubTqxgtdS0lrefaB4ayl6vEg20Dv9e9PvYVg==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
-"@styled-icons/feather@^9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/feather/-/feather-9.4.1.tgz#5e8a4193e70d477e9ad249f921c6d637f9fc631c"
-  integrity sha512-ucMOPhvaCp6N4lxL+z/66Kech20jAdMfewER732jhjV8P3FknoAY2+0CXXE+tBvJoJ/SOJZDOsW58Gr7yAWXOQ==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
 
 "@styled-icons/foundation@^10.34.0":
   version "10.34.0"
@@ -2060,78 +1949,6 @@
     "@babel/runtime" "^7.14.0"
     "@styled-icons/styled-icon" "^10.6.3"
 
-"@styled-icons/foundation@^9.5.0":
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/@styled-icons/foundation/-/foundation-9.5.0.tgz#011ac022ffcb20868385b97bf4fb173cceaf634d"
-  integrity sha512-O4Y62bfZfZjhZDXYtJYd/RsID1vpmMtgLSP54b0KbvY70hjdlFQZ0ZVR2fAzA0YSK90VjbYBbQDCCyqim4v3qA==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
-"@styled-icons/heroicons-outline@^9.5.0":
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/@styled-icons/heroicons-outline/-/heroicons-outline-9.5.0.tgz#235046e3310e10165b9587a122a60e83e94e51de"
-  integrity sha512-MMY5NjVVimhTHhk+ADR4/a2KpjIjbmzW+SNPRCKMWgGyqXx1NjBrD72bnvrzApLdMnDvEsM/DYK6DVUW7UZhKw==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
-"@styled-icons/heroicons-solid@^9.5.0":
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/@styled-icons/heroicons-solid/-/heroicons-solid-9.5.0.tgz#2ed99d05a9a82c742eb7667c75b0d9c319fdee10"
-  integrity sha512-dYQYdxZ0BkGpl3nGQmkvONF1+Yq+E6I9S7snba1mirCDWQpIdgylGm+Z9CM/OvdIlhr5da00D4oZu+2CiGdCFQ==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
-"@styled-icons/icomoon@^9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/icomoon/-/icomoon-9.4.1.tgz#b75118a6d10cb8f5e7e15ae7a323009dd2f98e7e"
-  integrity sha512-oEw84P55EahJFdhQPBnUbvQqB08LuJKq75AkwaCSqk6w1DIEDbjY72lb6mbAwZB/AwNYeRVJJhTHaF1MNY103A==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
-"@styled-icons/material@^9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/material/-/material-9.4.1.tgz#26169db802a10e333a5608aec2611878dd45f6fe"
-  integrity sha512-7Ucsm7RxCrnznZb+WDptBrGE45ZVBODm6J0e+fy0hvO9sjWAcuoKffYTcQEhDS2pqC1Rcc/nSZHDbqwZrpGJVw==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
-"@styled-icons/octicons@^9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/octicons/-/octicons-9.4.1.tgz#9670b6a3fc70eb80961fa0771464d8dbde18a6ea"
-  integrity sha512-MHiMMah2agDpmk8JcNLgeZab74TO3elM8CIYIQahrucyVbHfCY7mX1z8OOyXZwrf/hgrBKK4nUM4jf0wxk70+Q==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
-"@styled-icons/open-iconic@^9.5.0":
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/@styled-icons/open-iconic/-/open-iconic-9.5.0.tgz#03c70256244ee4a1ed422563f3ce3d0270a6beb8"
-  integrity sha512-mSDnCPDKYXhXY+oNfgNKMj2+ltl63k8QIC6bCDsX18bYXDqkeEwKthfNw0minabyP4Tq+yJe/B03RH+EdQWmDg==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
-"@styled-icons/remix-fill@^9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/remix-fill/-/remix-fill-9.4.1.tgz#afc7141d0c5c0606ef190b0cebe4793a4449b389"
-  integrity sha512-OlxQudeM/u+IAHacSVwwiuSYBDSsQNKA4gr8WSFHpy1CEciLc/hE/aNJP+SLcBETdg/C/kJIj8JNme5B8aYIeg==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
-"@styled-icons/remix-line@^9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/remix-line/-/remix-line-9.4.1.tgz#1d4fdaef53f3c366a746f054d70dcd138a4e567e"
-  integrity sha512-NAdR8LD7ugeUhmd6W3v+GA5/6OBexe15fjQTt1kFHYclS+2nrLQ7MA4kF5SkwsRQNGPy+3CMN5cQoMy5R8NAtQ==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
 "@styled-icons/styled-icon@^10.6.3":
   version "10.6.3"
   resolved "https://registry.yarnpkg.com/@styled-icons/styled-icon/-/styled-icon-10.6.3.tgz#eae0e5e18fd601ac47e821bb9c2e099810e86403"
@@ -2139,30 +1956,6 @@
   dependencies:
     "@babel/runtime" "^7.10.5"
     "@emotion/is-prop-valid" "^0.8.7"
-
-"@styled-icons/styled-icon@^9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/styled-icon/-/styled-icon-9.4.1.tgz#9dc236c85afd89edc2bc7265ec7858cbc35d4234"
-  integrity sha512-qF0E2QOcyR1e6rh1QkKGsFt9vuayhZBJEKRa8erbHpOYLRNiEmoF1dLEVVMUKjnj5jAzzk0fNd8jSz0su3kpKg==
-  dependencies:
-    "@emotion/is-prop-valid" "^0.8.6"
-    tslib "^1.9.3"
-
-"@styled-icons/typicons@^9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@styled-icons/typicons/-/typicons-9.4.1.tgz#b201080bc3985cab1f0ff0e8827350aea14cb309"
-  integrity sha512-gV3W836B7k7FuNjZJt2H7WYcV+wPf7L5RYJQUL99lPdvADeOUhG2hIVIKvmS4F2Tc3XbyYbRmSBPTHtu4Fcftg==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
-
-"@styled-icons/zondicons@^9.5.0":
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/@styled-icons/zondicons/-/zondicons-9.5.0.tgz#27f184764f586f31aa9256905ab3db1cd833bfa8"
-  integrity sha512-26PYTzSr85tf1+P/N1zaqbLuJLG1YP9rp3QN1TsCcM19gT0Y3WzVUmiNHdv15jGO9bH/jpV9b7TjuT+1gkMPCw==
-  dependencies:
-    "@styled-icons/styled-icon" "^9.4.1"
-    tslib "^1.9.3"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -2217,7 +2010,7 @@
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.5.0.tgz#f79af094bd6b8ce7ed2bd3e089a8493ee6cae82e"
   integrity sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==
 
-"@turf/invariant@6.x", "@turf/invariant@^6.4.0", "@turf/invariant@^6.5.0":
+"@turf/invariant@6.x", "@turf/invariant@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.5.0.tgz#970afc988023e39c7ccab2341bd06979ddc7463f"
   integrity sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==
@@ -8149,7 +7942,7 @@ gentle-fs@^2.3.0, gentle-fs@^2.3.1:
     read-cmd-shim "^1.0.1"
     slide "^1.1.6"
 
-geocoder-arcgis@^2.0.4, geocoder-arcgis@^2.0.5:
+geocoder-arcgis@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/geocoder-arcgis/-/geocoder-arcgis-2.0.5.tgz#61cd1ff2b5b325e6d36b6e7da8138611936b2f26"
   integrity sha512-KebkgRbjJ5+682DVUswqRrNHGhcCz8CG3kqP21l6xeGWDbaoSkuFzgE+fMHrKs0Ij2NJHe2/R4Z779EaXdR/3w==
@@ -8998,7 +8791,7 @@ inflight@^1.0.4, inflight@~1.0.6:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -9719,7 +9512,7 @@ isomorphic-fetch@^3.0.0:
     node-fetch "^2.6.1"
     whatwg-fetch "^3.4.1"
 
-isomorphic-mapzen-search@^1.5.1, isomorphic-mapzen-search@^1.6.0:
+isomorphic-mapzen-search@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/isomorphic-mapzen-search/-/isomorphic-mapzen-search-1.6.0.tgz#eb368756d6132016a32c76435d6f34a38da5279f"
   integrity sha512-90Zp8jxWuMCk582S7d6b85lHO2Lj4Nybv8o6ShqQX2SRP7SFh1fzHx67eilNUGNjBeamKYQJHmijZ1/wSzFe3A==
@@ -11805,7 +11598,7 @@ mold-source-map@~0.4.0:
     convert-source-map "^1.1.0"
     through "~2.2.7"
 
-moment-timezone@^0.5.27, moment-timezone@^0.5.33:
+moment-timezone@^0.5.33:
   version "0.5.33"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
   integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
@@ -15876,7 +15669,7 @@ safe-buffer@5.1.2, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, 
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+safe-buffer@^5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -16885,36 +16678,6 @@ styled-components@^5.0.0:
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
-styled-icons@^9.1.0:
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/styled-icons/-/styled-icons-9.5.0.tgz#d1f6c8dcc3ea81c3d30fe20dfda5d39a8afc593c"
-  integrity sha512-nby51U6+SRY5010P15XogBZubrqblqXTV50+lA/xBkC1QrTap1BIgCvoJwH9FF5kYI+LKFl/xeco/drwqIR2Pw==
-  dependencies:
-    "@styled-icons/boxicons-logos" "^9.4.1"
-    "@styled-icons/boxicons-regular" "^9.4.1"
-    "@styled-icons/boxicons-solid" "^9.4.1"
-    "@styled-icons/crypto" "^9.4.1"
-    "@styled-icons/entypo" "^9.5.0"
-    "@styled-icons/entypo-social" "^9.5.0"
-    "@styled-icons/evil" "^9.4.1"
-    "@styled-icons/fa-brands" "^9.4.1"
-    "@styled-icons/fa-regular" "^9.4.1"
-    "@styled-icons/fa-solid" "^9.4.1"
-    "@styled-icons/feather" "^9.4.1"
-    "@styled-icons/foundation" "^9.5.0"
-    "@styled-icons/heroicons-outline" "^9.5.0"
-    "@styled-icons/heroicons-solid" "^9.5.0"
-    "@styled-icons/icomoon" "^9.4.1"
-    "@styled-icons/material" "^9.4.1"
-    "@styled-icons/octicons" "^9.4.1"
-    "@styled-icons/open-iconic" "^9.5.0"
-    "@styled-icons/remix-fill" "^9.4.1"
-    "@styled-icons/remix-line" "^9.4.1"
-    "@styled-icons/styled-icon" "^9.4.1"
-    "@styled-icons/typicons" "^9.4.1"
-    "@styled-icons/zondicons" "^9.5.0"
-    tslib "^1.9.3"
-
 stylehacks@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-4.0.3.tgz#6718fcaf4d1e07d8a1318690881e8d96726a71d5"
@@ -17455,7 +17218,7 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.4.tgz#3b52b1f13924f460c3fbfd0df69b587dbcbc762e"
   integrity sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==
 
-tslib@^1.10.0, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -18594,11 +18357,6 @@ xml2js@0.4.19, xml2js@^0.4.17:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
-
-xmlbuilder@~11.0.0:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
-  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlbuilder@~9.0.1:
   version "9.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1687,6 +1687,16 @@
     isomorphic-mapzen-search "^1.5.1"
     lodash.memoize "^4.1.2"
 
+"@opentripplanner/geocoder@^1.1.0":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/geocoder/-/geocoder-1.1.2.tgz#fb4c939f5746705d0bebd9791b3f9d9eb055ce8e"
+  integrity sha512-XEHzueckoi6UM1wfgLj/VTjOilEoAj9WA5D26wAM992ItJfvlllis2XfSQecBHDAFc7YbRoKxT6IbsJOmqeMuQ==
+  dependencies:
+    "@conveyal/geocoder-arcgis-geojson" "^0.0.3"
+    "@conveyal/lonlat" "^1.4.1"
+    isomorphic-mapzen-search "^1.6.0"
+    lodash.memoize "^4.1.2"
+
 "@opentripplanner/geocoder@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@opentripplanner/geocoder/-/geocoder-1.1.1.tgz#a449ad868a01d9e35291e52f68946929469c065a"
@@ -9893,6 +9903,14 @@ isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
 
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
+
 isomorphic-mapzen-search@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/isomorphic-mapzen-search/-/isomorphic-mapzen-search-1.5.1.tgz#5ac0214cec436fb550e8ef362cf8d11b17de8e9c"
@@ -9900,6 +9918,15 @@ isomorphic-mapzen-search@^1.5.1:
   dependencies:
     "@conveyal/lonlat" "^1.1.2"
     isomorphic-fetch "^2.2.1"
+    qs "^6.3.0"
+
+isomorphic-mapzen-search@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-mapzen-search/-/isomorphic-mapzen-search-1.6.0.tgz#eb368756d6132016a32c76435d6f34a38da5279f"
+  integrity sha512-90Zp8jxWuMCk582S7d6b85lHO2Lj4Nybv8o6ShqQX2SRP7SFh1fzHx67eilNUGNjBeamKYQJHmijZ1/wSzFe3A==
+  dependencies:
+    "@conveyal/lonlat" "^1.4.1"
+    isomorphic-fetch "^3.0.0"
     qs "^6.3.0"
 
 isstream@~0.1.2:
@@ -18591,6 +18618,11 @@ whatwg-fetch@>=0.10.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+
+whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,7 +1677,7 @@
     "@opentripplanner/location-icon" "^1.3.0"
     prop-types "^15.7.2"
 
-"@opentripplanner/geocoder@^1.0.2", "@opentripplanner/geocoder@^1.1.0":
+"@opentripplanner/geocoder@^1.0.2":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@opentripplanner/geocoder/-/geocoder-1.1.0.tgz#f3c0cd825e3c12f7661f781e85a58c08f4394755"
   integrity sha512-rqMdQVwf/JjxCNMwdYhRslYjou8Y2yREzdwSh14PM88m8FEB0GMdfE+NUtKKzZfVfpbt08LdsUOkN45i+dnBKw==
@@ -1735,10 +1735,10 @@
     react-resize-detector "^4.2.1"
     velocity-react "^1.4.3"
 
-"@opentripplanner/location-field@^1.7.1":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/location-field/-/location-field-1.7.1.tgz#90aa4c06eb13a91a5c95076d33c34ff043fd50b2"
-  integrity sha512-I98YSf0JXdqax2B9f8zlf7f2f3e3g5nw62zv5lGeC2DdmPb8rwDXskUxqq4c9xzsXW8aMN4+ihkuyMpbhhJiNA==
+"@opentripplanner/location-field@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/location-field/-/location-field-1.8.0.tgz#a210c9b7fbddd7a503b1077bdfbcfdd3c1dca579"
+  integrity sha512-0CKWy9kV/odd0mpSSCPm+F/XinYkus5xUHXsBjKcN4Fc5y+uA9mR9pfXaL7ztNARbdQMWwtPhenzsO+qae8D/Q==
   dependencies:
     "@conveyal/geocoder-arcgis-geojson" "^0.0.3"
     "@opentripplanner/core-utils" "^4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,14 +1064,7 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.2.0", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
-  version "7.14.8"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
-  integrity sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.14.0", "@babel/runtime@^7.15.3":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.15.3", "@babel/runtime@^7.2.0", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
   integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
@@ -1136,12 +1129,7 @@
     eslint-config-standard-jsx "^10.0.0"
     geocoder-arcgis "^2.0.5"
 
-"@conveyal/lonlat@^1.1.2", "@conveyal/lonlat@^1.3.0", "@conveyal/lonlat@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@conveyal/lonlat/-/lonlat-1.4.0.tgz#18a5c1349078a779e710d24af11bc02b24127ba0"
-  integrity sha512-ag1FcRuwRGAZgeZ4e3sUq+gblf1Pgma2c9SaIVXluIrgsZ9Lrq7xhCbV0ErN8chyg/OCOoG8m/l3mgzbycQCnQ==
-
-"@conveyal/lonlat@^1.4.1":
+"@conveyal/lonlat@^1.1.2", "@conveyal/lonlat@^1.3.0", "@conveyal/lonlat@^1.4.0", "@conveyal/lonlat@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@conveyal/lonlat/-/lonlat-1.4.1.tgz#9970f33a2dc810ac08e89c844901405f18da478b"
   integrity sha512-Z4W1NmvDsnkylhPMDWCk7kLaAjRtA9BVixASFxDPVkQwAiceOxaLEo4UVbZys4jNFzdtbcZ1UVPr6SQHBmEsrA==
@@ -1596,42 +1584,7 @@
     prop-types "^15.7.2"
     qs "^6.9.1"
 
-"@opentripplanner/core-utils@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-4.1.0.tgz#fd1f879de0366e9b1ac1d4af9450df4296338711"
-  integrity sha512-SGsazdapV7zUxaLg8AM3TgLGqlLHc34qhAoI/6Z3fjFFlbOb5+vFefltFSnKvOh0IYx/33gRJZ35FTcmCSZqkQ==
-  dependencies:
-    "@mapbox/polyline" "^1.1.0"
-    "@opentripplanner/geocoder" "^1.0.2"
-    "@turf/along" "^6.0.1"
-    bowser "^2.7.0"
-    date-fns "^2.23.0"
-    date-fns-tz "^1.1.4"
-    lodash.clonedeep "^4.5.0"
-    lodash.isequal "^4.5.0"
-    moment "^2.24.0"
-    prop-types "^15.7.2"
-    qs "^6.9.1"
-
-"@opentripplanner/core-utils@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-4.2.0.tgz#c6b1097221f7372798bf53db969e47cf86e9bb66"
-  integrity sha512-FdwLQJxrS9oxbITctFBar4v0UcJng5F2OaApQN8tGWqQhnIrxb+odtgvFMxR4ExKBGkS8TKfv4DSSmZXUC24Mg==
-  dependencies:
-    "@mapbox/polyline" "^1.1.0"
-    "@opentripplanner/geocoder" "^1.1.0"
-    "@styled-icons/foundation" "^10.34.0"
-    "@turf/along" "^6.0.1"
-    bowser "^2.7.0"
-    date-fns "^2.23.0"
-    date-fns-tz "^1.1.4"
-    lodash.clonedeep "^4.5.0"
-    lodash.isequal "^4.5.0"
-    moment "^2.24.0"
-    prop-types "^15.7.2"
-    qs "^6.9.1"
-
-"@opentripplanner/core-utils@^4.3.0", "@opentripplanner/core-utils@^4.4.0":
+"@opentripplanner/core-utils@^4.1.0", "@opentripplanner/core-utils@^4.2.0", "@opentripplanner/core-utils@^4.3.0", "@opentripplanner/core-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-4.4.0.tgz#3eb8f9718d32ce50e3b79d975d682559c5a7b0bf"
   integrity sha512-qCd+NXa0PxwcN2DFR0HX1u/76RzQwHe2r0VGcaOS4GxvQ5HEL4zPyaT+lkxAyE6AFQAvNynyofhxlnMwbxtqEA==
@@ -1659,16 +1612,7 @@
     "@styled-icons/fa-solid" "^10.34.0"
     prop-types "^15.7.2"
 
-"@opentripplanner/from-to-location-picker@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/from-to-location-picker/-/from-to-location-picker-1.2.1.tgz#b9787ae891d35d3ac0604ced89d2bae5f74fa5e8"
-  integrity sha512-uNNnedAcLNWCAdqZuwls1lLE0zBWkDus0oYXqZ9qEk0ipdB68cK97kULKy4vcts+hvujGfXGpdJKImYIVU5FhQ==
-  dependencies:
-    "@opentripplanner/core-utils" "^3.0.4"
-    "@opentripplanner/location-icon" "^1.0.1"
-    prop-types "^15.7.2"
-
-"@opentripplanner/from-to-location-picker@^1.3.0":
+"@opentripplanner/from-to-location-picker@^1.2.1", "@opentripplanner/from-to-location-picker@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@opentripplanner/from-to-location-picker/-/from-to-location-picker-1.3.0.tgz#fa24a1e0e9b8df41b997ef766dbc2f67843db9f0"
   integrity sha512-OHvGphABYQv075CuLqiw1CdONl6TYQMVw27CR5xr24wz6KVOhLokd5BEcHvKGJvhMtKDmU5csXUx6b42y58lww==
@@ -1677,17 +1621,7 @@
     "@opentripplanner/location-icon" "^1.3.0"
     prop-types "^15.7.2"
 
-"@opentripplanner/geocoder@^1.0.2":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/geocoder/-/geocoder-1.1.0.tgz#f3c0cd825e3c12f7661f781e85a58c08f4394755"
-  integrity sha512-rqMdQVwf/JjxCNMwdYhRslYjou8Y2yREzdwSh14PM88m8FEB0GMdfE+NUtKKzZfVfpbt08LdsUOkN45i+dnBKw==
-  dependencies:
-    "@conveyal/geocoder-arcgis-geojson" "^0.0.2"
-    "@conveyal/lonlat" "^1.4.0"
-    isomorphic-mapzen-search "^1.5.1"
-    lodash.memoize "^4.1.2"
-
-"@opentripplanner/geocoder@^1.1.0":
+"@opentripplanner/geocoder@^1.0.2", "@opentripplanner/geocoder@^1.1.0", "@opentripplanner/geocoder@^1.1.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@opentripplanner/geocoder/-/geocoder-1.1.2.tgz#fb4c939f5746705d0bebd9791b3f9d9eb055ce8e"
   integrity sha512-XEHzueckoi6UM1wfgLj/VTjOilEoAj9WA5D26wAM992ItJfvlllis2XfSQecBHDAFc7YbRoKxT6IbsJOmqeMuQ==
@@ -1697,30 +1631,12 @@
     isomorphic-mapzen-search "^1.6.0"
     lodash.memoize "^4.1.2"
 
-"@opentripplanner/geocoder@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/geocoder/-/geocoder-1.1.1.tgz#a449ad868a01d9e35291e52f68946929469c065a"
-  integrity sha512-XejHs5KvYcZOnv/oh8QrF4JU43Fne803HjWx0o0a7OfxqvWj9Xh7ioKktKz7HMXmtI9nSMWWXpeqLW6tTp9K9w==
-  dependencies:
-    "@conveyal/geocoder-arcgis-geojson" "^0.0.2"
-    "@conveyal/lonlat" "^1.4.1"
-    isomorphic-mapzen-search "^1.5.1"
-    lodash.memoize "^4.1.2"
-
 "@opentripplanner/humanize-distance@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@opentripplanner/humanize-distance/-/humanize-distance-1.1.0.tgz#aa5ecdd70f33cfbdd214c76da4ba799a8ab473a5"
   integrity sha512-U+rANHgl+Fz6srX2lZ6LNLkDKPaUvWb27pZeVs9f8qsA/hLlx8X3FY1T9BrYaXwxgSlwAha+YzcKUC/2SfQjJQ==
 
-"@opentripplanner/icons@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/icons/-/icons-1.1.0.tgz#434c6a6ee2ad300fe54d67b2891450c1f7fe59a4"
-  integrity sha512-G583Evm46qk38CAgT7AWB+zNg5N9wcsox+W/c4DBSMdE/9ZAu9uFfwyOuMp+WhbNO5Gj5k+13YLp/FN3jgA9pQ==
-  dependencies:
-    "@opentripplanner/core-utils" "^3.0.4"
-    prop-types "^15.7.2"
-
-"@opentripplanner/icons@^1.2.0":
+"@opentripplanner/icons@^1.1.0", "@opentripplanner/icons@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@opentripplanner/icons/-/icons-1.2.0.tgz#00751e17aad99620bd08b47af0c09c94cb99cf74"
   integrity sha512-0wVJmBa7NLeurer8dq3BJdZhPOhrRomomSEB6gYODZsKL6ZqWm8PykXeT6ACDfz3e2nsrKBdsg+XvqYeL6eG7Q==
@@ -1758,14 +1674,7 @@
     "@styled-icons/fa-solid" "^10.34.0"
     throttle-debounce "^2.1.0"
 
-"@opentripplanner/location-icon@^1.0.1", "@opentripplanner/location-icon@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/location-icon/-/location-icon-1.3.0.tgz#d3e315c906f4e0054322e0e1de102a76d5ead81c"
-  integrity sha512-R36HaGt7iC9WRbUscJJY2HyerAOT5/Z8ytWT3U/y3grpMkf9rUajA17YX7qsZoL+FBgyBiVRsVqoq7n6TYARJw==
-  dependencies:
-    styled-icons "^9.1.0"
-
-"@opentripplanner/location-icon@^1.4.0":
+"@opentripplanner/location-icon@^1.0.1", "@opentripplanner/location-icon@^1.3.0", "@opentripplanner/location-icon@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@opentripplanner/location-icon/-/location-icon-1.4.0.tgz#49f34b5e61d407a4a76a00922296b746efd41b2e"
   integrity sha512-HlQ2ddAXpgXVnlB0oe8Nz79PLz0+Ew98e7KrSU9PSq66i0IdR7GqAhDiEQfHbiMWeWVU+wXsJCiVwVmgAysXiA==
@@ -2279,15 +2188,7 @@
     "@turf/helpers" "^6.4.0"
     "@turf/meta" "^6.4.0"
 
-"@turf/bearing@6.x":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@turf/bearing/-/bearing-6.4.0.tgz#9a85567cbdd2cdd17ffe6243342a656af70e74d9"
-  integrity sha512-CmMsT8hSzzhZWe0+49OP48m/EAXryZjNh/7D/0nqMIlayslRZ+bHuV3KcrOCD20xoDFtBuSEdwEd6i4+2Nw3LA==
-  dependencies:
-    "@turf/helpers" "^6.4.0"
-    "@turf/invariant" "^6.4.0"
-
-"@turf/bearing@^6.5.0":
+"@turf/bearing@6.x", "@turf/bearing@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/bearing/-/bearing-6.5.0.tgz#462a053c6c644434bdb636b39f8f43fb0cd857b0"
   integrity sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==
@@ -2295,15 +2196,7 @@
     "@turf/helpers" "^6.5.0"
     "@turf/invariant" "^6.5.0"
 
-"@turf/destination@6.x":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@turf/destination/-/destination-6.4.0.tgz#0325fb9297179dc7938563324f5b7e0bcb9a48ac"
-  integrity sha512-jSZtFhwG2JMUc3MLH5z6IVbvk/MYfsQmqOhjc7Lv6twjdipJ/KzKfLD8FRClaDm/ByCMcO7ZYG3z5AagyQu31g==
-  dependencies:
-    "@turf/helpers" "^6.4.0"
-    "@turf/invariant" "^6.4.0"
-
-"@turf/destination@^6.5.0":
+"@turf/destination@6.x", "@turf/destination@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/destination/-/destination-6.5.0.tgz#30a84702f9677d076130e0440d3223ae503fdae1"
   integrity sha512-4cnWQlNC8d1tItOz9B4pmJdWpXqS0vEvv65bI/Pj/genJnsL7evI0/Xw42RvEGROS481MPiU80xzvwxEvhQiMQ==
@@ -2311,15 +2204,7 @@
     "@turf/helpers" "^6.5.0"
     "@turf/invariant" "^6.5.0"
 
-"@turf/distance@6.x":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-6.4.0.tgz#c5b40af4851785f6792f651749aedb9d16e1d599"
-  integrity sha512-EyNEfHfFNVwLHsD31hIpaDInoxlwUFZAVryTWxDu6O+XNE+VfVomMUxLYPm3t0tVqVNUGwOhYo5Z4HfTlr6V1g==
-  dependencies:
-    "@turf/helpers" "^6.4.0"
-    "@turf/invariant" "^6.4.0"
-
-"@turf/distance@^6.5.0":
+"@turf/distance@6.x", "@turf/distance@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-6.5.0.tgz#21f04d5f86e864d54e2abde16f35c15b4f36149a"
   integrity sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==
@@ -2327,24 +2212,12 @@
     "@turf/helpers" "^6.5.0"
     "@turf/invariant" "^6.5.0"
 
-"@turf/helpers@6.x", "@turf/helpers@^6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.4.0.tgz#e263d960ab1caed3bfe86a7f2f4b2096dbbf0635"
-  integrity sha512-7vVpWZwHP0Qn8DDSlM++nhs3/6zfPt+GODjvLVZ+sWIG4S3vOtUUOfO5eIjRzxsUHHqhgiIL0QA17u79uLM+mQ==
-
-"@turf/helpers@^6.5.0":
+"@turf/helpers@6.x", "@turf/helpers@^6.4.0", "@turf/helpers@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.5.0.tgz#f79af094bd6b8ce7ed2bd3e089a8493ee6cae82e"
   integrity sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==
 
-"@turf/invariant@6.x", "@turf/invariant@^6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.4.0.tgz#bedef5a55e6dc867eabbc5660f3df754b5709d4b"
-  integrity sha512-ncAiOLkL6Ul6NnyOZSSmEbTwcZZ8PTx7O1IzB89Ed/mAe1g5PvFnyFieWbcnERGmuqH1ftzgtWMFFHFi2PQLsg==
-  dependencies:
-    "@turf/helpers" "^6.4.0"
-
-"@turf/invariant@^6.5.0":
+"@turf/invariant@6.x", "@turf/invariant@^6.4.0", "@turf/invariant@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.5.0.tgz#970afc988023e39c7ccab2341bd06979ddc7463f"
   integrity sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==
@@ -2371,14 +2244,7 @@
     "@turf/invariant" "^6.5.0"
     "@turf/meta" "^6.5.0"
 
-"@turf/meta@6.x", "@turf/meta@^6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-6.4.0.tgz#6f6ff110199063c8eee3ee036ede2c1e52d12a04"
-  integrity sha512-fMra6vMskwz1knn0/tb22ppOeE8CCmpvOvTIxLdV1WYWAoC4bJ4WdXKvZRsJKpHOX5iFehx4DT8aaGdROA4Y3Q==
-  dependencies:
-    "@turf/helpers" "^6.4.0"
-
-"@turf/meta@^6.5.0":
+"@turf/meta@6.x", "@turf/meta@^6.4.0", "@turf/meta@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-6.5.0.tgz#b725c3653c9f432133eaa04d3421f7e51e0418ca"
   integrity sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==
@@ -2479,12 +2345,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
-"@types/node@*", "@types/node@>= 8":
-  version "14.14.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.9.tgz#04afc9a25c6ff93da14deabd65dc44485b53c8d6"
-  integrity sha512-JsoLXFppG62tWTklIoO4knA+oDTYsmqWxHRvd4lpmfQRNhX6osheUOWETP2jMoV/2bEHuMra8Pp3Dmo/stBFcw==
-
-"@types/node@^8.9.4":
+"@types/node@*", "@types/node@>= 8", "@types/node@^8.9.4":
   version "8.10.66"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.66.tgz#dd035d409df322acc83dff62a602f12a5783bbb3"
   integrity sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==
@@ -2906,12 +2767,12 @@ append-buffer@^1.0.2:
   dependencies:
     buffer-equal "^1.0.0"
 
-aproba@^1.0.3, aproba@^1.1.1, aproba@^1.1.2:
+aproba@^1.0.3, aproba@^1.1.1, aproba@^1.1.2, "aproba@^1.1.2 || 2":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
-"aproba@^1.1.2 || 2", aproba@^2.0.0:
+aproba@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
   integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
@@ -5062,12 +4923,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
-  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
-
-classnames@^2.2.6:
+classnames@^2.2.5, classnames@^2.2.6:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
@@ -5330,12 +5186,7 @@ colors@1.0.3:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-colors@^1.1.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
-
-colors@~1.1.2:
+colors@^1.1.2, colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
   integrity sha1-FopHAXVran9RoSzgyXv6KMCE7WM=
@@ -5427,15 +5278,10 @@ component-each@0.2.6:
     component-type "1.0.0"
     to-function "2.0.6"
 
-component-emitter@1.2.1:
+component-emitter@1.2.1, component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
   integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
-
-component-emitter@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
-  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
 component-props@*:
   version "1.1.1"
@@ -6276,12 +6122,7 @@ de-indent@^1.0.2:
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
 
-debounce@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
-  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
-
-debounce@^1.2.0:
+debounce@^1.0.0, debounce@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
   integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
@@ -7282,18 +7123,10 @@ eslint-plugin-standard@^4.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz#f845b45109c99cd90e77796940a344546c8f6b5c"
   integrity sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==
 
-eslint-scope@3.7.1:
+eslint-scope@3.7.1, eslint-scope@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
   integrity sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=
-  dependencies:
-    esrecurse "^4.1.0"
-    estraverse "^4.1.1"
-
-eslint-scope@^3.7.1:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.3.tgz#bb507200d3d17f60247636160b4826284b108535"
-  integrity sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
@@ -7731,15 +7564,10 @@ extract-zip@2.0.1:
   optionalDependencies:
     "@types/yauzl" "^2.9.1"
 
-extsprintf@1.3.0:
+extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
   integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
-
-extsprintf@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
-  integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
 fast-deep-equal@^3.1.1:
   version "3.1.3"
@@ -8074,16 +7902,7 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@^2.3.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
-  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
-    mime-types "^2.1.12"
-
-form-data@~2.3.2:
+form-data@^2.3.1, form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
   integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
@@ -8954,24 +8773,13 @@ http-cache-semantics@^3.8.1:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
   integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
 
-http-errors@1.7.2:
+http-errors@1.7.2, http-errors@~1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f"
   integrity sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
   dependencies:
     depd "~1.1.2"
     inherits "2.0.3"
-    setprototypeof "1.1.1"
-    statuses ">= 1.5.0 < 2"
-    toidentifier "1.0.0"
-
-http-errors@~1.7.2:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
-  integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.4"
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
@@ -9911,16 +9719,7 @@ isomorphic-fetch@^3.0.0:
     node-fetch "^2.6.1"
     whatwg-fetch "^3.4.1"
 
-isomorphic-mapzen-search@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-mapzen-search/-/isomorphic-mapzen-search-1.5.1.tgz#5ac0214cec436fb550e8ef362cf8d11b17de8e9c"
-  integrity sha512-38GcjidOqjVQkUzDovx+ceUXHwOliIoFq+qJ/zUzaZwn2h8qEANLMTjaZkFvYN2XdSGB65zBOH5n/iP/Vs1ejA==
-  dependencies:
-    "@conveyal/lonlat" "^1.1.2"
-    isomorphic-fetch "^2.2.1"
-    qs "^6.3.0"
-
-isomorphic-mapzen-search@^1.6.0:
+isomorphic-mapzen-search@^1.5.1, isomorphic-mapzen-search@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/isomorphic-mapzen-search/-/isomorphic-mapzen-search-1.6.0.tgz#eb368756d6132016a32c76435d6f34a38da5279f"
   integrity sha512-90Zp8jxWuMCk582S7d6b85lHO2Lj4Nybv8o6ShqQX2SRP7SFh1fzHx67eilNUGNjBeamKYQJHmijZ1/wSzFe3A==
@@ -12050,15 +11849,10 @@ ms@2.1.2, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-mute-stream@0.0.7:
+mute-stream@0.0.7, mute-stream@~0.0.4:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
-
-mute-stream@~0.0.4:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
-  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
 nan@^2.12.1:
   version "2.14.0"
@@ -14455,15 +14249,10 @@ process@^0.11.10, process@~0.11.0:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-progress@2.0.1:
+progress@2.0.1, progress@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
   integrity sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
-
-progress@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
-  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 promise-inflight@^1.0.1, promise-inflight@~1.0.1:
   version "1.0.1"
@@ -14649,15 +14438,10 @@ pumpify@^1.3.3, pumpify@^1.3.5:
     inherits "^2.0.3"
     pump "^2.0.0"
 
-punycode@1.3.2:
+punycode@1.3.2, punycode@^1.2.4, punycode@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
-
-punycode@^1.2.4, punycode@^1.3.2:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-  integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
@@ -15310,7 +15094,7 @@ read@1, read@~1.0.1, read@~1.0.7:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.3, readable-stream@~2.3.6:
+"readable-stream@1 || 2", "readable-stream@2 || 3", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.3, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -15323,7 +15107,7 @@ read@1, read@~1.0.1, read@~1.0.7:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-"readable-stream@2 || 3", readable-stream@3, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
+readable-stream@3, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -16087,12 +15871,12 @@ rxjs@^6.1.0, rxjs@^6.4.0, rxjs@^6.5.2, rxjs@^6.6.7:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -16973,14 +16757,7 @@ string_decoder@0.10, string_decoder@~0.10.x:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
   integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
-string_decoder@^1.0.0, string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
-string_decoder@~1.1.1:
+string_decoder@^1.0.0, string_decoder@^1.1.1, string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
@@ -18241,7 +18018,7 @@ util.promisify@^1.0.0, util.promisify@~1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-util@0.10.3:
+util@0.10.3, util@~0.10.1:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
@@ -18252,13 +18029,6 @@ util@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
   integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
-  dependencies:
-    inherits "2.0.3"
-
-util@~0.10.1:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
-  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
   dependencies:
     inherits "2.0.3"
 
@@ -18614,12 +18384,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@>=0.10.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
-
-whatwg-fetch@^3.4.1:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^3.4.1:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
   integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
@@ -18822,21 +18587,13 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xml2js@0.4.19:
+xml2js@0.4.19, xml2js@^0.4.17:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
   integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
-
-xml2js@^0.4.17:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
-  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~11.0.0"
 
 xmlbuilder@~11.0.0:
   version "11.0.1"


### PR DESCRIPTION
The 1.7.0 location field update introduced street names to business/place search results, however the street names didn't show up in other locations, like the itinerary or saved trips. This update fixes that, so those results will propagate everywhere. For old saved trips, or for URLs (with query params) saved before this update, users will still see the old names. 