### PR TITLE
Add new flex message if both call-ahead and continuous service exist in itinerary

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -112,7 +112,7 @@ map:
   ###   styles.segment_labels: styles attributes recognized by transitive.js.
   ###                         For examples of applicable style attributes, see
   ###                         https://github.com/conveyal/transitive.js/blob/master/stories/Transitive.stories.js#L47.
-  ### - disableFlexArc: optional parameter to disable rendering flex itinerary legs as an arc. 
+  ### - disableFlexArc: optional parameter to disable rendering flex itinerary legs as an arc.
   # transitive:
   #   labeledModes:
   #     - BUS
@@ -343,7 +343,7 @@ itinerary:
 ### Languages defined may be region-specific (e.g. en-US) or language-specific (e.g. es, kr)
 ### The LocaleSelector component, which provides a dropdown for the user to change their locale, will
 ### only be rendered if more than one valid language (all languages must have "name" defined) is included
-### in the language config. 
+### in the language config.
 
 # language:
 #   allLanguages
@@ -357,6 +357,7 @@ itinerary:
 #     config:
 #       flex:
 #         flex-service: Flex Service
+#         both: See bottom of itinerary for details.
 #         call-ahead: "Call to reserve: (555) 555-5555"
 #         continuous-dropoff: Communicate with operator about stop
 #       acessibilityScore:

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -883,3 +883,11 @@ util:
     titleBarRouteId: "Route {routeId}"
     titleBarStopId: "Stop {stopId}"
     titleBarWithStatus: "{title} | {status}"
+
+# Default values for Flex Indicator (set in configuration as well)
+config:
+  flex:
+    flex-service: Flex Service
+    both: See bottom of itinerary for details
+    call-ahead: Call to reserve
+    continuous-dropoff: Communicate with operator about stop

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -827,3 +827,11 @@ util:
     titleBarRouteId: "Ligne {routeId}"
     titleBarStopId: "Arrêt {stopId}"
     titleBarWithStatus: "{title} | {status}"
+
+# Default values for Flex Indicator (set in configuration as well)
+config:
+  flex:
+    flex-service: Service Flex
+    both: Plus de détails au bas de l'itinéraire
+    call-ahead: Appelez pour réserver
+    continuous-dropoff: Demandez l'arrêt au conducteur

--- a/lib/components/narrative/default/flex-indicator.tsx
+++ b/lib/components/narrative/default/flex-indicator.tsx
@@ -100,7 +100,16 @@ export const FlexIndicator = ({
         <FormattedMessage id="config.flex.flex-service" />
       </h4>
     )}
