### PR TITLE
Use Stop Code as Stop ID where Applicable

### DIFF
--- a/lib/components/viewers/stop-viewer.js
+++ b/lib/components/viewers/stop-viewer.js
@@ -217,7 +217,7 @@ class StopViewer extends Component {
         <div>
           <FormattedMessage
             id="components.StopViewer.displayStopId"
-            values={{ stopId, strong: Strong }}
+            values={{ stopId: stopData.code || stopId, strong: Strong }}
           />
           <button
             className="link-button"

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -777,7 +777,7 @@ export function getTitle(state, intl) {
     case MainPanelContent.STOP_VIEWER:
       status = intl.formatMessage(
         { id: 'util.state.titleBarStopId' },
-        { stopId: viewedStop?.stopId }
+        { stopId: viewedStop?.stopCode || viewedStop?.stopId }
       )
       break
     default:

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@opentripplanner/printable-itinerary": "^1.3.1",
     "@opentripplanner/route-viewer-overlay": "^1.2.0",
     "@opentripplanner/stop-viewer-overlay": "^1.1.1",
-    "@opentripplanner/stops-overlay": "^3.4.0",
+    "@opentripplanner/stops-overlay": "^3.4.1",
     "@opentripplanner/transit-vehicle-overlay": "^2.3.1",
     "@opentripplanner/transitive-overlay": "^1.1.2",
     "@opentripplanner/trip-details": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2617,10 +2617,10 @@
     "@opentripplanner/core-utils" "^4.1.0"
     prop-types "^15.7.2"
 
-"@opentripplanner/stops-overlay@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/stops-overlay/-/stops-overlay-3.4.0.tgz#0ded677db2dead7e02a968fca4177c341b527033"
-  integrity sha512-cq40s9iy5t9L1fN3/cyaFjf4OzNsecCSdZC5f+N9/FL8/lLgpE8bsEh03Ggy40T6T3mY23sRPGw3Fqk+rEI62A==
+"@opentripplanner/stops-overlay@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/stops-overlay/-/stops-overlay-3.4.1.tgz#a8f791e7927ad93d950c529c90a3f056c80cf0f5"
+  integrity sha512-yrYrdAv7HHqqzA13OoglperS5p4004+NtjSP34yu25K3HYQ4ogIUhsz2p428YI23io5W5sKRuGCUjxEI9/s8rw==
   dependencies:
     "@opentripplanner/core-utils" "^4.5.0"
     "@opentripplanner/from-to-location-picker" "^1.3.0"


### PR DESCRIPTION
This PR uses stop ID instead of stop code when it makes sense to. This makes the stop ID more useful for users.