### PR TITLE
Avoid Crash on Missing Geometry

### DIFF
--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -509,7 +509,7 @@ export const findRoute = (params) =>
               routePatterns[pattern.id] = {
                 ...pattern,
                 desc: pattern.name,
-                geometry: pattern.patternGeometry,
+                geometry: pattern?.patternGeometry || { points: '' },
                 stops: patternStops
               }
             })

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -509,7 +509,7 @@ export const findRoute = (params) =>
               routePatterns[pattern.id] = {
                 ...pattern,
                 desc: pattern.name,
-                geometry: pattern?.patternGeometry || { points: '' },
+                geometry: pattern?.patternGeometry || { length: 0, points: '' },
                 stops: patternStops
               }
             })

--- a/lib/components/map/connected-stops-overlay.js
+++ b/lib/components/map/connected-stops-overlay.js
@@ -36,6 +36,13 @@ const mapStateToProps = (state, ownProps) => {
 
       // Override the stop index so that only relevant stops are shown
       stops = route.patterns?.[viewedPattern]?.stops
+      // Discard duplicates
+      stops = stops.reduce((prev, cur) => {
+        if (!prev.find((stop) => stop.id === cur.id)) {
+          prev.push(cur)
+        }
+        return prev
+      }, [])
       // Override the minimum zoom so that the stops appear even if zoomed out
       minZoom = 2
     }

--- a/lib/components/map/connected-stops-overlay.js
+++ b/lib/components/map/connected-stops-overlay.js
@@ -37,7 +37,7 @@ const mapStateToProps = (state, ownProps) => {
       // Override the stop index so that only relevant stops are shown
       stops = route.patterns?.[viewedPattern]?.stops
       // Discard duplicates
-      stops = stops.reduce((prev, cur) => {
+      stops = (stops || []).reduce((prev, cur) => {
         if (!prev.find((stop) => stop.id === cur.id)) {
           prev.push(cur)
         }
@@ -49,7 +49,7 @@ const mapStateToProps = (state, ownProps) => {
   }
 
   return {
-    stops: stops || [],
+    stops,
     symbols: [
       {
         minZoom,


### PR DESCRIPTION
Some patterns don't have geometry which was crashing the route viewer overlay. This PR fixes this.