### PR TITLE
Improve batch panel markup

### DIFF
--- a/lib/components/app/app.css
+++ b/lib/components/app/app.css
@@ -62,10 +62,6 @@
   box-sizing: border-box;
 }
 
-/* Batch routing panel requires padding removed from sidebar */
-.batch-routing-panel {
-  padding: 10px;
-}
 /* View Switcher Styling */
 .view-switcher {
   align-items: center;

--- a/lib/components/app/batch-routing-panel.js
+++ b/lib/components/app/batch-routing-panel.js
@@ -1,85 +1,77 @@
-import React, { Component } from 'react'
-import { injectIntl } from 'react-intl'
+/* eslint-disable react/prop-types */
 import { connect } from 'react-redux'
-import styled from 'styled-components'
+import { injectIntl } from 'react-intl'
+import React, { Component } from 'react'
 
 import * as apiActions from '../../actions/api'
 import * as formActions from '../../actions/form'
+import { getActiveSearch, getShowUserSettings } from '../../util/state'
 import BatchSettings from '../form/batch-settings'
 import LocationField from '../form/connected-location-field'
 import NarrativeItineraries from '../narrative/narrative-itineraries'
-import { getActiveSearch, getShowUserSettings } from '../../util/state'
-import ViewerContainer from '../viewers/viewer-container'
 import SwitchButton from '../form/switch-button'
-
-// Style for setting the top of the narrative itineraries based on the width of the window.
-// If the window width is less than 1200px (Bootstrap's "large" size), the
-// mode buttons will be shown on their own row, meaning that the
-// top position of this component needs to be lower (higher value
-// equals lower position on the page).
-// TODO: figure out a better way to use flex rendering for accommodating the mode button overflow.
-const NarrativeContainer = styled.div`
-  & .options.itinerary {
-    @media (min-width: 1200px) {
-      top: 160px;
-    }
-    @media (max-width: 1199px) {
-      top: 210px;
-    }
-  }
-`
+import ViewerContainer from '../viewers/viewer-container'
 
 /**
  * Main panel for the batch/trip comparison form.
  */
 class BatchRoutingPanel extends Component {
-  render () {
+  render() {
     const { intl, mobile } = this.props
     return (
-      <ViewerContainer className='batch-routing-panel'>
-        <div className='locations'>
+      <ViewerContainer
+        className="batch-routing-panel"
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%'
+        }}
+      >
+        <div className="form" style={{ padding: '10px' }}>
           <LocationField
-            inputPlaceholder={
-              intl.formatMessage(
-                { id: 'common.searchForms.enterStartLocation' },
-                { mobile }
-              )
-            }
-            locationType='from'
+            inputPlaceholder={intl.formatMessage(
+              { id: 'common.searchForms.enterStartLocation' },
+              { mobile }
+            )}
+            locationType="from"
             showClearButton
           />
           <LocationField
-            inputPlaceholder={
-              intl.formatMessage(
-                { id: 'common.searchForms.enterDestination' },
-                { mobile }
-              )
-            }
-            locationType='to'
+            inputPlaceholder={intl.formatMessage(
+              { id: 'common.searchForms.enterDestination' },
+              { mobile }
+            )}
+            locationType="to"
             showClearButton={!mobile}
           />
-          <div className='switch-button-container'>
-            <SwitchButton content={<i className='fa fa-exchange fa-rotate-90' />} />
+          <div className="switch-button-container">
+            <SwitchButton
+              content={<i className="fa fa-exchange fa-rotate-90" />}
+            />
           </div>
+          <BatchSettings />
         </div>
-        <BatchSettings />
         {/* FIXME: Add back user settings (home, work, etc.) once connected to
             the middleware persistence.
           !activeSearch && showUserSettings &&
           <UserSettings />
         */}
-        <NarrativeContainer className='desktop-narrative-container'>
+        <div
+          className="desktop-narrative-container"
+          style={{
+            flexGrow: 1,
+            overflowY: 'hidden'
+          }}
+        >
+          {/* FIXME: sharing styles with BatchRoutingPanel. */}
           <NarrativeItineraries
             containerStyle={{
-              bottom: '0',
               display: 'flex',
               flexDirection: 'column',
-              left: '0',
-              position: 'absolute',
-              right: '0'
+              height: '100%'
             }}
           />
-        </NarrativeContainer>
+        </div>
       </ViewerContainer>
     )
   }
@@ -103,6 +95,7 @@ const mapDispatchToProps = {
   setQueryParam: formActions.setQueryParam
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(
-  injectIntl(BatchRoutingPanel)
-)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(injectIntl(BatchRoutingPanel))

--- a/lib/components/app/batch-routing-panel.js
+++ b/lib/components/app/batch-routing-panel.js
@@ -63,14 +63,7 @@ class BatchRoutingPanel extends Component {
             overflowY: 'hidden'
           }}
         >
-          {/* FIXME: sharing styles with BatchRoutingPanel. */}
-          <NarrativeItineraries
-            containerStyle={{
-              display: 'flex',
-              flexDirection: 'column',
-              height: '100%'
-            }}
-          />
+          <NarrativeItineraries />
         </div>
       </ViewerContainer>
     )
