### PR TITLE
Mobile View Support Stop Viewer Deep-Linking

### DIFF
--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -960,7 +960,7 @@ export function findPatternsForRoute(params) {
     const { routeId } = params
     const route = state?.otp?.transitIndex?.routes?.[routeId]
     // If a route was fetched from GraphQL, it already has patterns
-    if (route && route.v2) {
+    if (route?.v2) {
       if (!route.patterns) {
         return dispatch(findRoute(params))
       }
@@ -1022,7 +1022,7 @@ export function findGeometryForPattern(params) {
     const state = getState()
     const route = state?.otp?.transitIndex?.routes?.[params.routeId]
     // If a route was fetched from GraphQL, it already has geometry
-    if (route && route.v2) {
+    if (route?.v2) {
       return
     }
 
@@ -1059,7 +1059,7 @@ export function findStopsForPattern(params) {
     const state = getState()
     const route = state?.otp?.transitIndex?.routes?.[params.routeId]
     // If a route was fetched from GraphQL, it already has patterns
-    if (route && route?.v2) {
+    if (route?.v2) {
       return
     }
 

--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -1,20 +1,20 @@
+import { createAction } from 'redux-actions'
 import coreUtils from '@opentripplanner/core-utils'
 import debounce from 'lodash.debounce'
 import isEqual from 'lodash.isequal'
 import moment from 'moment'
 import qs from 'qs'
-import { createAction } from 'redux-actions'
 
 import { queryIsValid } from '../util/state'
 
-import { routingQuery } from './api'
-import { setLocation } from './map'
 import {
   MobileScreens,
   routeTo,
   setMainPanelContent,
   setMobileScreen
 } from './ui'
+import { routingQuery } from './api'
+import { setLocation } from './map'
 
 const {
   getDefaultQuery,
@@ -34,7 +34,7 @@ export const storeDefaultSettings = createAction('STORE_DEFAULT_SETTINGS')
  * @param {Boolean} [full=false] if set to true, the from/to locations and URL
  *  query parameters will also be reset.
  */
-export function resetForm (full = false) {
+export function resetForm(full = false) {
   return function (dispatch, getState) {
     const state = getState()
     const { transitModes } = state.otp.config.modes
@@ -51,15 +51,15 @@ export function resetForm (full = false) {
       const options = getTripOptionsFromQuery(defaultQuery)
       // Default mode is currently WALK,TRANSIT. We need to update this value
       // here to match the list of modes, otherwise the form will break.
-      options.mode = ['WALK', ...transitModes.map(m => m.mode)].join(',')
+      options.mode = ['WALK', ...transitModes.map((m) => m.mode)].join(',')
       dispatch(settingQueryParam(options))
     }
     if (full) {
       // If fully resetting form, also clear the active search, from/to
       // locations, and query params.
       dispatch(clearActiveSearch())
-      dispatch(setLocation({location: null, locationType: 'from'}))
-      dispatch(setLocation({location: null, locationType: 'to'}))
+      dispatch(setLocation({ location: null, locationType: 'from' }))
+      dispatch(setLocation({ location: null, locationType: 'to' }))
       // Get query params. Delete everything except sessionId.
       const params = getUrlParams()
       for (const key in params) {
@@ -75,7 +75,7 @@ export function resetForm (full = false) {
  * parameter-specific actions. If a search ID is provided, a routing query (OTP
  * search) will be kicked off immediately.
  */
-export function setQueryParam (payload, searchId) {
+export function setQueryParam(payload, searchId) {
   return function (dispatch, getState) {
     dispatch(settingQueryParam(payload))
     if (searchId) dispatch(routingQuery(searchId))
@@ -93,18 +93,19 @@ export function setQueryParam (payload, searchId) {
  *                         query made during a call taker session, to prevent
  *                         a search from being added to the current call)
  */
-export function parseUrlQueryString (params = getUrlParams(), source) {
+export function parseUrlQueryString(params = getUrlParams(), source) {
   return function (dispatch, getState) {
     // Filter out the OTP (i.e. non-UI) params and set the initial query
     const planParams = {}
-    Object.keys(params).forEach(key => {
+    Object.keys(params).forEach((key) => {
       if (!key.startsWith('ui_')) planParams[key] = params[key]
     })
     let searchId = params.ui_activeSearch || coreUtils.storage.randId()
     if (source) searchId += source
     // Convert strings to numbers/objects and dispatch
-    planParamsToQueryAsync(planParams, getState().otp.config)
-      .then(query => dispatch(setQueryParam(query, searchId)))
+    planParamsToQueryAsync(planParams, getState().otp.config).then((query) =>
+      dispatch(setQueryParam(query, searchId))
+    )
   }
 }
 
@@ -117,18 +118,14 @@ let lastDebouncePlanTimeMs
  * (based on autoPlan strategies) as well as updating the UI state (esp. for
  * mobile).
  */
-export function formChanged (oldQuery, newQuery) {
+export function formChanged(oldQuery, newQuery) {
   return function (dispatch, getState) {
     const state = getState()
     const { config, currentQuery, ui } = state.otp
     const { autoPlan, debouncePlanTimeMs } = config
     const isMobile = coreUtils.ui.isMobile()
-    const {
-      fromChanged,
-      oneLocationChanged,
-      shouldReplanTrip,
-      toChanged
-    } = checkShouldReplanTrip(autoPlan, isMobile, oldQuery, newQuery)
+    const { fromChanged, oneLocationChanged, shouldReplanTrip, toChanged } =
+      checkShouldReplanTrip(autoPlan, isMobile, oldQuery, newQuery)
     // If departArrive is set to 'NOW', update the query time to current
     if (currentQuery.departArrive === 'NOW') {
       const now = moment().format(coreUtils.time.OTP_API_TIME_FORMAT)
@@ -156,7 +153,10 @@ export function formChanged (oldQuery, newQuery) {
       // If replanning trip and query is valid,
       // check if debouncing function needs to be (re)created.
       if (!debouncedPlanTrip || lastDebouncePlanTimeMs !== debouncePlanTimeMs) {
-        debouncedPlanTrip = debounce(() => dispatch(routingQuery()), debouncePlanTimeMs)
+        debouncedPlanTrip = debounce(
+          () => dispatch(routingQuery()),
+          debouncePlanTimeMs
+        )
         lastDebouncePlanTimeMs = debouncePlanTimeMs
       }
       debouncedPlanTrip()
@@ -169,15 +169,15 @@ export function formChanged (oldQuery, newQuery) {
  * whether the mobile view is active, and the old/new queries. Response type is
  * an object containing various booleans.
  */
-export function checkShouldReplanTrip (autoPlan, isMobile, oldQuery, newQuery) {
+export function checkShouldReplanTrip(autoPlan, isMobile, oldQuery, newQuery) {
   // Determine if either from/to location has changed
   const fromChanged = !isEqual(oldQuery.from, newQuery.from)
   const toChanged = !isEqual(oldQuery.to, newQuery.to)
-  const oneLocationChanged = (fromChanged && !toChanged) || (!fromChanged && toChanged)
+  const oneLocationChanged =
+    (fromChanged && !toChanged) || (!fromChanged && toChanged)
   // Check whether a trip should be auto-replanned
-  const strategy = isMobile && autoPlan?.mobile
-    ? autoPlan?.mobile
-    : autoPlan?.default
+  const strategy =
+    isMobile && autoPlan?.mobile ? autoPlan?.mobile : autoPlan?.default
   const shouldReplanTrip = evaluateAutoPlanStrategy(
     strategy,
     fromChanged,
@@ -198,7 +198,12 @@ export function checkShouldReplanTrip (autoPlan, isMobile, oldQuery, newQuery) {
  * some query param has already changed. If further checking of query params is
  * needed, additional strategies should be added.
  */
-const evaluateAutoPlanStrategy = (strategy, fromChanged, toChanged, oneLocationChanged) => {
+const evaluateAutoPlanStrategy = (
+  strategy,
+  fromChanged,
+  toChanged,
+  oneLocationChanged
+) => {
   switch (strategy) {
     case 'ONE_LOCATION_CHANGED':
       if (oneLocationChanged) return true
@@ -206,7 +211,9 @@ const evaluateAutoPlanStrategy = (strategy, fromChanged, toChanged, oneLocationC
     case 'BOTH_LOCATIONS_CHANGED':
       if (fromChanged && toChanged) return true
       break
-    case 'ANY': return true
-    default: return false
+    case 'ANY':
+      return true
+    default:
+      return false
   }
 }

--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -137,7 +137,7 @@ export function formChanged (oldQuery, newQuery) {
     // Only clear the main panel if a single location changed. This prevents
     // clearing the panel on load if the app is focused on a stop viewer but a
     // search query should also be visible.
-    if (oneLocationChanged) {
+    if (oneLocationChanged && !isMobile) {
       dispatch(setMainPanelContent(null))
     }
     if (!shouldReplanTrip) {

--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -1,3 +1,5 @@
+// TODO: Typescript
+/* eslint-disable @typescript-eslint/no-use-before-define */
 import { createAction } from 'redux-actions'
 import coreUtils from '@opentripplanner/core-utils'
 import debounce from 'lodash.debounce'

--- a/lib/components/map/bounds-updating-overlay.js
+++ b/lib/components/map/bounds-updating-overlay.js
@@ -109,8 +109,9 @@ class BoundsUpdatingOverlay extends MapLayer {
     // Also refit map if itineraryView prop has changed.
     const itineraryViewChanged =
       oldProps.itineraryView !== newProps.itineraryView
+    const isMobile = coreUtils.ui.isMobile()
 
-    if (oldMapConfig !== newMapConfig) {
+    if (oldMapConfig !== newMapConfig && !isMobile) {
       setTimeout(() => {
         map.invalidateSize(true)
         map.setZoom(newMapConfig.initZoom || 13)


### PR DESCRIPTION
Stop viewer deep linking (opening the stop viewer directly by including #/stop/<stop_id> in the URL) works great on desktop, but it looks like it was never tested for mobile. This PR adds support for mobile stop viewer deep linking and ensures the map shows things correctly.

Blocked by https://github.com/opentripplanner/otp-react-redux/pull/548