### PR TITLE
Add config param to disable flex arc display

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -112,6 +112,7 @@ map:
   ###   styles.segment_labels: styles attributes recognized by transitive.js.
   ###                         For examples of applicable style attributes, see
   ###                         https://github.com/conveyal/transitive.js/blob/master/stories/Transitive.stories.js#L47.
+  ### - disableFlexArc: optional parameter to disable rendering flex itinerary legs as an arc. 
   # transitive:
   #   labeledModes:
   #     - BUS
@@ -127,6 +128,7 @@ map:
   #       color: "#FFE0D0"
   #       font-family: Hind, sans-serif
   #       font-size: 18px
+  #   disableFlexArc: true
 
 # it is possible to leave out a geocoder config entirely. In that case only
 # GPS coordinates will be used when finding the origin/destination.

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -605,6 +605,7 @@ export const getTransitiveData = createSelector(
   itineraryResponseExists,
   getItineraryToRender,
   (state) => state.otp.config.companies,
+  (state) => state.otp.config.map.transitive?.disableFlexArc,
   (state, props) => props.getTransitiveRouteLabel,
   (
     hasResponse,
@@ -612,6 +613,7 @@ export const getTransitiveData = createSelector(
     hasItineraryResponse,
     itineraryToRender,
     companies,
+    disableFlexArc,
     getTransitiveRouteLabel
   ) => {
     if (hasResponse) {
@@ -620,7 +622,8 @@ export const getTransitiveData = createSelector(
           ? coreUtils.map.itineraryToTransitive(
               itineraryToRender,
               companies,
-              getTransitiveRouteLabel
+              getTransitiveRouteLabel,
+              disableFlexArc
             )
           : null
       } else if (otpResponse) {


### PR DESCRIPTION
…display

This PR makes use of a configuration parameter (which would be put under the transitive section) to disable displaying a flex route arc (as requested by NYSDOT). 

Relies on OPT-UI PR: https://github.com/opentripplanner/otp-ui/pull/352