### PR TITLE
Do not display $0.00 fares if no fares are provided in GTFS

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -784,8 +784,9 @@ common:
   itineraryDescriptions:
     calories: "{calories, number} Cal"
     noItineraryToDisplay: No itinerary to display.
-    transfers: "{transfers, plural, =0 {} one {# transfer} other {# transfers}}"
+    # Note to translator: noTransitFareProvided is width-constrained.
     noTransitFareProvided: No fare info
+    transfers: "{transfers, plural, =0 {} one {# transfer} other {# transfers}}"
 
   # Note to translator: the strings below are used in sentences such as:
   # "No trip found for bike, walk, and transit."

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -785,6 +785,7 @@ common:
     calories: "{calories, number} Cal"
     noItineraryToDisplay: No itinerary to display.
     transfers: "{transfers, plural, =0 {} one {# transfer} other {# transfers}}"
+    noTransitFareProvided: No fare info
 
   # Note to translator: the strings below are used in sentences such as:
   # "No trip found for bike, walk, and transit."

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -734,6 +734,8 @@ common:
   itineraryDescriptions:
     calories: "{calories, number} kcal" # SI unit
     noItineraryToDisplay: Aucun trajet à afficher.
+    # Note to translator: noTransitFareProvided is width-constrained.
+    noTransitFareProvided: Tarif inconnu 
     transfers: "{transfers, plural, =0 {} one {# correspondance} other {# correspondances}}"
 
   # Note to translator: some of the strings below are used in sentences such as:

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -140,7 +140,7 @@ const ITINERARY_ATTRIBUTES = [
           currencyDisplay='narrowSymbol'
           style='currency'
           value={
-            getTotalFare(itinerary, options.configCosts, defaultFareKey) / 100
+            fareInCents / 100
           }
         />
       )

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -131,7 +131,6 @@ const ITINERARY_ATTRIBUTES = [
     id: 'cost',
     order: 2,
     render: (itinerary, options, defaultFareKey = 'regular') => {
-      debugger
       const fareInCents = getTotalFare(itinerary, options.configCosts, defaultFareKey)
       const fareCurrency = itinerary.fare?.fare?.regular?.currency?.currencyCode
       const fare = fareInCents === null ? null : fareInCents / 100

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -132,8 +132,8 @@ const ITINERARY_ATTRIBUTES = [
     order: 2,
     render: (itinerary, options, defaultFareKey = 'regular') => {
       const fareInCents = getTotalFare(itinerary, options.configCosts, defaultFareKey)
-      const fare = fareInCents == null ? null : fareInCents / 100
-      if (fare == null) return null
+      const fare = fareInCents === null ? null : fareInCents / 100
+      if (fare === null) return <div>No fare info</div>
       return (
         <FormattedNumber
           currency={options.currency}

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -139,9 +139,7 @@ const ITINERARY_ATTRIBUTES = [
           currency={options.currency}
           currencyDisplay='narrowSymbol'
           style='currency'
-          value={
-            fareInCents / 100
-          }
+          value={fare} 
         />
       )
     }

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -131,12 +131,15 @@ const ITINERARY_ATTRIBUTES = [
     id: 'cost',
     order: 2,
     render: (itinerary, options, defaultFareKey = 'regular') => {
+      debugger
       const fareInCents = getTotalFare(itinerary, options.configCosts, defaultFareKey)
+      const fareCurrency = itinerary.fare?.fare?.regular?.currency?.currencyCode
       const fare = fareInCents === null ? null : fareInCents / 100
       if (fare === null) return <FormattedMessage id="common.itineraryDescriptions.noTransitFareProvided" />
       return (
         <FormattedNumber
-          currency={options.currency}
+          // Currency from itinerary fare or from config.
+          currency={fareCurrency || options.currency}
           currencyDisplay='narrowSymbol'
           style='currency'
           value={fare} 

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -131,6 +131,9 @@ const ITINERARY_ATTRIBUTES = [
     id: 'cost',
     order: 2,
     render: (itinerary, options, defaultFareKey = 'regular') => {
+      const fareInCents = getTotalFare(itinerary, options.configCosts, defaultFareKey)
+      const fare = fareInCents == null ? null : fareInCents / 100
+      if (fare == null) return null
       return (
         <FormattedNumber
           currency={options.currency}

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -133,7 +133,7 @@ const ITINERARY_ATTRIBUTES = [
     render: (itinerary, options, defaultFareKey = 'regular') => {
       const fareInCents = getTotalFare(itinerary, options.configCosts, defaultFareKey)
       const fare = fareInCents === null ? null : fareInCents / 100
-      if (fare === null) return <div>No fare info</div>
+      if (fare === null) return <FormattedMessage id="common.itineraryDescriptions.noTransitFareProvided" />
       return (
         <FormattedNumber
           currency={options.currency}

--- a/lib/components/narrative/tabbed-itineraries.js
+++ b/lib/components/narrative/tabbed-itineraries.js
@@ -51,6 +51,7 @@ class TabButton extends Component {
     const transitFare =
       (transitFares?.[defaultFareKey] || transitFares.regular)?.transitFare ||
       null
+    const fareCurrency = itinerary.fare?.fare?.regular?.currency?.currencyCode
     const minTotalFare = minTNCFare * 100 + transitFare
     const startTime = itinerary.startTime + timezoneOffset
     const endTime = itinerary.endTime + timezoneOffset
@@ -70,7 +71,8 @@ class TabButton extends Component {
             hasMaxFare: maxTNCFare && maxTNCFare > minTNCFare,
             minTotalFare: (
               <FormattedNumber
-                currency={currency}
+                // Currency from itinerary fare or from config.
+                currency={fareCurrency || currency}
                 currencyDisplay="narrowSymbol"
                 // This isn't a "real" style prop
                 // eslint-disable-next-line react/style-prop-object

--- a/lib/components/narrative/tabbed-itineraries.js
+++ b/lib/components/narrative/tabbed-itineraries.js
@@ -18,8 +18,12 @@ import Icon from '../util/icon'
 
 import { FLEX_COLOR } from './default/flex-indicator'
 
-const { calculateFares, calculatePhysicalActivity, getTimeZoneOffset } =
-  coreUtils.itinerary
+const {
+  calculateFares,
+  calculatePhysicalActivity,
+  getTimeZoneOffset,
+  isTransit
+} = coreUtils.itinerary
 
 const Bullet = styled.span`
   ::before {
@@ -46,15 +50,40 @@ class TabButton extends Component {
     )
     // TODO: support non-USD
     const transitFare =
-      (transitFares?.[defaultFareKey] || transitFares.regular)?.transitFare || 0
+      (transitFares?.[defaultFareKey] || transitFares.regular)?.transitFare ||
+      null
     const minTotalFare = minTNCFare * 100 + transitFare
     const startTime = itinerary.startTime + timezoneOffset
     const endTime = itinerary.endTime + timezoneOffset
     const mustCallAhead = itinerary.legs.some(
       coreUtils.itinerary.isReservationRequired
     )
+    const transitFareNotProvided = itinerary.legs.some(
+      (leg) => isTransit(leg.mode) && transitFare == null
+    )
 
     if (isActive) classNames.push('selected')
+    const newLocal = minTotalFare > 0 && (
+      <>
+        <FormattedMessage
+          id="components.TabbedItineraries.fareCost"
+          values={{
+            hasMaxFare: maxTNCFare && maxTNCFare > minTNCFare,
+            minTotalFare: (
+              <FormattedNumber
+                currency={currency}
+                currencyDisplay="narrowSymbol"
+                // This isn't a "real" style prop
+                // eslint-disable-next-line react/style-prop-object
+                style="currency"
+                value={minTotalFare / 100}
+              />
+            )
+          }}
+        />
+        <Bullet />
+      </>
+    )
     return (
       <Button
         className={classNames.join(' ')}
@@ -92,26 +121,34 @@ class TabButton extends Component {
           </span>
           {/* the fare / calories summary line */}
           <span>
-            {minTotalFare > 0 && (
+            {/* Display "No Fare Info" if there is a transit leg w/o fare information */}
+            {transitFareNotProvided ? (
               <>
-                <FormattedMessage
-                  id="components.TabbedItineraries.fareCost"
-                  values={{
-                    hasMaxFare: maxTNCFare && maxTNCFare > minTNCFare,
-                    minTotalFare: (
-                      <FormattedNumber
-                        currency={currency}
-                        currencyDisplay="narrowSymbol"
-                        // This isn't a "real" style prop
-                        // eslint-disable-next-line react/style-prop-object
-                        style="currency"
-                        value={minTotalFare / 100}
-                      />
-                    )
-                  }}
-                />
+                <FormattedMessage id="common.itineraryDescriptions.noTransitFareProvided" />
                 <Bullet />
               </>
+            ) : (
+              minTotalFare > 0 && (
+                <>
+                  <FormattedMessage
+                    id="components.TabbedItineraries.fareCost"
+                    values={{
+                      hasMaxFare: maxTNCFare && maxTNCFare > minTNCFare,
+                      minTotalFare: (
+                        <FormattedNumber
+                          currency={currency}
+                          currencyDisplay="narrowSymbol"
+                          // This isn't a "real" style prop
+                          // eslint-disable-next-line react/style-prop-object
+                          style="currency"
+                          value={minTotalFare / 100}
+                        />
+                      )
+                    }}
+                  />
+                  <Bullet />
+                </>
+              )
             )}
             <FormattedMessage
               id="common.itineraryDescriptions.calories"

--- a/lib/components/narrative/tabbed-itineraries.js
+++ b/lib/components/narrative/tabbed-itineraries.js
@@ -48,7 +48,6 @@ class TabButton extends Component {
       itinerary,
       true
     )
-    // TODO: support non-USD
     const transitFare =
       (transitFares?.[defaultFareKey] || transitFares.regular)?.transitFare ||
       null

--- a/lib/components/narrative/tabbed-itineraries.js
+++ b/lib/components/narrative/tabbed-itineraries.js
@@ -51,7 +51,8 @@ class TabButton extends Component {
     const transitFare =
       (transitFares?.[defaultFareKey] || transitFares.regular)?.transitFare ||
       null
-    const fareCurrency = itinerary.fare?.fare?.regular?.currency?.currencyCode
+    const fareCurrency =
+      itinerary.fare?.fare?.regular?.currency?.currencyCode || currency
     const minTotalFare = minTNCFare * 100 + transitFare
     const startTime = itinerary.startTime + timezoneOffset
     const endTime = itinerary.endTime + timezoneOffset
@@ -72,7 +73,7 @@ class TabButton extends Component {
             minTotalFare: (
               <FormattedNumber
                 // Currency from itinerary fare or from config.
-                currency={fareCurrency || currency}
+                currency={fareCurrency}
                 currencyDisplay="narrowSymbol"
                 // This isn't a "real" style prop
                 // eslint-disable-next-line react/style-prop-object
@@ -137,7 +138,7 @@ class TabButton extends Component {
                       hasMaxFare: maxTNCFare && maxTNCFare > minTNCFare,
                       minTotalFare: (
                         <FormattedNumber
-                          currency={currency}
+                          currency={fareCurrency}
                           currencyDisplay="narrowSymbol"
                           // This isn't a "real" style prop
                           // eslint-disable-next-line react/style-prop-object

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -339,7 +339,7 @@ function sortItineraries(type, direction, a, b, config) {
       else return b.duration - a.duration
     case 'COST':
       const configCosts = config.itinerary?.costs
-      // Sort an itinerary without fare information last (MAX_FARE is an arbitrarily high number)
+      // Sort an itinerary without fare information last
       const aTotal = getTotalFare(a, configCosts) === null ? Number.MAX_VALUE : getTotalFare(a, configCosts)
       const bTotal = getTotalFare(b, configCosts) === null ? Number.MAX_VALUE : getTotalFare(b, configCosts)
       if (direction === 'ASC') return aTotal - bTotal

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -340,9 +340,8 @@ function sortItineraries(type, direction, a, b, config) {
     case 'COST':
       const configCosts = config.itinerary?.costs
       // Sort an itinerary without fare information last (MAX_FARE is an arbitrarily high number)
-      const MAX_FARE = 999999.99 
-      const aTotal = getTotalFare(a, configCosts) === null ? MAX_FARE : getTotalFare(a, configCosts)
-      const bTotal = getTotalFare(b, configCosts) === null ? MAX_FARE : getTotalFare(b, configCosts)
+      const aTotal = getTotalFare(a, configCosts) === null ? Number.MAX_VALUE : getTotalFare(a, configCosts)
+      const bTotal = getTotalFare(b, configCosts) === null ? Number.MAX_VALUE : getTotalFare(b, configCosts)
       if (direction === 'ASC') return aTotal - bTotal
       else return bTotal - aTotal
     default:

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -2,6 +2,7 @@
 /* eslint-disable  */
 import { createSelector } from 'reselect'
 import { FormattedList, FormattedMessage } from 'react-intl'
+import { isTransit } from '@opentripplanner/core-utils/lib/itinerary'
 import coreUtils from '@opentripplanner/core-utils'
 import hash from 'object-hash'
 import isEqual from 'lodash.isequal'
@@ -433,7 +434,8 @@ export function getTotalFare(
   // Get transit/TNC fares.
   const { maxTNCFare, transitFares } = calculateFares(itinerary, true)
   const transitFare =
-    (transitFares?.[defaultFareKey] || transitFares.regular)?.transitFare || 0
+    (transitFares?.[defaultFareKey] || transitFares.regular)?.transitFare ||
+    null
   // Start with default cost values.
   const costs = DEFAULT_COSTS
   // If config contains values to override defaults, apply those.
@@ -441,6 +443,7 @@ export function getTotalFare(
   // Calculate total cost from itinerary legs.
   let drivingCost = 0
   let hasBikeshare = false
+  let transitFareNotProvided = false
   itinerary.legs.forEach((leg) => {
     if (leg.mode === 'CAR') {
       // Convert meters to miles and multiple by cost per mile.
@@ -453,7 +456,13 @@ export function getTotalFare(
     ) {
       hasBikeshare = true
     }
+    if (isTransit(leg.mode) && transitFare == null) {
+      transitFareNotProvided = true
+    }
   })
+  // If our itinerary includes a transit leg, but transit fare data is not provided
+  // return no fare information, rather than an underestimate
+  if (transitFareNotProvided) return null
   const bikeshareCost = hasBikeshare ? costs.bikeshareTripCostCents : 0
   // If some leg uses driving, add parking cost to the total.
   if (drivingCost > 0) drivingCost += costs.carParkingCostCents

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -339,8 +339,10 @@ function sortItineraries(type, direction, a, b, config) {
       else return b.duration - a.duration
     case 'COST':
       const configCosts = config.itinerary?.costs
-      const aTotal = getTotalFare(a, configCosts)
-      const bTotal = getTotalFare(b, configCosts)
+      // Sort an itinerary without fare information last (MAX_FARE is an arbitrarily high number)
+      const MAX_FARE = 999999.99 
+      const aTotal = getTotalFare(a, configCosts) === null ? MAX_FARE : getTotalFare(a, configCosts)
+      const bTotal = getTotalFare(b, configCosts) === null ? MAX_FARE : getTotalFare(b, configCosts)
       if (direction === 'ASC') return aTotal - bTotal
       else return bTotal - aTotal
     default:


### PR DESCRIPTION
Currently, if a transit agency does not provide fare information a fare of $0.00 is displayed. A simple fix (on branch [GitHub - opentripplanner/otp-react-redux at hide-zero-fare](https://github.com/opentripplanner/otp-react-redux/tree/hide-zero-fare) ) has been implemented, but there is still the case of bikeshare → transit which displays a fare of $2.00 which this PR resolves..

One open question is if nothing should be displayed in place of the fare, or if text such as "No fare info" should be displayed. 
(current behaviour is to display nothing, e.g.): 
<img width="755" alt="image" src="https://user-images.githubusercontent.com/63798641/157533622-a212acb2-1414-4c31-b165-31dbcea0dbc9.png">


As well, the way this PR is currently implemented, it allows sorting of itineraries w/ no fare info as 0.00 (e.g.):
![image](https://user-images.githubusercontent.com/63798641/157533068-ecdc536d-425b-4eb7-b924-ecd5645ca73b.png)
