### PR TITLE
Remove flags from LocaleSelector

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -343,7 +343,7 @@ itinerary:
 ### Languages defined may be region-specific (e.g. en-US) or language-specific (e.g. es, kr)
 ### The LocaleSelector component, which provides a dropdown for the user to change their locale, will
 ### only be rendered if more than one valid language (all languages must have "name" defined) is included
-### in the language config. Locale icons (flags) are rendered based on the country code provided below (i.e. flag: US)
+### in the language config. 
 
 # language:
 #   allLanguages
@@ -372,7 +372,6 @@ itinerary:
 #         modes: "CAR_HAIL, CAR_RENT"
 #       480:
 #         msg: No available transit routes or rideshare/carshare service at origin.
-#     flag: US
 #     name: English (US)
 #
 #   fr:
@@ -383,23 +382,18 @@ itinerary:
 #         give-us-feedback: Donnez votre avis
 #         log-my-commute: Mes trajets verts
 #         traveler-tools: Outils du voyageur
-#     flag: FR
 #     name: French
 
 #   ko:
-#     flag: KR
 #     name: 한국인
 
 #   vi:
-#     flag: VN
 #     name: Tiếng Việt
 
 #   zh:
-#     flag: CN
 #     name: 中国人
 
 #   es:
-#     flag: ES
 #     name: Español
 
 ### Localization section to provide language/locale settings

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -344,7 +344,11 @@ export function setLocale(locale) {
     const { language: customMessages } = config
     const configLocales = getConfigLocales(customMessages)
     const effectiveLocale = locale || getDefaultLocale(config, loggedInUser)
-    const matchedLocale = getMatchingLocaleString(effectiveLocale, 'en-US')
+    const matchedLocale = getMatchingLocaleString(
+      effectiveLocale,
+      'en-US',
+      configLocales
+    )
     const messages = await loadLocaleData(
       matchedLocale,
       customMessages,

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -3,7 +3,12 @@ import { matchPath } from 'react-router'
 import { push } from 'connected-react-router'
 import coreUtils from '@opentripplanner/core-utils'
 
-import { getDefaultLocale, loadLocaleData } from '../util/i18n'
+import {
+  getConfigLocales,
+  getDefaultLocale,
+  getMatchingLocaleString,
+  loadLocaleData
+} from '../util/i18n'
 import { getModesForActiveAgencyFilter, getUiUrlParams } from '../util/state'
 import { getPathFromParts } from '../util/ui'
 
@@ -336,13 +341,18 @@ export function setLocale(locale) {
   return async function (dispatch, getState) {
     const { config } = getState().otp
     const { loggedInUser } = getState().user
-
     const { language: customMessages } = config
+    const configLocales = getConfigLocales(customMessages)
     const effectiveLocale = locale || getDefaultLocale(config, loggedInUser)
-    const messages = await loadLocaleData(effectiveLocale, customMessages)
+    const matchedLocale = getMatchingLocaleString(effectiveLocale, 'en-US')
+    const messages = await loadLocaleData(
+      matchedLocale,
+      customMessages,
+      configLocales
+    )
 
-    // Update the redux state
-    dispatch(updateLocale({ locale: effectiveLocale, messages }))
+    // Update the redux state, only with a matched locale
+    dispatch(updateLocale({ locale: matchedLocale, messages }))
 
     // Update the lang attribute in the root <html> element.
     // (The lang is the first portion of the locale.)

--- a/lib/components/app/locale-selector.tsx
+++ b/lib/components/app/locale-selector.tsx
@@ -46,7 +46,9 @@ const LocaleSelector = (props: LocaleSelectorProps): JSX.Element => {
     <NavDropdown
       id="locale-selector"
       pullRight
-      title={<Icon style={{ color: '#fff' }} type="globe" />}
+      title={
+        <Icon style={{ color: 'rgba(255, 255, 255, 0.85)' }} type="globe" />
+      }
     >
       {Object.keys(configLanguages).map((locale) => {
         return (

--- a/lib/components/app/locale-selector.tsx
+++ b/lib/components/app/locale-selector.tsx
@@ -1,32 +1,17 @@
-import * as flags from 'country-flag-icons/react/3x2'
 import { connect, ConnectedProps } from 'react-redux'
 import { MenuItem, NavDropdown } from 'react-bootstrap'
 import { useIntl } from 'react-intl'
 import React, { MouseEvent } from 'react'
-import styled from 'styled-components'
 
 import * as uiActions from '../../actions/ui'
 import * as userActions from '../../actions/user'
 import Icon from '../util/icon'
-
-const FlagContainer = styled.span`
-  &::after {
-    content: '';
-    margin: 0 0.125em;
-  }
-
-  align-items: center;
-  display: inline-flex;
-  justify-content: center;
-  width: 15px;
-`
 
 type PropsFromRedux = ConnectedProps<typeof connector>
 
 interface LocaleSelectorProps extends PropsFromRedux {
   // Typescript TODO configLanguageType
   configLanguages: Record<string, any>
-  style?: any
 }
 
 const LocaleSelector = (props: LocaleSelectorProps): JSX.Element => {
@@ -38,10 +23,6 @@ const LocaleSelector = (props: LocaleSelectorProps): JSX.Element => {
     setLocale
   } = props
 
-  // If the currentLocale does not exist, avoid error by rendering US flag
-  const CurrentLocaleFlag = configLanguages[currentLocale]
-    ? flags[configLanguages[currentLocale].flag]
-    : flags[configLanguages['en-US'].flag]
   const intl = useIntl()
 
   const handleLocaleSelection = (e: MouseEvent<Element>, locale: string) => {
@@ -65,20 +46,20 @@ const LocaleSelector = (props: LocaleSelectorProps): JSX.Element => {
     <NavDropdown
       id="locale-selector"
       pullRight
-      title={<CurrentLocaleFlag style={{ width: 15 }} />}
+      title={<Icon style={{ color: '#fff' }} type="globe" />}
     >
       {Object.keys(configLanguages).map((locale) => {
-        const Flag = flags[configLanguages[locale].flag]
         return (
           locale !== 'allLanguages' && (
             <MenuItem
+              className="locale-name"
               onClick={(e: MouseEvent) => handleLocaleSelection(e, locale)}
             >
-              <FlagContainer>
-                {locale === currentLocale && <Icon type="check-square" />}
-                {locale !== currentLocale && <Flag style={{ width: 15 }} />}
-              </FlagContainer>
-              {configLanguages[locale].name}
+              <span
+                style={locale === currentLocale ? { fontWeight: 'bold' } : {}}
+              >
+                {configLanguages[locale].name}
+              </span>
             </MenuItem>
           )
         )

--- a/lib/components/user/nav-login-button.css
+++ b/lib/components/user/nav-login-button.css
@@ -7,6 +7,11 @@
   * and add back some of the default visuals provided by react-bootstrap's <Nav>.
   * In desktop and mobile modes, we change the link color to white for consistency with the AppMenu component.
   */
+  
+/* Locale selector dropdown width override (default bootstrap dropdown is 120px)*/
+.dropdown > .dropdown-menu {
+  min-width: 0px;
+}
 
 .otp.mobile .navbar .container-fluid .locale-selector-and-login {
   position: fixed;

--- a/lib/util/i18n.js
+++ b/lib/util/i18n.js
@@ -10,7 +10,7 @@ import flatten from 'flat'
  * Match the provided locale (language and region) to the list of supported locales.
  * Default to english if unsupported.
  */
-function getMatchingLocaleString(
+export function getMatchingLocaleString(
   locale = '',
   defaultLocale = 'en-US',
   configLocales = {}
@@ -53,9 +53,7 @@ export function getConfigLocales(configLanguages) {
  *   id => string.
  * FIXME: Load languages on demand using fetch.
  */
-export async function loadLocaleData(locale, customMessages) {
-  const configLocales = getConfigLocales(customMessages)
-  const matchedLocale = getMatchingLocaleString(locale, 'en-US', configLocales)
+export async function loadLocaleData(matchedLocale, customMessages) {
   let messages
   switch (matchedLocale) {
     case 'es': // Spanish translation is not specific to a region
@@ -83,7 +81,7 @@ export async function loadLocaleData(locale, customMessages) {
     ...flatten(messages),
     // Override the predefined strings with the custom ones, if any provided.
     ...flatten(customMessages.allLanguages || {}),
-    ...flatten(customMessages[locale] || {})
+    ...flatten(customMessages[matchedLocale] || {})
   }
 
   return mergedMessages


### PR DESCRIPTION
This PR removes flags from the `LocaleSelector` component. Flags are replaced by the language name, which is bolded if selected (checkbox removed). 

A small improvement to the locale state update is made as well, which only updates the state with a matched (supported) locale. This allows bolding of the used language on initialization, as well as preventing a bug where custom messages are not imported before language selection. 

A related PR (https://github.com/ibi-group/configurations/pull/234) removes the flags from the ATL-RIDES QA config