-    {isCallAhead && (
+    {isCallAhead && isContinuousDropoff && (
+      <FlexNotice
+        faKey="share"
+        showText={!shrink}
+        text={
+          <FormattedMessage id="config.flex.both" values={{ phoneNumber }} />
+        }
+      />
+    )}
+    {isCallAhead && !isContinuousDropoff && (
       <FlexNotice
         faKey="phone"
         showText={!shrink}

--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -62,11 +62,12 @@ class ConnectedItineraryBody extends Component {
     } = this.props
     const { LegIcon } = this.context
 
-    let [pickupAdded, dropOffAdded] = [false, false]
+    const clonedItinerary = clone(itinerary)
+    let pickupAdded = false
+    let dropOffAdded = false
 
     // Support OTP1 flex messages in Trip Details
-    itinerary.legs = itinerary.legs.map((oldLeg) => {
-      const leg = clone(oldLeg)
+    clonedItinerary.legs = clonedItinerary.legs.map((leg) => {
       if (!!leg.boardRule && !leg.pickupBookingInfo && !pickupAdded) {
         pickupAdded = true
         leg.pickupBookingInfo = {
@@ -92,7 +93,7 @@ class ConnectedItineraryBody extends Component {
           accessibilityScoreGradationMap={accessibilityScoreGradationMap}
           config={config}
           diagramVisible={diagramVisible}
-          itinerary={itinerary}
+          itinerary={clonedItinerary}
           LegIcon={LegIcon}
           LineColumnContent={LineColumnContent}
           mapillaryCallback={setMapillaryId}
@@ -114,8 +115,8 @@ class ConnectedItineraryBody extends Component {
           TransitLegSubheader={TransitLegSubheader}
           TransitLegSummary={TransitLegSummary}
         />
-        <TripDetails itinerary={itinerary} />
-        <TripTools itinerary={itinerary} />
+        <TripDetails itinerary={clonedItinerary} />
+        <TripTools itinerary={clonedItinerary} />
       </ItineraryBodyContainer>
     )
   }

--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -61,31 +61,35 @@ class ConnectedItineraryBody extends Component {
       timeOptions
     } = this.props
     const { LegIcon } = this.context
-
     const clonedItinerary = clone(itinerary)
-    let pickupAdded = false
-    let dropOffAdded = false
 
     // Support OTP1 flex messages in Trip Details
-    clonedItinerary.legs = clonedItinerary.legs.map((leg) => {
-      if (!!leg.boardRule && !leg.pickupBookingInfo && !pickupAdded) {
-        pickupAdded = true
-        leg.pickupBookingInfo = {
-          latestBookingTime: {
-            daysPrior: 0
-          }
+    // Adding empty pickupBookingInfo and dropOffBookingInfo objects
+    // to a leg will trigger relevant flex pickup / dropoff descriptions in
+    // the Trip Details component.
+    const boardingRuleLeg = clonedItinerary.legs.find(
+      (leg) => !!leg.boardRule && !leg.pickupBookingInfo
+    )
+    const alightingRuleLeg = clonedItinerary.legs.find(
+      (leg) => !!leg.alightRule && !leg.dropOffBookingInfo
+    )
+
+    // Add pickupBookingInfo for any boarding rules
+    if (boardingRuleLeg) {
+      boardingRuleLeg.pickupBookingInfo = {
+        latestBookingTime: {
+          daysPrior: 0
         }
       }
-      if (!!leg.alightRule && !leg.dropOffBookingInfo && !dropOffAdded) {
-        dropOffAdded = true
-        leg.dropOffBookingInfo = {
-          latestBookingTime: {
-            daysPrior: 0
-          }
+    }
+    // Add dropOffBookingInfo for any alighting rules
+    if (alightingRuleLeg) {
+      alightingRuleLeg.dropOffBookingInfo = {
+        latestBookingTime: {
+          daysPrior: 0
         }
       }
-      return leg
-    })
+    }
 
     return (
       <ItineraryBodyContainer>

--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -5,6 +5,7 @@ import {
   PlaceName as PlaceNameWrapper,
   PlaceRowWrapper
 } from '@opentripplanner/itinerary-body/lib/styled'
+import clone from 'clone'
 import isEqual from 'lodash.isequal'
 import ItineraryBody from '@opentripplanner/itinerary-body/lib/otp-react-redux/itinerary-body'
 import LineColumnContent from '@opentripplanner/itinerary-body/lib/otp-react-redux/line-column-content'
@@ -60,6 +61,30 @@ class ConnectedItineraryBody extends Component {
       timeOptions
     } = this.props
     const { LegIcon } = this.context
+
+    let [pickupAdded, dropOffAdded] = [false, false]
+
+    // Support OTP1 flex messages in Trip Details
+    itinerary.legs = itinerary.legs.map((oldLeg) => {
+      const leg = clone(oldLeg)
+      if (!!leg.boardRule && !leg.pickupBookingInfo && !pickupAdded) {
+        pickupAdded = true
+        leg.pickupBookingInfo = {
+          latestBookingTime: {
+            daysPrior: 0
+          }
+        }
+      }
+      if (!!leg.alightRule && !leg.dropOffBookingInfo && !dropOffAdded) {
+        dropOffAdded = true
+        leg.dropOffBookingInfo = {
+          latestBookingTime: {
+            daysPrior: 0
+          }
+        }
+      }
+      return leg
+    })
 
     return (
       <ItineraryBodyContainer>


### PR DESCRIPTION
Currently in the flex indicator, if an itinerary includes both call-ahead and continuous service, only one of the two messages will be provided in the `FlexIndicator`. This PR provides a new message, which directs a user to check out the `TripDetails` in order to see that the itinerary includes both call-ahead and continuous service. The `TripDetails` description for these type of flex service is new in this PR, and required adding some flex information to the leg pickup and drop off booking info to recognize the service as traditional flex. 

The PR also adds default flex messages in the en-US translations. 