### PR TITLE
Itinerary block upgrade

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -250,6 +250,11 @@ itinerary:
   # Whether the plan first/previous/next/last buttons should be shown along with
   # plan trip itineraries.
   showPlanFirstLastButtons: false
+  # Whether to render route names and colors in the blocks inside
+  # the batch ui rows
+  renderRouteNamesInBlocks: true
+  # Whether the mode icons should be colored as well
+  fillModeIcons: true
   # If multiple fares are returned by OTP, assign names to the fare keys here
   #fareKeyNameMap:
   #  regular: "Transit Fare"

--- a/lib/components/narrative/default/itinerary-summary.js
+++ b/lib/components/narrative/default/itinerary-summary.js
@@ -1,16 +1,34 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
+import { connect } from 'react-redux'
 import { getCompanyFromLeg } from '@opentripplanner/core-utils/lib/itinerary'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import styled from 'styled-components'
 
+const mapStateToProps = (state, ownProps) => {
+  return {
+    fillModeIcons: state.otp.config.itinerary?.fillModeIcons,
+    renderRouteNamesAndColors:
+      state.otp.config.itinerary?.renderRouteNamesInBlocks
+  }
+}
 // FIXME: Some of these must be marked !important, otherwise the summary-block
 // mode-block css class selectors will take precedence.
-const Block = styled.div`
+const Block = connect(mapStateToProps)(styled.div`
   background-color: ${(props) =>
-    props.routeColor ? `#${props.routeColor}` : getModeColor(props.mode)};
+    props.renderRouteNamesAndColors && props.routeColor
+      ? `#${props.routeColor}`
+      : getModeColor(props.mode)};
   color: ${(props) =>
-    props.routeTextColor ? `#${props.routeTextColor}` : 'inherit'};
+    props.renderRouteNamesAndColors && props.routeTextColor
+      ? `#${props.routeTextColor}`
+      : 'inherit'};
+  fill: ${(props) =>
+    props.renderRouteNamesAndColors &&
+    props.fillModeIcons &&
+    props.routeTextColor
+      ? `#${props.routeTextColor}`
+      : 'inherit'};
   height: 24px !important;
   margin: 0px !important;
   padding: 3px !important;
@@ -26,7 +44,11 @@ const Block = styled.div`
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-`
+
+  span {
+    display: ${(props) => (props.renderRouteNamesAndColors ? 'block' : 'none')};
+  }
+`)
 
 const modeColors = {
   BICYCLE: '#E0C3E2',

--- a/lib/components/narrative/default/itinerary-summary.js
+++ b/lib/components/narrative/default/itinerary-summary.js
@@ -48,6 +48,11 @@ const Block = connect(mapStateToProps)(styled.div`
   span {
     display: ${(props) => (props.renderRouteNamesAndColors ? 'block' : 'none')};
   }
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
 `)
 
 const modeColors = {

--- a/lib/components/narrative/default/itinerary-summary.js
+++ b/lib/components/narrative/default/itinerary-summary.js
@@ -1,16 +1,23 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
 import { getCompanyFromLeg } from '@opentripplanner/core-utils/lib/itinerary'
-import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import React, { Component } from 'react'
 import styled from 'styled-components'
 
 // FIXME: Some of these must be marked !important, otherwise the summary-block
 // mode-block css class selectors will take precedence.
 const Block = styled.div`
-  background-color: ${props => getModeColor(props.mode)};
-  height: 24px!important;
-  margin: 0px!important;
-  padding: 3px!important;
-  width: 24px!important;
+  background-color: ${(props) =>
+    props.routeColor ? `#${props.routeColor}` : getModeColor(props.mode)};
+  color: ${(props) =>
+    props.routeTextColor ? `#${props.routeTextColor}` : 'inherit'};
+  height: 24px !important;
+  margin: 0px !important;
+  padding: 3px !important;
+  width: auto !important;
+  display: inline-flex !important;
+  align-items: normal;
+  gap: 2px;
   :first-child {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
@@ -29,9 +36,9 @@ const modeColors = {
   RAIL: '#BDDAC0',
   WALK: '#DFC486'
 }
-const DEFAULT_COLOR = '#685C5C'
+const DEFAULT_COLOR = '#c49494'
 
-function getModeColor (mode) {
+function getModeColor(mode) {
   if (!mode) return DEFAULT_COLOR
   let color = modeColors[mode.toUpperCase()]
   if (typeof color === 'undefined') color = DEFAULT_COLOR
@@ -44,7 +51,7 @@ export default class ItinerarySummary extends Component {
     LegIcon: PropTypes.elementType.isRequired
   }
 
-  render () {
+  render() {
     const { itinerary, LegIcon } = this.props
 
     const blocks = []
@@ -55,7 +62,8 @@ export default class ItinerarySummary extends Component {
         i < itinerary.legs.length - 1 &&
         !leg.transitLeg &&
         itinerary.legs[i - 1].transitLeg &&
-        itinerary.legs[i + 1].transitLeg) {
+        itinerary.legs[i + 1].transitLeg
+      ) {
         return null
       }
 
@@ -63,7 +71,9 @@ export default class ItinerarySummary extends Component {
       let title = leg.mode
       if (leg.transitLeg) {
         title = leg.routeShortName
-          ? `${leg.routeShortName}${leg.routeLongName ? ` - ${leg.routeLongName}` : ''}`
+          ? `${leg.routeShortName}${
+              leg.routeLongName ? ` - ${leg.routeLongName}` : ''
+            }`
           : leg.routeLongName
       }
       const company = getCompanyFromLeg(leg)
@@ -71,20 +81,23 @@ export default class ItinerarySummary extends Component {
       // FIXME: hack for HOPR company logo, which must be offset a few pixels
       // to look good.
       if (company && company.toLowerCase() === 'hopr') {
-        iconStyle = {marginTop: '-5px'}
+        iconStyle = { marginTop: '-5px' }
       }
       blocks.push(
         <Block
-          className='summary-block mode-block'
+          className="summary-block mode-block"
           key={blocks.length}
           mode={leg.mode}
+          routeColor={leg.routeColor}
+          routeTextColor={leg.routeTextColor}
           title={title}
         >
           <LegIcon leg={leg} style={iconStyle} />
+          <span>{leg.routeShortName}</span>
         </Block>
       )
     })
 
-    return <div className='summary'>{blocks}</div>
+    return <div className="summary">{blocks}</div>
   }
 }


### PR DESCRIPTION
This PR adds rudimentary improvements to the batch UI itinerary blocks, showing route colors and names.

This is not a complete upgrade, but a start in the right direction.

 <img width="266" alt="Screen Shot 2022-04-05 at 12 40 25 PM" src="https://user-images.githubusercontent.com/86619099/161836234-db3bc41c-0377-48eb-bcbf-0d0f575dcac8.png">


## TODO
- [x] allow the route names to be disabled via config
- [x] allow text coloring to be disabled via config 
- [x] allow for icons that need to be `fill`ed (config option to enable/disable icon coloring)

Waiting on https://github.com/opentripplanner/otp-react-redux/pull/583