@@ -78,7 +71,7 @@ class BatchRoutingPanel extends Component {
 }
 
 // connect to the redux store
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   const showUserSettings = getShowUserSettings(state)
   return {
     activeSearch: getActiveSearch(state),

--- a/lib/components/app/call-taker-panel.js
+++ b/lib/components/app/call-taker-panel.js
@@ -292,8 +292,7 @@ class CallTakerPanel extends Component {
             containerStyle={{
               display: 'flex',
               flexDirection: 'column',
-              height: '100%',
-              marginTop: '0px' // Overrides the margin defined in CSS for `options itinerary`
+              height: '100%'
             }}
           />
         </div>

--- a/lib/components/app/call-taker-panel.js
+++ b/lib/components/app/call-taker-panel.js
@@ -287,14 +287,7 @@ class CallTakerPanel extends Component {
             overflowY: 'hidden'
           }}
         >
-          {/* FIXME: sharing styles with BatchRoutingPanel. */}
-          <NarrativeItineraries
-            containerStyle={{
-              display: 'flex',
-              flexDirection: 'column',
-              height: '100%'
-            }}
-          />
+          <NarrativeItineraries />
         </div>
       </ViewerContainer>
     )

--- a/lib/components/mobile/batch-results-screen.js
+++ b/lib/components/mobile/batch-results-screen.js
@@ -1,19 +1,20 @@
+/* eslint-disable react/prop-types */
+import { Button } from 'react-bootstrap'
+import { connect } from 'react-redux'
+import { FormattedMessage } from 'react-intl'
 import coreUtils from '@opentripplanner/core-utils'
 import React from 'react'
-import { Button } from 'react-bootstrap'
-import { FormattedMessage } from 'react-intl'
-import { connect } from 'react-redux'
 import styled, { css } from 'styled-components'
 
 import * as uiActions from '../../actions/ui'
-import Map from '../map/map'
-import NarrativeItineraries from '../narrative/narrative-itineraries'
-import Icon from '../util/icon'
 import {
   getActiveItineraries,
   getActiveSearch,
   getResponsesWithErrors
 } from '../../util/state'
+import Icon from '../util/icon'
+import Map from '../map/map'
+import NarrativeItineraries from '../narrative/narrative-itineraries'
 
 import MobileContainer from './container'
 import ResultsError from './results-error'
@@ -45,8 +46,9 @@ const NARRATIVE_SPLIT_TOP_PERCENT = 45
 
 // Styles for the results map also include prop-independent styles copied from mobile.css.
 const ResultsMap = styled.div`
-  bottom: ${props => props.expanded ? '0' : `${100 - NARRATIVE_SPLIT_TOP_PERCENT}%`};
-  display: ${props => props.visible ? 'inherit' : 'none'};
+  bottom: ${(props) =>
+    props.expanded ? '0' : `${100 - NARRATIVE_SPLIT_TOP_PERCENT}%`};
+  display: ${(props) => (props.visible ? 'inherit' : 'none')};
   left: 0;
   position: fixed;
   right: 0;
@@ -54,12 +56,17 @@ const ResultsMap = styled.div`
 `
 
 const narrativeCss = css`
