### PR TITLE
fix(route-viewer): don’t zoom to itinerary when route viewer is active

### DIFF
--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -1030,6 +1030,7 @@ export function findGeometryForPattern(params) {
         findGeometryForPatternResponse,
         findGeometryForPatternError,
         {
+          noThrottle: true,
           rewritePayload: (payload) => ({
             geometry: payload,
             patternId,

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -75,8 +75,8 @@ export function matchContentToUrl (location) {
           dispatch(setViewedRoute({ patternId, routeId: id }))
         } else {
           dispatch(setViewedRoute(null))
-          dispatch(setMainPanelContent(MainPanelContent.ROUTE_VIEWER))
         }
+        dispatch(setMainPanelContent(MainPanelContent.ROUTE_VIEWER))
         break
       case 'stop':
         if (id) {

--- a/lib/components/map/bounds-updating-overlay.js
+++ b/lib/components/map/bounds-updating-overlay.js
@@ -86,6 +86,9 @@ class BoundsUpdatingOverlay extends MapLayer {
     const { map } = newProps.leaflet
     if (!map) return
 
+    const itineraryShown = newProps.mainPanelContent === null
+    if (!itineraryShown) return
+
     // Fit map to to entire itinerary if active itinerary bounds changed
     const newFrom = newProps.query && newProps.query.from
     const newItinBounds =
@@ -195,6 +198,7 @@ const mapStateToProps = (state) => {
     activeStep: activeSearch && activeSearch.activeStep,
     itinerary: getActiveItinerary(state),
     itineraryView: urlParams.ui_itineraryView,
+    mainPanelContent: state.otp.ui.mainPanelContent,
     mapConfig: state.otp.config.map,
     popupLocation: state.otp.ui.mapPopupLocation,
     query: state.otp.currentQuery

--- a/lib/components/viewers/route-viewer.js
+++ b/lib/components/viewers/route-viewer.js
@@ -79,7 +79,6 @@ class RouteViewer extends Component {
   /** Used to scroll to actively viewed route on load */
   componentDidUpdate() {
     const { routes } = this.props
-    console.log(routes)
     const { initialRender } = this.state
 
     // Wait until more than the one route is present.


### PR DESCRIPTION
There were a few regressions brought in over the past few releases that caused some problems with the route viewer zooming to the correct route. All these bugs have been fixed. This should also resolve some "white screen of death" issues we've been seeing in relation to the route viewer.

This PR closes https://github.com/opentripplanner/otp-react-redux/issues/543 and https://github.com/opentripplanner/otp-react-redux/issues/547