### PR TITLE
Only Set Map Bounds to Route When Clicking New Route

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -62,6 +62,7 @@ const viewStop = createAction('SET_VIEWED_STOP')
 export const setHoveredStop = createAction('SET_HOVERED_STOP')
 export const setViewedTrip = createAction('SET_VIEWED_TRIP')
 const viewRoute = createAction('SET_VIEWED_ROUTE')
+export const unfocusRoute = createAction('UNFOCUS_ROUTE')
 export const toggleAutoRefresh = createAction('TOGGLE_AUTO_REFRESH')
 const setPreviousItineraryView = createAction('SET_PREVIOUS_ITINERARY_VIEW')
 

--- a/lib/components/map/connected-route-viewer-overlay.js
+++ b/lib/components/map/connected-route-viewer-overlay.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
 import RouteViewerOverlay from '@opentripplanner/route-viewer-overlay'
 
-import { MainPanelContent } from '../../actions/ui'
+import { unfocusRoute } from '../../actions/ui'
 
 // connect to the redux store
 
@@ -22,16 +22,13 @@ const mapStateToProps = (state, ownProps) => {
   }
 
   return {
-    allowMapCentering:
-      // TODO: allow panning of the map after initial click, but before pattern
-      // viewer open
-      state.otp.ui?.mainPanelContent === MainPanelContent.ROUTE_VIEWER,
+    allowMapCentering: state.otp.ui?.focusRoute,
     clipToPatternStops:
       state.otp.config?.routeViewer?.hideRouteShapesWithinFlexZones,
     routeData: { ...routeData, patterns: filteredPatterns }
   }
 }
 
-const mapDispatchToProps = {}
+const mapDispatchToProps = { mapCenterCallback: unfocusRoute }
 
 export default connect(mapStateToProps, mapDispatchToProps)(RouteViewerOverlay)

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -693,6 +693,7 @@ function createOtpReducer(config) {
           // If setting to a route (not null), also set main panel.
           return update(state, {
             ui: {
+              focusRoute: { $set: true },
               mainPanelContent: { $set: MainPanelContent.ROUTE_VIEWER },
               viewedRoute: { $set: action.payload }
             }
@@ -703,6 +704,8 @@ function createOtpReducer(config) {
             ui: { viewedRoute: { $set: action.payload } }
           })
         }
+      case 'UNFOCUS_ROUTE':
+        return update(state, { ui: { focusRoute: { $set: false } } })
       case 'FIND_STOP_RESPONSE':
         return update(state, {
           transitIndex: {


### PR DESCRIPTION
Makes use of https://github.com/opentripplanner/otp-ui/pull/362 to only adjust bounds when the user clicks a new route. Adds a new redux state field to keep track of if the map was re-centered.

This behavior feels most natural, but I'm open to feedback.