### PR TITLE
fix(schedule viewer): avoid crash on missing pattern description

### DIFF
--- a/lib/util/viewer.js
+++ b/lib/util/viewer.js
@@ -76,7 +76,7 @@ export function extractHeadsignFromPattern(pattern) {
   // In case stop time headsign is blank, extract headsign from the pattern 'desc' attribute
   // (format: '49 to <Destination> (<destid>)[ from <Origin> (<originid)]').
   if (isBlank(headsign)) {
-    const matches = pattern.desc.match(/(?: to )(.*?)(?: \()/)
+    const matches = pattern?.desc?.match(/(?: to )(.*?)(?: \()/)
     if (matches) {
       headsign = matches[1]
     }
@@ -84,7 +84,7 @@ export function extractHeadsignFromPattern(pattern) {
 
   // If that regex didn't work, try the old regex
   if (isBlank(headsign)) {
-    const matches = pattern.desc.match(/ to ([^(from)]+) \(.+\)/)
+    const matches = pattern?.desc?.match(/ to ([^(from)]+) \(.+\)/)
     if (matches) {
       headsign = matches[1]
     }
@@ -92,7 +92,7 @@ export function extractHeadsignFromPattern(pattern) {
 
   // If the headsign is still blank, show the description
   if (isBlank(headsign)) {
-    headsign = pattern.desc
+    headsign = pattern?.desc || ''
   }
 
   return headsign


### PR DESCRIPTION
The schedule viewer had a bug where it would crash if a pattern had no description. This small PR resolves this bug.