### PR TITLE
Temporarily remove lint step to allow package release

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -23,11 +23,7 @@ jobs:
         uses: bahmutov/npm-install@v1
       - name: Copy example config
         run: cp example-config.yml config.yml
-      - name: Lint code
-        # Move everything from latest commit back to staged
-        run: git reset --soft HEAD^ && yarn lint
-        # For our info, lint all files but don't mark them as failure
-        # TODO: remove this once project is typescripted
+        # Actual lint step temporarily removed to allow for package release
       - name: Lint all code (ignoring errors)
         run: yarn lint-all || true
       - name: Run tests


### PR DESCRIPTION
To create our last 3.x release, we need to push code that was created prior to the move to craco, and the new eslint config. After the last 3.x release is published, another PR will follow that reverts this one, so that the first 4.x release contains the expected eslint ci step.