### PR TITLE
refactor(call-taker): make plan button more prominent

### DIFF
--- a/lib/components/admin/call-taker.css
+++ b/lib/components/admin/call-taker.css
@@ -20,3 +20,7 @@
   margin-bottom: 5px;
   height: 24px;
 }
+
+.otp .search-plan-button-container {
+  padding: 1rem;
+}

--- a/lib/components/app/call-taker-panel.js
+++ b/lib/components/app/call-taker-panel.js
@@ -230,8 +230,6 @@ class CallTakerPanel extends Component {
           </div>
           <div className="search-plan-button-container">
             <Button
-              bsSize="default"
-              bsStyle="primary"
               onClick={this._planTrip}
               style={{
                 fontWeight: 'bold',

--- a/lib/components/app/call-taker-panel.js
+++ b/lib/components/app/call-taker-panel.js
@@ -227,13 +227,15 @@ class CallTakerPanel extends Component {
                 this.setState({ transitModes })
               }}
             />
+          </div>
+          <div className="search-plan-button-container">
             <Button
-              bsSize="small"
-              bsStyle="default"
+              bsSize="default"
+              bsStyle="primary"
               onClick={this._planTrip}
               style={{
-                fontSize: '13px',
-                padding: '1px 10px'
+                fontWeight: 'bold',
+                width: '100%'
               }}
             >
               Plan


### PR DESCRIPTION
This makes the Calltaker UI plan button more prominent and puts it on its own line. 
<img width="556" alt="image" src="https://user-images.githubusercontent.com/92878779/152303571-5330e70e-2b7d-44b1-b5ce-7e2094113b47.png">
