### PR TITLE
V4 Release Updates

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -23,7 +23,11 @@ jobs:
         uses: bahmutov/npm-install@v1
       - name: Copy example config
         run: cp example-config.yml config.yml
-        # Actual lint step temporarily removed to allow for package release
+      - name: Lint code
+        # Move everything from latest commit back to staged
+        run: git reset --soft HEAD^ && yarn lint
+        # For our info, lint all files but don't mark them as failure
+        # TODO: remove this once project is typescripted
       - name: Lint all code (ignoring errors)
         run: yarn lint-all || true
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn start
 Should you want to maintain multiple configuration files, OTP-RR can be made to use a custom config file by using environment variables. Other environment variables also exist. `CUSTOM_CSS` can be used to point to a css file to inject, and `JS_CONFIG` can be used to point to a `config.js` file to override the one shipped with OTP-RR.
 
 ```bash
-yarn start --env.YAML_CONFIG=/absolute/path/to/config.yml
+env YAML_CONFIG=/absolute/path/to/config.yml yarn start
 ```
 
 ## Deploying the UI
@@ -31,7 +31,7 @@ Build the js/css bundle by running `yarn build`. The build will appear in the `d
 The same environment variables which affect the behavior of `yarn start` also affect `yarn build`. Running the following command builds OTP-RR with customized js and css:
 
 ```bash
-yarn build --env.JS_CONFIG=my-custom-js.js env.CUSTOM_CSS=my-custom-css.css
+env JS_CONFIG=my-custom-js.js CUSTOM_CSS=my-custom-css.css yarn build
 ```
 
 ## Library Documentation

--- a/craco.config.js
+++ b/craco.config.js
@@ -31,8 +31,7 @@ module.exports = {
   /**
    * Webpack can be passed a few environment variables to override the default
    * files used to run this project. The environment variables are CUSTOM_CSS,
-   * HTML_FILE, YAML_CONFIG, and JS_CONFIG. They must each be passed via env
-   * variables *=/path/to/file. For example:
+   * HTML_FILE, YAML_CONFIG, and JS_CONFIG. For example:
    *
    *    env YAML_CONFIG=/absolute/path/to/config.yml yarn start
    */

--- a/craco.config.js
+++ b/craco.config.js
@@ -20,10 +20,10 @@ module.exports = {
   /**
    * Webpack can be passed a few environment variables to override the default
    * files used to run this project. The environment variables are CUSTOM_CSS,
-   * HTML_FILE, YAML_CONFIG, and JS_CONFIG. They must each be passed in the
-   * format --env.*=/path/to/file. For example:
+   * HTML_FILE, YAML_CONFIG, and JS_CONFIG. They must each be passed via env
+   * variables *=/path/to/file. For example:
    *
-   *    yarn start --env.YAML_CONFIG=/absolute/path/to/config.yml
+   *    env YAML_CONFIG=/absolute/path/to/config.yml yarn start
    */
   webpack: {
     // eslint-disable-next-line complexity


### PR DESCRIPTION
This PR contains the README updates for craco that should've shipped with the craco PR. It also contains a breaking change to upgrade otp-rr to version 4 (as craco was a significant change). 

This PR should be merged after #512 and #516 to ensure the versions are updated correctly (this PR must reverse the changes made in #512)!

Reverts https://github.com/opentripplanner/otp-react-redux/commit/39fd703fa7cec12f92d25acd7a8ec13e6869f168