### PR TITLE
Show date/time picker on focus on Chrome desktop

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -450,3 +450,7 @@ dateTime:
 # Mapillary calls these "Client Tokens". They can be created at https://www.mapillary.com/dashboard/developers
 # mapillary:
 #   key: <Mapillary Key>
+
+### Setting to enable touch-friendly behavior
+### e.g. on touch-screen kiosks that run a desktop OS.
+# isTouchScreenOnDesktop: true

--- a/lib/components/form/date-time-modal.js
+++ b/lib/components/form/date-time-modal.js
@@ -1,7 +1,9 @@
+// TODO: TypeScript with props.
+/* eslint-disable react/prop-types */
+import { connect } from 'react-redux'
 import coreUtils from '@opentripplanner/core-utils'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { connect } from 'react-redux'
 
 import { setQueryParam } from '../../actions/form'
 
@@ -12,8 +14,9 @@ class DateTimeModal extends Component {
     setQueryParam: PropTypes.func
   }
 
-  render () {
+  render() {
     const {
+      config,
       date,
       dateFormatLegacy,
       departArrive,
@@ -21,12 +24,16 @@ class DateTimeModal extends Component {
       time,
       timeFormatLegacy
     } = this.props
+    const { isTouchScreenOnDesktop } = config
+    const touchClassName = isTouchScreenOnDesktop
+      ? 'with-desktop-touchscreen'
+      : ''
 
     return (
-      <div className='date-time-modal'>
-        <div className='main-panel'>
+      <div className="date-time-modal">
+        <div className="main-panel">
           <StyledDateTimeSelector
-            className='date-time-selector'
+            className={`date-time-selector ${touchClassName}`}
             date={date}
             departArrive={departArrive}
             onQueryParamChange={setQueryParam}
@@ -46,17 +53,19 @@ class DateTimeModal extends Component {
   }
 }
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   const { date, departArrive, time } = state.otp.currentQuery
   const config = state.otp.config
   return {
     config,
     date,
-    departArrive,
-    time,
     // These props below are for legacy browsers (see render method above).
     // eslint-disable-next-line sort-keys
     dateFormatLegacy: coreUtils.time.getDateFormat(config),
+
+    departArrive,
+
+    time,
     timeFormatLegacy: coreUtils.time.getTimeFormat(config)
   }
 }

--- a/lib/components/form/date-time-modal.js
+++ b/lib/components/form/date-time-modal.js
@@ -59,13 +59,11 @@ const mapStateToProps = (state) => {
   return {
     config,
     date,
-    // These props below are for legacy browsers (see render method above).
-    // eslint-disable-next-line sort-keys
+    // This prop is for legacy browsers (see render method above).
     dateFormatLegacy: coreUtils.time.getDateFormat(config),
-
     departArrive,
-
     time,
+    // This prop is for legacy browsers (see render method above).
     timeFormatLegacy: coreUtils.time.getTimeFormat(config)
   }
 }

--- a/lib/components/form/form.css
+++ b/lib/components/form/form.css
@@ -429,3 +429,20 @@
 .otp .user-settings .disclaimer {
   font-size: x-small;
 }
+
+/* For Chrome/ium desktop browsers, if so configured,
+   set the date/time input controls to automatically show the date-time picker on focus.
+   This changes do not seem to affect Chrome/ium mobile browsers. */
+.otp .date-time-modal .date-time-selector.with-desktop-touchscreen input {
+  position: relative;
+}
+.otp .date-time-modal .date-time-selector.with-desktop-touchscreen input::-webkit-calendar-picker-indicator {
+  background-position-x: right;
+  margin-inline-end: 8px;
+  position: absolute;
+  right: 0;
+  width: 100%;
+}
+.otp .date-time-modal .date-time-selector.with-desktop-touchscreen input::-webkit-datetime-edit {
+  margin-inline-end: 8px;
+}


### PR DESCRIPTION
This PR hacks the `<input type="date">` and `<input type="time">` components on the desktop versions of Chrome/Chromium, so that, if so configured, when tapping "~anywhere" on these controls on a desktop OS, even using a touchscreen, the date or time picker is displayed automatically.

Note: there is https://developer.chrome.com/blog/show-picker/ that I have considered, but requires a longer review cycle because it touches the OTP-UI repo.
