### PR TITLE
chore(call-taker): fix padding on batch routing panel

### DIFF
--- a/lib/components/app/call-taker-panel.js
+++ b/lib/components/app/call-taker-panel.js
@@ -159,14 +159,13 @@ class CallTakerPanel extends Component {
             bottom: showPlanTripButton ? 55 : 0,
             left: 0,
             overflow: 'hidden',
-            padding: '10px',
             paddingBottom: 15,
             position: 'absolute',
             right: 0,
             top: 0
           }}
         >
-          <div className="form">
+          <div className="form" style={{ padding: '5px 10px' }}>
             <LocationField
               inputPlaceholder={intl.formatMessage(
                 { id: 'common.searchForms.enterStartLocation' },


### PR DESCRIPTION
This fixes #514 by adjusting where the padding is applied so that the batch routing panel touches the edge of the page.