### PR TITLE
Don't display fares explictly set <0

### DIFF
--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -134,7 +134,7 @@ const ITINERARY_ATTRIBUTES = [
       const fareInCents = getTotalFare(itinerary, options.configCosts, defaultFareKey)
       const fareCurrency = itinerary.fare?.fare?.regular?.currency?.currencyCode
       const fare = fareInCents === null ? null : fareInCents / 100
-      if (fare === null) return <FormattedMessage id="common.itineraryDescriptions.noTransitFareProvided" />
+      if (fare === null || fare < 0) return <FormattedMessage id="common.itineraryDescriptions.noTransitFareProvided" />
       return (
         <FormattedNumber
           // Currency from itinerary fare or from config.


### PR DESCRIPTION
This fix feels like it may be more appropriate to make at the OTP level. I would be open to closing this PR and making one in OTP instead.

Either way, this PR prevents the following object from being rendered "correctly"
<img width="484" alt="MicrosoftTeams-image (1)" src="https://user-images.githubusercontent.com/86619099/162037323-9c0937ac-1c18-4f85-af00-ab2ce5f36fb6.png">

