### PR TITLE
fix(switch-button): automatically re-plan after clicking

### DIFF
--- a/lib/actions/map.js
+++ b/lib/actions/map.js
@@ -102,19 +102,19 @@ export function setLocationToCurrent (payload) {
 }
 
 export function switchLocations () {
-  return function (dispatch, getState) {
+  return async function (dispatch, getState) {
     const { from, to } = getState().otp.currentQuery
     // First, reverse the locations.
-    dispatch(settingLocation({
+    await dispatch(settingLocation({
       location: to,
       locationType: 'from'
     }))
-    dispatch(settingLocation({
+    await dispatch(settingLocation({
       location: from,
       locationType: 'to'
     }))
     // Then kick off a routing query (if the query is invalid, search will abort).
-    dispatch(routingQuery())
+    return dispatch(routingQuery())
   }
 }
 


### PR DESCRIPTION
The switch button was doing everything correctly, but because didn't wait for dispatches to finish, had an internal race condition that sometimes resulted in it not planning the new trip.

This PR fixes this.