### PR TITLE
Create Percy Baseline Snapshots

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - dev
   pull_request:
 
 jobs:

--- a/percy/percy.test.js
+++ b/percy/percy.test.js
@@ -49,10 +49,12 @@ beforeAll(async () => {
       'yarn',
       'build'
     ])
+    console.log('Built OTP-RR')
 
     // grab ATL har file to tmp
     if (process.env.HAR_URL) {
       await execa('curl', [process.env.HAR_URL, '-s', '--output', 'mock.har'])
+      console.log('Downloaded HAR data')
     }
   } catch (error) {
     console.log(error)


### PR DESCRIPTION
The Percy config failed to run on merge into dev, causing there to be no baseline for the tests! This PR will trigger a Percy run on merge to dev, which should create the baseline snapshots we need.