-  top: ${props => props.visible ? (props.expanded ? '100px' : `${NARRATIVE_SPLIT_TOP_PERCENT}%`) : '100%'};
+  top: ${(props) =>
+    props.visible
+      ? props.expanded
+        ? '100px'
+        : `${NARRATIVE_SPLIT_TOP_PERCENT}%`
+      : '100%'};
   transition: top 300ms;
 `
 
 const StyledResultsError = styled(ResultsError)`
-  display: ${props => props.visible ? 'inherit' : 'none'};
+  display: ${(props) => (props.visible ? 'inherit' : 'none')};
   ${narrativeCss}
 `
 
@@ -80,52 +87,40 @@ const BatchMobileResultsScreen = ({
   toggleBatchResultsMap
 }) => {
   const hasErrorsAndNoResult = itineraries.length === 0 && errors.length > 0
-  const mapExpanded = itineraryView === ItineraryView.LEG_HIDDEN || itineraryView === ItineraryView.LIST_HIDDEN
+  const mapExpanded =
+    itineraryView === ItineraryView.LEG_HIDDEN ||
+    itineraryView === ItineraryView.LIST_HIDDEN
   const itineraryExpanded = itineraryView === ItineraryView.FULL
 
   return (
     <StyledMobileContainer>
       <ResultsHeader />
-      <ResultsMap
-        expanded={mapExpanded}
-        visible={!itineraryExpanded}
-      >
+      <ResultsMap expanded={mapExpanded} visible={!itineraryExpanded}>
         <Map />
-        <ExpandMapButton
-          bsSize='small'
-          onClick={toggleBatchResultsMap}
-        >
+        <ExpandMapButton bsSize="small" onClick={toggleBatchResultsMap}>
           <Icon name={mapExpanded ? 'list-ul' : 'arrows-alt'} withSpace />
-          {mapExpanded
-            ? <FormattedMessage id='components.BatchResultsScreen.showResults' />
-            : <FormattedMessage id='components.BatchResultsScreen.expandMap' />
-          }
+          {mapExpanded ? (
+            <FormattedMessage id="components.BatchResultsScreen.showResults" />
+          ) : (
+            <FormattedMessage id="components.BatchResultsScreen.expandMap" />
+          )}
         </ExpandMapButton>
       </ResultsMap>
-      {hasErrorsAndNoResult
-        ? <StyledResultsError
+      {hasErrorsAndNoResult ? (
+        <StyledResultsError
           error={errors[0]}
           expanded={itineraryExpanded}
           visible={!mapExpanded}
         />
-        : (
-          <NarrativeContainer
-            className='mobile-narrative-container'
-            expanded={itineraryExpanded}
-            visible={!mapExpanded}
-          >
-            <NarrativeItineraries
-              containerStyle={{
-                background: '#fff',
-                display: 'flex',
-                flexDirection: 'column',
-                height: '100%',
-                width: '100%'
-              }}
-            />
-          </NarrativeContainer>
-        )
-      }
+      ) : (
+        <NarrativeContainer
+          className="mobile-narrative-container"
+          expanded={itineraryExpanded}
+          visible={!mapExpanded}
+        >
+          <NarrativeItineraries />
+        </NarrativeContainer>
+      )}
     </StyledMobileContainer>
   )
 }
@@ -147,4 +142,7 @@ const mapDispatchToProps = {
   toggleBatchResultsMap: uiActions.toggleBatchResultsMap
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(BatchMobileResultsScreen)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(BatchMobileResultsScreen)

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -1,17 +1,10 @@
-import coreUtils from '@opentripplanner/core-utils'
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
-import Skeleton, { SkeletonTheme } from 'react-loading-skeleton'
+/* eslint-disable react/prop-types */
 import { connect } from 'react-redux'
+import coreUtils from '@opentripplanner/core-utils'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import Skeleton, { SkeletonTheme } from 'react-loading-skeleton'
 
-import {
-  setActiveItinerary,
-  setActiveLeg,
-  setActiveStep,
-  setUseRealtimeResponse,
-  setVisibleItinerary,
-  updateItineraryFilter
-} from '../../actions/narrative'
 import * as uiActions from '../../actions/ui'
 import { ComponentContext } from '../../util/contexts'
 import {
@@ -21,7 +14,16 @@ import {
   getResponsesWithErrors,
   getVisibleItineraryIndex
 } from '../../util/state'
+import {
+  setActiveItinerary,
+  setActiveLeg,
+  setActiveStep,
+  setUseRealtimeResponse,
+  setVisibleItinerary,
+  updateItineraryFilter
+} from '../../actions/narrative'
 
+import * as S from './styled'
 import NarrativeItinerariesErrors from './narrative-itineraries-errors'
 import NarrativeItinerariesHeader from './narrative-itineraries-header'
 
@@ -68,16 +70,16 @@ class NarrativeItineraries extends Component {
     setActiveLeg(null, null)
   }
 
-  _onSortChange = evt => {
-    const {value: type} = evt.target
-    const {sort, updateItineraryFilter} = this.props
-    updateItineraryFilter({sort: {...sort, type}})
+  _onSortChange = (evt) => {
+    const { value: type } = evt.target
+    const { sort, updateItineraryFilter } = this.props
+    updateItineraryFilter({ sort: { ...sort, type } })
   }
 
   _onSortDirChange = () => {
-    const {sort, updateItineraryFilter} = this.props
+    const { sort, updateItineraryFilter } = this.props
     const direction = sort.direction === 'ASC' ? 'DESC' : 'ASC'
-    updateItineraryFilter({sort: {...sort, direction}})
+    updateItineraryFilter({ sort: { ...sort, direction } })
   }
 
   _onViewAllOptions = () => {
@@ -93,31 +95,28 @@ class NarrativeItineraries extends Component {
   }
 
   _renderLoadingDivs = () => {
-    const {itineraries, modes, pending} = this.props
-    const {showingErrors} = this.state
+    const { itineraries, modes, pending } = this.props
+    const { showingErrors } = this.state
     if (!pending || showingErrors) return null
     // Construct loading divs as placeholders while all itineraries load.
     const count = modes.combinations
       ? modes.combinations.length - itineraries.length
       : 0
-    return Array.from(
-      {length: count},
-      (v, i) =>
-        <div className='option default-itin' key={i}>
-          <SkeletonTheme color='#ddd' highlightColor='#eee'>
-            <Skeleton count={3} />
-          </SkeletonTheme>
-        </div>
-    )
+    return Array.from({ length: count }, (v, i) => (
+      <div className="option default-itin" key={i}>
+        <SkeletonTheme color="#ddd" highlightColor="#eee">
+          <Skeleton count={3} />
+        </SkeletonTheme>
+      </div>
+    ))
   }
 
-  render () {
+  render() {
     const {
       activeItinerary,
       activeLeg,
       activeSearch,
       activeStep,
-      containerStyle,
       errorMessages,
       errors,
       itineraries,
@@ -138,14 +137,14 @@ class NarrativeItineraries extends Component {
 
     if (!activeSearch) return null
 
-    const showRealtimeAnnotation = realtimeEffects.isAffectedByRealtimeData && (
-      realtimeEffects.exceedsThreshold ||
-      realtimeEffects.routesDiffer ||
-      !useRealtime
-    )
+    const showRealtimeAnnotation =
+      realtimeEffects.isAffectedByRealtimeData &&
+      (realtimeEffects.exceedsThreshold ||
+        realtimeEffects.routesDiffer ||
+        !useRealtime)
 
     return (
-      <div className='options itinerary' style={containerStyle}>
+      <S.NarrativeItinerariesContainer className="options itinerary">
         <NarrativeItinerariesHeader
           errors={errors}
           itineraries={itineraries}
@@ -160,20 +159,19 @@ class NarrativeItineraries extends Component {
         />
         <div
           // FIXME: Change to a ul with li children?
-          className='list'
+          className="list"
           style={{
             flexGrow: '1',
             overflowY: 'auto'
           }}
         >
-          {showingErrors || itineraries.length === 0
-            ? (
-              <NarrativeItinerariesErrors
-                errorMessages={errorMessages}
-                errors={errors}
-              />
-            )
-            : <>
+          {showingErrors || itineraries.length === 0 ? (
+            <NarrativeItinerariesErrors
+              errorMessages={errorMessages}
+              errors={errors}
+            />
+          ) : (
+            <>
               {itineraries.map((itinerary, index) => {
                 const active = index === activeItinerary
                 // Hide non-active itineraries.
@@ -189,7 +187,7 @@ class NarrativeItineraries extends Component {
                     key={index}
                     LegIcon={LegIcon}
                     onClick={active ? this._toggleDetailedItinerary : undefined}
-                    routingType='ITINERARY'
+                    routingType="ITINERARY"
                     setActiveItinerary={setActiveItinerary}
                     setActiveLeg={this._setActiveLeg}
                     setActiveStep={setActiveStep}
@@ -203,9 +201,9 @@ class NarrativeItineraries extends Component {
               })}
               {this._renderLoadingDivs()}
             </>
-          }
+          )}
         </div>
-      </div>
+      </S.NarrativeItinerariesContainer>
     )
   }
 }
@@ -223,12 +221,12 @@ const mapStateToProps = (state, ownProps) => {
   const useRealtime = state.otp.useRealtime
   const urlParams = coreUtils.query.getUrlParams()
   const itineraryView = urlParams.ui_itineraryView || ItineraryView.LIST
-  const showDetails = itineraryView === ItineraryView.FULL ||
-          itineraryView === ItineraryView.LEG ||
-          itineraryView === ItineraryView.LEG_HIDDEN
-  const itineraryIsExpanded = activeItinerary !== undefined &&
-    activeItinerary !== null &&
-    showDetails
+  const showDetails =
+    itineraryView === ItineraryView.FULL ||
+    itineraryView === ItineraryView.LEG ||
+    itineraryView === ItineraryView.LEG_HIDDEN
+  const itineraryIsExpanded =
+    activeItinerary !== undefined && activeItinerary !== null && showDetails
 
   return {
     // swap out realtime itineraries with non-realtime depending on boolean
@@ -260,22 +258,25 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   // so that only one argument is passed,
   // e.g. setActiveLeg({ index, leg })
   return {
-    setActiveItinerary: payload => dispatch(setActiveItinerary(payload)),
+    setActiveItinerary: (payload) => dispatch(setActiveItinerary(payload)),
     // FIXME
     setActiveLeg: (index, leg) => {
-      dispatch(setActiveLeg({index, leg}))
+      dispatch(setActiveLeg({ index, leg }))
     },
     // FIXME
     setActiveStep: (index, step) => {
-      dispatch(setActiveStep({index, step}))
+      dispatch(setActiveStep({ index, step }))
     },
-    setItineraryView: payload => dispatch(uiActions.setItineraryView(payload)),
-    setUseRealtimeResponse: payload => dispatch(setUseRealtimeResponse(payload)),
-    setVisibleItinerary: payload => dispatch(setVisibleItinerary(payload)),
-    updateItineraryFilter: payload => dispatch(updateItineraryFilter(payload))
+    setItineraryView: (payload) =>
+      dispatch(uiActions.setItineraryView(payload)),
+    setUseRealtimeResponse: (payload) =>
+      dispatch(setUseRealtimeResponse(payload)),
+    setVisibleItinerary: (payload) => dispatch(setVisibleItinerary(payload)),
+    updateItineraryFilter: (payload) => dispatch(updateItineraryFilter(payload))
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(
-  NarrativeItineraries
-)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(NarrativeItineraries)

--- a/lib/components/narrative/styled.js
+++ b/lib/components/narrative/styled.js
@@ -1,4 +1,4 @@
-import {ButtonGroup} from 'react-bootstrap'
+import { ButtonGroup } from 'react-bootstrap'
 import styled from 'styled-components'
 
 export const FlexButtonGroup = styled(ButtonGroup)`
@@ -8,4 +8,10 @@ export const FlexButtonGroup = styled(ButtonGroup)`
   button {
     flex: 1;
   }
+`
+
+export const NarrativeItinerariesContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 `


### PR DESCRIPTION
This PR applies the CSS flex vertical layout introduced in #520 to `BatchRoutingPanel` (see 
`<div className="desktop-narrative-container" ...>` and refactors the common styles used with the multiple instances `NarrativeItineraries` in calltaker, batch routing, and mobile batch results.

For best appearance, this PR assumes the defaults for these CSS styles:
```css
.batch-routing-panel {
  padding: 0; /* default */
}

.otp .options.itinerary {
  margin-top: 0; /* default */
}
```