### PR TITLE
Better screen reader support

### DIFF
--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -471,19 +471,61 @@ exports[`components > viewers > stop viewer should render countdown times after 
                     onClick={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <injectIntl(Icon)
                       type="arrow-left"
                     >
-                      <FontAwesome
-                        fixedWidth={true}
-                        name="arrow-left"
+                      <Icon
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en-US",
+                            "defaultRichTextElements": undefined,
+                            "formatDate": [Function],
+                            "formatDateTimeRange": [Function],
+                            "formatDateToParts": [Function],
+                            "formatDisplayName": [Function],
+                            "formatList": [Function],
+                            "formatListToParts": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatNumberToParts": [Function],
+                            "formatPlural": [Function],
+                            "formatRelativeTime": [Function],
+                            "formatTime": [Function],
+                            "formatTimeToParts": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getDisplayNames": [Function],
+                              "getListFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralRules": [Function],
+                              "getRelativeTimeFormat": [Function],
+                            },
+                            "locale": "en-US",
+                            "messages": Object {},
+                            "onError": [Function],
+                            "textComponent": Symbol(react.fragment),
+                            "timeZone": undefined,
+                            "wrapRichTextChunksInFragment": undefined,
+                          }
+                        }
+                        type="arrow-left"
                       >
-                        <span
-                          aria-hidden={true}
-                          className="fa fa-arrow-left fa-fw"
-                        />
-                      </FontAwesome>
-                    </Icon>
+                        <FontAwesome
+                          aria-label=""
+                          fixedWidth={true}
+                          name="arrow-left"
+                        >
+                          <span
+                            aria-hidden={true}
+                            aria-label=""
+                            className="fa fa-arrow-left fa-fw"
+                          />
+                        </FontAwesome>
+                      </Icon>
+                    </injectIntl(Icon)>
                     <FormattedMessage
                       id="common.forms.back"
                     >
@@ -534,19 +576,61 @@ exports[`components > viewers > stop viewer should render countdown times after 
                     onClick={[Function]}
                     title="components.StopViewer.zoomToStop"
                   >
-                    <Icon
+                    <injectIntl(Icon)
                       type="search"
                     >
-                      <FontAwesome
-                        fixedWidth={true}
-                        name="search"
+                      <Icon
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en-US",
+                            "defaultRichTextElements": undefined,
+                            "formatDate": [Function],
+                            "formatDateTimeRange": [Function],
+                            "formatDateToParts": [Function],
+                            "formatDisplayName": [Function],
+                            "formatList": [Function],
+                            "formatListToParts": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatNumberToParts": [Function],
+                            "formatPlural": [Function],
+                            "formatRelativeTime": [Function],
+                            "formatTime": [Function],
+                            "formatTimeToParts": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getDisplayNames": [Function],
+                              "getListFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralRules": [Function],
+                              "getRelativeTimeFormat": [Function],
+                            },
+                            "locale": "en-US",
+                            "messages": Object {},
+                            "onError": [Function],
+                            "textComponent": Symbol(react.fragment),
+                            "timeZone": undefined,
+                            "wrapRichTextChunksInFragment": undefined,
+                          }
+                        }
+                        type="search"
                       >
-                        <span
-                          aria-hidden={true}
-                          className="fa fa-search fa-fw"
-                        />
-                      </FontAwesome>
-                    </Icon>
+                        <FontAwesome
+                          aria-label=""
+                          fixedWidth={true}
+                          name="search"
+                        >
+                          <span
+                            aria-hidden={true}
+                            aria-label=""
+                            className="fa fa-search fa-fw"
+                          />
+                        </FontAwesome>
+                      </Icon>
+                    </injectIntl(Icon)>
                   </button>
                   <button
                     className="link-button pull-right"
@@ -557,26 +641,70 @@ exports[`components > viewers > stop viewer should render countdown times after 
                       }
                     }
                   >
-                    <Icon
+                    <injectIntl(Icon)
                       type="calendar"
                       withSpace={true}
                     >
-                      <Styled(FontAwesome)
-                        fixedWidth={true}
-                        name="calendar"
+                      <Icon
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en-US",
+                            "defaultRichTextElements": undefined,
+                            "formatDate": [Function],
+                            "formatDateTimeRange": [Function],
+                            "formatDateToParts": [Function],
+                            "formatDisplayName": [Function],
+                            "formatList": [Function],
+                            "formatListToParts": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatNumberToParts": [Function],
+                            "formatPlural": [Function],
+                            "formatRelativeTime": [Function],
+                            "formatTime": [Function],
+                            "formatTimeToParts": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getDisplayNames": [Function],
+                              "getListFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralRules": [Function],
+                              "getRelativeTimeFormat": [Function],
+                            },
+                            "locale": "en-US",
+                            "messages": Object {},
+                            "onError": [Function],
+                            "textComponent": Symbol(react.fragment),
+                            "timeZone": undefined,
+                            "wrapRichTextChunksInFragment": undefined,
+                          }
+                        }
+                        type="calendar"
+                        withSpace={true}
                       >
-                        <FontAwesome
-                          className="sc-gsTEea iqivwV"
+                        <Styled(FontAwesome)
+                          aria-label=""
                           fixedWidth={true}
                           name="calendar"
                         >
-                          <span
-                            aria-hidden={true}
-                            className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
-                          />
-                        </FontAwesome>
-                      </Styled(FontAwesome)>
-                    </Icon>
+                          <FontAwesome
+                            aria-label=""
+                            className="sc-gsTEea iqivwV"
+                            fixedWidth={true}
+                            name="calendar"
+                          >
+                            <span
+                              aria-hidden={true}
+                              aria-label=""
+                              className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
+                            />
+                          </FontAwesome>
+                        </Styled(FontAwesome)>
+                      </Icon>
+                    </injectIntl(Icon)>
                     <FormattedMessage
                       id="components.StopViewer.viewTypeBtnText"
                       values={
@@ -1342,7 +1470,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                     <div
                                       className="pull-left"
                                     >
-                                      <Icon
+                                      <injectIntl(Icon)
                                         style={
                                           Object {
                                             "color": "#888",
@@ -1352,9 +1480,43 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                         }
                                         type="clock-o"
                                       >
-                                        <FontAwesome
-                                          fixedWidth={true}
-                                          name="clock-o"
+                                        <Icon
+                                          intl={
+                                            Object {
+                                              "defaultFormats": Object {},
+                                              "defaultLocale": "en-US",
+                                              "defaultRichTextElements": undefined,
+                                              "formatDate": [Function],
+                                              "formatDateTimeRange": [Function],
+                                              "formatDateToParts": [Function],
+                                              "formatDisplayName": [Function],
+                                              "formatList": [Function],
+                                              "formatListToParts": [Function],
+                                              "formatMessage": [Function],
+                                              "formatNumber": [Function],
+                                              "formatNumberToParts": [Function],
+                                              "formatPlural": [Function],
+                                              "formatRelativeTime": [Function],
+                                              "formatTime": [Function],
+                                              "formatTimeToParts": [Function],
+                                              "formats": Object {},
+                                              "formatters": Object {
+                                                "getDateTimeFormat": [Function],
+                                                "getDisplayNames": [Function],
+                                                "getListFormat": [Function],
+                                                "getMessageFormat": [Function],
+                                                "getNumberFormat": [Function],
+                                                "getPluralRules": [Function],
+                                                "getRelativeTimeFormat": [Function],
+                                              },
+                                              "locale": "en-US",
+                                              "messages": Object {},
+                                              "onError": [Function],
+                                              "textComponent": Symbol(react.fragment),
+                                              "timeZone": undefined,
+                                              "wrapRichTextChunksInFragment": undefined,
+                                            }
+                                          }
                                           style={
                                             Object {
                                               "color": "#888",
@@ -1362,10 +1524,12 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                               "marginRight": 2,
                                             }
                                           }
+                                          type="clock-o"
                                         >
-                                          <span
-                                            aria-hidden={true}
-                                            className="fa fa-clock-o fa-fw"
+                                          <FontAwesome
+                                            aria-label=""
+                                            fixedWidth={true}
+                                            name="clock-o"
                                             style={
                                               Object {
                                                 "color": "#888",
@@ -1373,9 +1537,22 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                                 "marginRight": 2,
                                               }
                                             }
-                                          />
-                                        </FontAwesome>
-                                      </Icon>
+                                          >
+                                            <span
+                                              aria-hidden={true}
+                                              aria-label=""
+                                              className="fa fa-clock-o fa-fw"
+                                              style={
+                                                Object {
+                                                  "color": "#888",
+                                                  "fontSize": "0.8em",
+                                                  "marginRight": 2,
+                                                }
+                                              }
+                                            />
+                                          </FontAwesome>
+                                        </Icon>
+                                      </injectIntl(Icon)>
                                     </div>
                                     <div
                                       style={
@@ -1416,19 +1593,61 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                   className="expansion-button"
                                   onClick={[Function]}
                                 >
-                                  <Icon
+                                  <injectIntl(Icon)
                                     type="chevron-down"
                                   >
-                                    <FontAwesome
-                                      fixedWidth={true}
-                                      name="chevron-down"
+                                    <Icon
+                                      intl={
+                                        Object {
+                                          "defaultFormats": Object {},
+                                          "defaultLocale": "en-US",
+                                          "defaultRichTextElements": undefined,
+                                          "formatDate": [Function],
+                                          "formatDateTimeRange": [Function],
+                                          "formatDateToParts": [Function],
+                                          "formatDisplayName": [Function],
+                                          "formatList": [Function],
+                                          "formatListToParts": [Function],
+                                          "formatMessage": [Function],
+                                          "formatNumber": [Function],
+                                          "formatNumberToParts": [Function],
+                                          "formatPlural": [Function],
+                                          "formatRelativeTime": [Function],
+                                          "formatTime": [Function],
+                                          "formatTimeToParts": [Function],
+                                          "formats": Object {},
+                                          "formatters": Object {
+                                            "getDateTimeFormat": [Function],
+                                            "getDisplayNames": [Function],
+                                            "getListFormat": [Function],
+                                            "getMessageFormat": [Function],
+                                            "getNumberFormat": [Function],
+                                            "getPluralRules": [Function],
+                                            "getRelativeTimeFormat": [Function],
+                                          },
+                                          "locale": "en-US",
+                                          "messages": Object {},
+                                          "onError": [Function],
+                                          "textComponent": Symbol(react.fragment),
+                                          "timeZone": undefined,
+                                          "wrapRichTextChunksInFragment": undefined,
+                                        }
+                                      }
+                                      type="chevron-down"
                                     >
-                                      <span
-                                        aria-hidden={true}
-                                        className="fa fa-chevron-down fa-fw"
-                                      />
-                                    </FontAwesome>
-                                  </Icon>
+                                      <FontAwesome
+                                        aria-label=""
+                                        fixedWidth={true}
+                                        name="chevron-down"
+                                      >
+                                        <span
+                                          aria-hidden={true}
+                                          aria-label=""
+                                          className="fa fa-chevron-down fa-fw"
+                                        />
+                                      </FontAwesome>
+                                    </Icon>
+                                  </injectIntl(Icon)>
                                 </button>
                               </div>
                             </div>
@@ -1509,28 +1728,73 @@ exports[`components > viewers > stop viewer should render countdown times after 
                           }
                         }
                       >
-                        <Icon
+                        <injectIntl(Icon)
                           className="fa-spin"
                           type="refresh"
                           withSpace={true}
                         >
-                          <Styled(FontAwesome)
+                          <Icon
                             className="fa-spin"
-                            fixedWidth={true}
-                            name="refresh"
+                            intl={
+                              Object {
+                                "defaultFormats": Object {},
+                                "defaultLocale": "en-US",
+                                "defaultRichTextElements": undefined,
+                                "formatDate": [Function],
+                                "formatDateTimeRange": [Function],
+                                "formatDateToParts": [Function],
+                                "formatDisplayName": [Function],
+                                "formatList": [Function],
+                                "formatListToParts": [Function],
+                                "formatMessage": [Function],
+                                "formatNumber": [Function],
+                                "formatNumberToParts": [Function],
+                                "formatPlural": [Function],
+                                "formatRelativeTime": [Function],
+                                "formatTime": [Function],
+                                "formatTimeToParts": [Function],
+                                "formats": Object {},
+                                "formatters": Object {
+                                  "getDateTimeFormat": [Function],
+                                  "getDisplayNames": [Function],
+                                  "getListFormat": [Function],
+                                  "getMessageFormat": [Function],
+                                  "getNumberFormat": [Function],
+                                  "getPluralRules": [Function],
+                                  "getRelativeTimeFormat": [Function],
+                                },
+                                "locale": "en-US",
+                                "messages": Object {},
+                                "onError": [Function],
+                                "textComponent": Symbol(react.fragment),
+                                "timeZone": undefined,
+                                "wrapRichTextChunksInFragment": undefined,
+                              }
+                            }
+                            type="refresh"
+                            withSpace={true}
                           >
-                            <FontAwesome
-                              className="sc-gsTEea iqivwV fa-spin"
+                            <Styled(FontAwesome)
+                              aria-label=""
+                              className="fa-spin"
                               fixedWidth={true}
                               name="refresh"
                             >
-                              <span
-                                aria-hidden={true}
-                                className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
-                              />
-                            </FontAwesome>
-                          </Styled(FontAwesome)>
-                        </Icon>
+                              <FontAwesome
+                                aria-label=""
+                                className="sc-gsTEea iqivwV fa-spin"
+                                fixedWidth={true}
+                                name="refresh"
+                              >
+                                <span
+                                  aria-hidden={true}
+                                  aria-label=""
+                                  className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
+                                />
+                              </FontAwesome>
+                            </Styled(FontAwesome)>
+                          </Icon>
+                        </injectIntl(Icon)>
                         <FormattedTime
                           timeStyle="short"
                           timeZone="America/Los_Angeles"
@@ -2644,19 +2908,61 @@ exports[`components > viewers > stop viewer should render countdown times for st
                     onClick={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <injectIntl(Icon)
                       type="arrow-left"
                     >
-                      <FontAwesome
-                        fixedWidth={true}
-                        name="arrow-left"
+                      <Icon
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en-US",
+                            "defaultRichTextElements": undefined,
+                            "formatDate": [Function],
+                            "formatDateTimeRange": [Function],
+                            "formatDateToParts": [Function],
+                            "formatDisplayName": [Function],
+                            "formatList": [Function],
+                            "formatListToParts": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatNumberToParts": [Function],
+                            "formatPlural": [Function],
+                            "formatRelativeTime": [Function],
+                            "formatTime": [Function],
+                            "formatTimeToParts": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getDisplayNames": [Function],
+                              "getListFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralRules": [Function],
+                              "getRelativeTimeFormat": [Function],
+                            },
+                            "locale": "en-US",
+                            "messages": Object {},
+                            "onError": [Function],
+                            "textComponent": Symbol(react.fragment),
+                            "timeZone": undefined,
+                            "wrapRichTextChunksInFragment": undefined,
+                          }
+                        }
+                        type="arrow-left"
                       >
-                        <span
-                          aria-hidden={true}
-                          className="fa fa-arrow-left fa-fw"
-                        />
-                      </FontAwesome>
-                    </Icon>
+                        <FontAwesome
+                          aria-label=""
+                          fixedWidth={true}
+                          name="arrow-left"
+                        >
+                          <span
+                            aria-hidden={true}
+                            aria-label=""
+                            className="fa fa-arrow-left fa-fw"
+                          />
+                        </FontAwesome>
+                      </Icon>
+                    </injectIntl(Icon)>
                     <FormattedMessage
                       id="common.forms.back"
                     >
@@ -2707,19 +3013,61 @@ exports[`components > viewers > stop viewer should render countdown times for st
                     onClick={[Function]}
                     title="components.StopViewer.zoomToStop"
                   >
-                    <Icon
+                    <injectIntl(Icon)
                       type="search"
                     >
-                      <FontAwesome
-                        fixedWidth={true}
-                        name="search"
+                      <Icon
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en-US",
+                            "defaultRichTextElements": undefined,
+                            "formatDate": [Function],
+                            "formatDateTimeRange": [Function],
+                            "formatDateToParts": [Function],
+                            "formatDisplayName": [Function],
+                            "formatList": [Function],
+                            "formatListToParts": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatNumberToParts": [Function],
+                            "formatPlural": [Function],
+                            "formatRelativeTime": [Function],
+                            "formatTime": [Function],
+                            "formatTimeToParts": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getDisplayNames": [Function],
+                              "getListFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralRules": [Function],
+                              "getRelativeTimeFormat": [Function],
+                            },
+                            "locale": "en-US",
+                            "messages": Object {},
+                            "onError": [Function],
+                            "textComponent": Symbol(react.fragment),
+                            "timeZone": undefined,
+                            "wrapRichTextChunksInFragment": undefined,
+                          }
+                        }
+                        type="search"
                       >
-                        <span
-                          aria-hidden={true}
-                          className="fa fa-search fa-fw"
-                        />
-                      </FontAwesome>
-                    </Icon>
+                        <FontAwesome
+                          aria-label=""
+                          fixedWidth={true}
+                          name="search"
+                        >
+                          <span
+                            aria-hidden={true}
+                            aria-label=""
+                            className="fa fa-search fa-fw"
+                          />
+                        </FontAwesome>
+                      </Icon>
+                    </injectIntl(Icon)>
                   </button>
                   <button
                     className="link-button pull-right"
@@ -2730,26 +3078,70 @@ exports[`components > viewers > stop viewer should render countdown times for st
                       }
                     }
                   >
-                    <Icon
+                    <injectIntl(Icon)
                       type="calendar"
                       withSpace={true}
                     >
-                      <Styled(FontAwesome)
-                        fixedWidth={true}
-                        name="calendar"
+                      <Icon
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en-US",
+                            "defaultRichTextElements": undefined,
+                            "formatDate": [Function],
+                            "formatDateTimeRange": [Function],
+                            "formatDateToParts": [Function],
+                            "formatDisplayName": [Function],
+                            "formatList": [Function],
+                            "formatListToParts": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatNumberToParts": [Function],
+                            "formatPlural": [Function],
+                            "formatRelativeTime": [Function],
+                            "formatTime": [Function],
+                            "formatTimeToParts": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getDisplayNames": [Function],
+                              "getListFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralRules": [Function],
+                              "getRelativeTimeFormat": [Function],
+                            },
+                            "locale": "en-US",
+                            "messages": Object {},
+                            "onError": [Function],
+                            "textComponent": Symbol(react.fragment),
+                            "timeZone": undefined,
+                            "wrapRichTextChunksInFragment": undefined,
+                          }
+                        }
+                        type="calendar"
+                        withSpace={true}
                       >
-                        <FontAwesome
-                          className="sc-gsTEea iqivwV"
+                        <Styled(FontAwesome)
+                          aria-label=""
                           fixedWidth={true}
                           name="calendar"
                         >
-                          <span
-                            aria-hidden={true}
-                            className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
-                          />
-                        </FontAwesome>
-                      </Styled(FontAwesome)>
-                    </Icon>
+                          <FontAwesome
+                            aria-label=""
+                            className="sc-gsTEea iqivwV"
+                            fixedWidth={true}
+                            name="calendar"
+                          >
+                            <span
+                              aria-hidden={true}
+                              aria-label=""
+                              className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
+                            />
+                          </FontAwesome>
+                        </Styled(FontAwesome)>
+                      </Icon>
+                    </injectIntl(Icon)>
                     <FormattedMessage
                       id="components.StopViewer.viewTypeBtnText"
                       values={
@@ -3236,7 +3628,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                     <div
                                       className="pull-left"
                                     >
-                                      <Icon
+                                      <injectIntl(Icon)
                                         style={
                                           Object {
                                             "color": "#888",
@@ -3246,9 +3638,43 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                         }
                                         type="clock-o"
                                       >
-                                        <FontAwesome
-                                          fixedWidth={true}
-                                          name="clock-o"
+                                        <Icon
+                                          intl={
+                                            Object {
+                                              "defaultFormats": Object {},
+                                              "defaultLocale": "en-US",
+                                              "defaultRichTextElements": undefined,
+                                              "formatDate": [Function],
+                                              "formatDateTimeRange": [Function],
+                                              "formatDateToParts": [Function],
+                                              "formatDisplayName": [Function],
+                                              "formatList": [Function],
+                                              "formatListToParts": [Function],
+                                              "formatMessage": [Function],
+                                              "formatNumber": [Function],
+                                              "formatNumberToParts": [Function],
+                                              "formatPlural": [Function],
+                                              "formatRelativeTime": [Function],
+                                              "formatTime": [Function],
+                                              "formatTimeToParts": [Function],
+                                              "formats": Object {},
+                                              "formatters": Object {
+                                                "getDateTimeFormat": [Function],
+                                                "getDisplayNames": [Function],
+                                                "getListFormat": [Function],
+                                                "getMessageFormat": [Function],
+                                                "getNumberFormat": [Function],
+                                                "getPluralRules": [Function],
+                                                "getRelativeTimeFormat": [Function],
+                                              },
+                                              "locale": "en-US",
+                                              "messages": Object {},
+                                              "onError": [Function],
+                                              "textComponent": Symbol(react.fragment),
+                                              "timeZone": undefined,
+                                              "wrapRichTextChunksInFragment": undefined,
+                                            }
+                                          }
                                           style={
                                             Object {
                                               "color": "#888",
@@ -3256,10 +3682,12 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                               "marginRight": 2,
                                             }
                                           }
+                                          type="clock-o"
                                         >
-                                          <span
-                                            aria-hidden={true}
-                                            className="fa fa-clock-o fa-fw"
+                                          <FontAwesome
+                                            aria-label=""
+                                            fixedWidth={true}
+                                            name="clock-o"
                                             style={
                                               Object {
                                                 "color": "#888",
@@ -3267,9 +3695,22 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                                 "marginRight": 2,
                                               }
                                             }
-                                          />
-                                        </FontAwesome>
-                                      </Icon>
+                                          >
+                                            <span
+                                              aria-hidden={true}
+                                              aria-label=""
+                                              className="fa fa-clock-o fa-fw"
+                                              style={
+                                                Object {
+                                                  "color": "#888",
+                                                  "fontSize": "0.8em",
+                                                  "marginRight": 2,
+                                                }
+                                              }
+                                            />
+                                          </FontAwesome>
+                                        </Icon>
+                                      </injectIntl(Icon)>
                                     </div>
                                     <div
                                       style={
@@ -3310,19 +3751,61 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                   className="expansion-button"
                                   onClick={[Function]}
                                 >
-                                  <Icon
+                                  <injectIntl(Icon)
                                     type="chevron-down"
                                   >
-                                    <FontAwesome
-                                      fixedWidth={true}
-                                      name="chevron-down"
+                                    <Icon
+                                      intl={
+                                        Object {
+                                          "defaultFormats": Object {},
+                                          "defaultLocale": "en-US",
+                                          "defaultRichTextElements": undefined,
+                                          "formatDate": [Function],
+                                          "formatDateTimeRange": [Function],
+                                          "formatDateToParts": [Function],
+                                          "formatDisplayName": [Function],
+                                          "formatList": [Function],
+                                          "formatListToParts": [Function],
+                                          "formatMessage": [Function],
+                                          "formatNumber": [Function],
+                                          "formatNumberToParts": [Function],
+                                          "formatPlural": [Function],
+                                          "formatRelativeTime": [Function],
+                                          "formatTime": [Function],
+                                          "formatTimeToParts": [Function],
+                                          "formats": Object {},
+                                          "formatters": Object {
+                                            "getDateTimeFormat": [Function],
+                                            "getDisplayNames": [Function],
+                                            "getListFormat": [Function],
+                                            "getMessageFormat": [Function],
+                                            "getNumberFormat": [Function],
+                                            "getPluralRules": [Function],
+                                            "getRelativeTimeFormat": [Function],
+                                          },
+                                          "locale": "en-US",
+                                          "messages": Object {},
+                                          "onError": [Function],
+                                          "textComponent": Symbol(react.fragment),
+                                          "timeZone": undefined,
+                                          "wrapRichTextChunksInFragment": undefined,
+                                        }
+                                      }
+                                      type="chevron-down"
                                     >
-                                      <span
-                                        aria-hidden={true}
-                                        className="fa fa-chevron-down fa-fw"
-                                      />
-                                    </FontAwesome>
-                                  </Icon>
+                                      <FontAwesome
+                                        aria-label=""
+                                        fixedWidth={true}
+                                        name="chevron-down"
+                                      >
+                                        <span
+                                          aria-hidden={true}
+                                          aria-label=""
+                                          className="fa fa-chevron-down fa-fw"
+                                        />
+                                      </FontAwesome>
+                                    </Icon>
+                                  </injectIntl(Icon)>
                                 </button>
                               </div>
                             </div>
@@ -3403,28 +3886,73 @@ exports[`components > viewers > stop viewer should render countdown times for st
                           }
                         }
                       >
-                        <Icon
+                        <injectIntl(Icon)
                           className="fa-spin"
                           type="refresh"
                           withSpace={true}
                         >
-                          <Styled(FontAwesome)
+                          <Icon
                             className="fa-spin"
-                            fixedWidth={true}
-                            name="refresh"
+                            intl={
+                              Object {
+                                "defaultFormats": Object {},
+                                "defaultLocale": "en-US",
+                                "defaultRichTextElements": undefined,
+                                "formatDate": [Function],
+                                "formatDateTimeRange": [Function],
+                                "formatDateToParts": [Function],
+                                "formatDisplayName": [Function],
+                                "formatList": [Function],
+                                "formatListToParts": [Function],
+                                "formatMessage": [Function],
+                                "formatNumber": [Function],
+                                "formatNumberToParts": [Function],
+                                "formatPlural": [Function],
+                                "formatRelativeTime": [Function],
+                                "formatTime": [Function],
+                                "formatTimeToParts": [Function],
+                                "formats": Object {},
+                                "formatters": Object {
+                                  "getDateTimeFormat": [Function],
+                                  "getDisplayNames": [Function],
+                                  "getListFormat": [Function],
+                                  "getMessageFormat": [Function],
+                                  "getNumberFormat": [Function],
+                                  "getPluralRules": [Function],
+                                  "getRelativeTimeFormat": [Function],
+                                },
+                                "locale": "en-US",
+                                "messages": Object {},
+                                "onError": [Function],
+                                "textComponent": Symbol(react.fragment),
+                                "timeZone": undefined,
+                                "wrapRichTextChunksInFragment": undefined,
+                              }
+                            }
+                            type="refresh"
+                            withSpace={true}
                           >
-                            <FontAwesome
-                              className="sc-gsTEea iqivwV fa-spin"
+                            <Styled(FontAwesome)
+                              aria-label=""
+                              className="fa-spin"
                               fixedWidth={true}
                               name="refresh"
                             >
-                              <span
-                                aria-hidden={true}
-                                className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
-                              />
-                            </FontAwesome>
-                          </Styled(FontAwesome)>
-                        </Icon>
+                              <FontAwesome
+                                aria-label=""
+                                className="sc-gsTEea iqivwV fa-spin"
+                                fixedWidth={true}
+                                name="refresh"
+                              >
+                                <span
+                                  aria-hidden={true}
+                                  aria-label=""
+                                  className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
+                                />
+                              </FontAwesome>
+                            </Styled(FontAwesome)>
+                          </Icon>
+                        </injectIntl(Icon)>
                         <FormattedTime
                           timeStyle="short"
                           timeZone="America/Los_Angeles"
@@ -4340,19 +4868,61 @@ exports[`components > viewers > stop viewer should render times after midnight w
                     onClick={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <injectIntl(Icon)
                       type="arrow-left"
                     >
-                      <FontAwesome
-                        fixedWidth={true}
-                        name="arrow-left"
+                      <Icon
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en-US",
+                            "defaultRichTextElements": undefined,
+                            "formatDate": [Function],
+                            "formatDateTimeRange": [Function],
+                            "formatDateToParts": [Function],
+                            "formatDisplayName": [Function],
+                            "formatList": [Function],
+                            "formatListToParts": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatNumberToParts": [Function],
+                            "formatPlural": [Function],
+                            "formatRelativeTime": [Function],
+                            "formatTime": [Function],
+                            "formatTimeToParts": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getDisplayNames": [Function],
+                              "getListFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralRules": [Function],
+                              "getRelativeTimeFormat": [Function],
+                            },
+                            "locale": "en-US",
+                            "messages": Object {},
+                            "onError": [Function],
+                            "textComponent": Symbol(react.fragment),
+                            "timeZone": undefined,
+                            "wrapRichTextChunksInFragment": undefined,
+                          }
+                        }
+                        type="arrow-left"
                       >
-                        <span
-                          aria-hidden={true}
-                          className="fa fa-arrow-left fa-fw"
-                        />
-                      </FontAwesome>
-                    </Icon>
+                        <FontAwesome
+                          aria-label=""
+                          fixedWidth={true}
+                          name="arrow-left"
+                        >
+                          <span
+                            aria-hidden={true}
+                            aria-label=""
+                            className="fa fa-arrow-left fa-fw"
+                          />
+                        </FontAwesome>
+                      </Icon>
+                    </injectIntl(Icon)>
                     <FormattedMessage
                       id="common.forms.back"
                     >
@@ -4403,19 +4973,61 @@ exports[`components > viewers > stop viewer should render times after midnight w
                     onClick={[Function]}
                     title="components.StopViewer.zoomToStop"
                   >
-                    <Icon
+                    <injectIntl(Icon)
                       type="search"
                     >
-                      <FontAwesome
-                        fixedWidth={true}
-                        name="search"
+                      <Icon
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en-US",
+                            "defaultRichTextElements": undefined,
+                            "formatDate": [Function],
+                            "formatDateTimeRange": [Function],
+                            "formatDateToParts": [Function],
+                            "formatDisplayName": [Function],
+                            "formatList": [Function],
+                            "formatListToParts": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatNumberToParts": [Function],
+                            "formatPlural": [Function],
+                            "formatRelativeTime": [Function],
+                            "formatTime": [Function],
+                            "formatTimeToParts": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getDisplayNames": [Function],
+                              "getListFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralRules": [Function],
+                              "getRelativeTimeFormat": [Function],
+                            },
+                            "locale": "en-US",
+                            "messages": Object {},
+                            "onError": [Function],
+                            "textComponent": Symbol(react.fragment),
+                            "timeZone": undefined,
+                            "wrapRichTextChunksInFragment": undefined,
+                          }
+                        }
+                        type="search"
                       >
-                        <span
-                          aria-hidden={true}
-                          className="fa fa-search fa-fw"
-                        />
-                      </FontAwesome>
-                    </Icon>
+                        <FontAwesome
+                          aria-label=""
+                          fixedWidth={true}
+                          name="search"
+                        >
+                          <span
+                            aria-hidden={true}
+                            aria-label=""
+                            className="fa fa-search fa-fw"
+                          />
+                        </FontAwesome>
+                      </Icon>
+                    </injectIntl(Icon)>
                   </button>
                   <button
                     className="link-button pull-right"
@@ -4426,26 +5038,70 @@ exports[`components > viewers > stop viewer should render times after midnight w
                       }
                     }
                   >
-                    <Icon
+                    <injectIntl(Icon)
                       type="calendar"
                       withSpace={true}
                     >
-                      <Styled(FontAwesome)
-                        fixedWidth={true}
-                        name="calendar"
+                      <Icon
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en-US",
+                            "defaultRichTextElements": undefined,
+                            "formatDate": [Function],
+                            "formatDateTimeRange": [Function],
+                            "formatDateToParts": [Function],
+                            "formatDisplayName": [Function],
+                            "formatList": [Function],
+                            "formatListToParts": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatNumberToParts": [Function],
+                            "formatPlural": [Function],
+                            "formatRelativeTime": [Function],
+                            "formatTime": [Function],
+                            "formatTimeToParts": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getDisplayNames": [Function],
+                              "getListFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralRules": [Function],
+                              "getRelativeTimeFormat": [Function],
+                            },
+                            "locale": "en-US",
+                            "messages": Object {},
+                            "onError": [Function],
+                            "textComponent": Symbol(react.fragment),
+                            "timeZone": undefined,
+                            "wrapRichTextChunksInFragment": undefined,
+                          }
+                        }
+                        type="calendar"
+                        withSpace={true}
                       >
-                        <FontAwesome
-                          className="sc-gsTEea iqivwV"
+                        <Styled(FontAwesome)
+                          aria-label=""
                           fixedWidth={true}
                           name="calendar"
                         >
-                          <span
-                            aria-hidden={true}
-                            className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
-                          />
-                        </FontAwesome>
-                      </Styled(FontAwesome)>
-                    </Icon>
+                          <FontAwesome
+                            aria-label=""
+                            className="sc-gsTEea iqivwV"
+                            fixedWidth={true}
+                            name="calendar"
+                          >
+                            <span
+                              aria-hidden={true}
+                              aria-label=""
+                              className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
+                            />
+                          </FontAwesome>
+                        </Styled(FontAwesome)>
+                      </Icon>
+                    </injectIntl(Icon)>
                     <FormattedMessage
                       id="components.StopViewer.viewTypeBtnText"
                       values={
@@ -5211,7 +5867,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                     <div
                                       className="pull-left"
                                     >
-                                      <Icon
+                                      <injectIntl(Icon)
                                         style={
                                           Object {
                                             "color": "#888",
@@ -5221,9 +5877,43 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                         }
                                         type="clock-o"
                                       >
-                                        <FontAwesome
-                                          fixedWidth={true}
-                                          name="clock-o"
+                                        <Icon
+                                          intl={
+                                            Object {
+                                              "defaultFormats": Object {},
+                                              "defaultLocale": "en-US",
+                                              "defaultRichTextElements": undefined,
+                                              "formatDate": [Function],
+                                              "formatDateTimeRange": [Function],
+                                              "formatDateToParts": [Function],
+                                              "formatDisplayName": [Function],
+                                              "formatList": [Function],
+                                              "formatListToParts": [Function],
+                                              "formatMessage": [Function],
+                                              "formatNumber": [Function],
+                                              "formatNumberToParts": [Function],
+                                              "formatPlural": [Function],
+                                              "formatRelativeTime": [Function],
+                                              "formatTime": [Function],
+                                              "formatTimeToParts": [Function],
+                                              "formats": Object {},
+                                              "formatters": Object {
+                                                "getDateTimeFormat": [Function],
+                                                "getDisplayNames": [Function],
+                                                "getListFormat": [Function],
+                                                "getMessageFormat": [Function],
+                                                "getNumberFormat": [Function],
+                                                "getPluralRules": [Function],
+                                                "getRelativeTimeFormat": [Function],
+                                              },
+                                              "locale": "en-US",
+                                              "messages": Object {},
+                                              "onError": [Function],
+                                              "textComponent": Symbol(react.fragment),
+                                              "timeZone": undefined,
+                                              "wrapRichTextChunksInFragment": undefined,
+                                            }
+                                          }
                                           style={
                                             Object {
                                               "color": "#888",
@@ -5231,10 +5921,12 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                               "marginRight": 2,
                                             }
                                           }
+                                          type="clock-o"
                                         >
-                                          <span
-                                            aria-hidden={true}
-                                            className="fa fa-clock-o fa-fw"
+                                          <FontAwesome
+                                            aria-label=""
+                                            fixedWidth={true}
+                                            name="clock-o"
                                             style={
                                               Object {
                                                 "color": "#888",
@@ -5242,9 +5934,22 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                                 "marginRight": 2,
                                               }
                                             }
-                                          />
-                                        </FontAwesome>
-                                      </Icon>
+                                          >
+                                            <span
+                                              aria-hidden={true}
+                                              aria-label=""
+                                              className="fa fa-clock-o fa-fw"
+                                              style={
+                                                Object {
+                                                  "color": "#888",
+                                                  "fontSize": "0.8em",
+                                                  "marginRight": 2,
+                                                }
+                                              }
+                                            />
+                                          </FontAwesome>
+                                        </Icon>
+                                      </injectIntl(Icon)>
                                     </div>
                                     <div
                                       style={
@@ -5297,19 +6002,61 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                   className="expansion-button"
                                   onClick={[Function]}
                                 >
-                                  <Icon
+                                  <injectIntl(Icon)
                                     type="chevron-down"
                                   >
-                                    <FontAwesome
-                                      fixedWidth={true}
-                                      name="chevron-down"
+                                    <Icon
+                                      intl={
+                                        Object {
+                                          "defaultFormats": Object {},
+                                          "defaultLocale": "en-US",
+                                          "defaultRichTextElements": undefined,
+                                          "formatDate": [Function],
+                                          "formatDateTimeRange": [Function],
+                                          "formatDateToParts": [Function],
+                                          "formatDisplayName": [Function],
+                                          "formatList": [Function],
+                                          "formatListToParts": [Function],
+                                          "formatMessage": [Function],
+                                          "formatNumber": [Function],
+                                          "formatNumberToParts": [Function],
+                                          "formatPlural": [Function],
+                                          "formatRelativeTime": [Function],
+                                          "formatTime": [Function],
+                                          "formatTimeToParts": [Function],
+                                          "formats": Object {},
+                                          "formatters": Object {
+                                            "getDateTimeFormat": [Function],
+                                            "getDisplayNames": [Function],
+                                            "getListFormat": [Function],
+                                            "getMessageFormat": [Function],
+                                            "getNumberFormat": [Function],
+                                            "getPluralRules": [Function],
+                                            "getRelativeTimeFormat": [Function],
+                                          },
+                                          "locale": "en-US",
+                                          "messages": Object {},
+                                          "onError": [Function],
+                                          "textComponent": Symbol(react.fragment),
+                                          "timeZone": undefined,
+                                          "wrapRichTextChunksInFragment": undefined,
+                                        }
+                                      }
+                                      type="chevron-down"
                                     >
-                                      <span
-                                        aria-hidden={true}
-                                        className="fa fa-chevron-down fa-fw"
-                                      />
-                                    </FontAwesome>
-                                  </Icon>
+                                      <FontAwesome
+                                        aria-label=""
+                                        fixedWidth={true}
+                                        name="chevron-down"
+                                      >
+                                        <span
+                                          aria-hidden={true}
+                                          aria-label=""
+                                          className="fa fa-chevron-down fa-fw"
+                                        />
+                                      </FontAwesome>
+                                    </Icon>
+                                  </injectIntl(Icon)>
                                 </button>
                               </div>
                             </div>
@@ -5390,28 +6137,73 @@ exports[`components > viewers > stop viewer should render times after midnight w
                           }
                         }
                       >
-                        <Icon
+                        <injectIntl(Icon)
                           className="fa-spin"
                           type="refresh"
                           withSpace={true}
                         >
-                          <Styled(FontAwesome)
+                          <Icon
                             className="fa-spin"
-                            fixedWidth={true}
-                            name="refresh"
+                            intl={
+                              Object {
+                                "defaultFormats": Object {},
+                                "defaultLocale": "en-US",
+                                "defaultRichTextElements": undefined,
+                                "formatDate": [Function],
+                                "formatDateTimeRange": [Function],
+                                "formatDateToParts": [Function],
+                                "formatDisplayName": [Function],
+                                "formatList": [Function],
+                                "formatListToParts": [Function],
+                                "formatMessage": [Function],
+                                "formatNumber": [Function],
+                                "formatNumberToParts": [Function],
+                                "formatPlural": [Function],
+                                "formatRelativeTime": [Function],
+                                "formatTime": [Function],
+                                "formatTimeToParts": [Function],
+                                "formats": Object {},
+                                "formatters": Object {
+                                  "getDateTimeFormat": [Function],
+                                  "getDisplayNames": [Function],
+                                  "getListFormat": [Function],
+                                  "getMessageFormat": [Function],
+                                  "getNumberFormat": [Function],
+                                  "getPluralRules": [Function],
+                                  "getRelativeTimeFormat": [Function],
+                                },
+                                "locale": "en-US",
+                                "messages": Object {},
+                                "onError": [Function],
+                                "textComponent": Symbol(react.fragment),
+                                "timeZone": undefined,
+                                "wrapRichTextChunksInFragment": undefined,
+                              }
+                            }
+                            type="refresh"
+                            withSpace={true}
                           >
-                            <FontAwesome
-                              className="sc-gsTEea iqivwV fa-spin"
+                            <Styled(FontAwesome)
+                              aria-label=""
+                              className="fa-spin"
                               fixedWidth={true}
                               name="refresh"
                             >
-                              <span
-                                aria-hidden={true}
-                                className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
-                              />
-                            </FontAwesome>
-                          </Styled(FontAwesome)>
-                        </Icon>
+                              <FontAwesome
+                                aria-label=""
+                                className="sc-gsTEea iqivwV fa-spin"
+                                fixedWidth={true}
+                                name="refresh"
+                              >
+                                <span
+                                  aria-hidden={true}
+                                  aria-label=""
+                                  className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
+                                />
+                              </FontAwesome>
+                            </Styled(FontAwesome)>
+                          </Icon>
+                        </injectIntl(Icon)>
                         <FormattedTime
                           timeStyle="short"
                           timeZone="America/Los_Angeles"
@@ -7239,19 +8031,61 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                     onClick={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <injectIntl(Icon)
                       type="arrow-left"
                     >
-                      <FontAwesome
-                        fixedWidth={true}
-                        name="arrow-left"
+                      <Icon
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en-US",
+                            "defaultRichTextElements": undefined,
+                            "formatDate": [Function],
+                            "formatDateTimeRange": [Function],
+                            "formatDateToParts": [Function],
+                            "formatDisplayName": [Function],
+                            "formatList": [Function],
+                            "formatListToParts": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatNumberToParts": [Function],
+                            "formatPlural": [Function],
+                            "formatRelativeTime": [Function],
+                            "formatTime": [Function],
+                            "formatTimeToParts": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getDisplayNames": [Function],
+                              "getListFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralRules": [Function],
+                              "getRelativeTimeFormat": [Function],
+                            },
+                            "locale": "en-US",
+                            "messages": Object {},
+                            "onError": [Function],
+                            "textComponent": Symbol(react.fragment),
+                            "timeZone": undefined,
+                            "wrapRichTextChunksInFragment": undefined,
+                          }
+                        }
+                        type="arrow-left"
                       >
-                        <span
-                          aria-hidden={true}
-                          className="fa fa-arrow-left fa-fw"
-                        />
-                      </FontAwesome>
-                    </Icon>
+                        <FontAwesome
+                          aria-label=""
+                          fixedWidth={true}
+                          name="arrow-left"
+                        >
+                          <span
+                            aria-hidden={true}
+                            aria-label=""
+                            className="fa fa-arrow-left fa-fw"
+                          />
+                        </FontAwesome>
+                      </Icon>
+                    </injectIntl(Icon)>
                     <FormattedMessage
                       id="common.forms.back"
                     >
@@ -7302,19 +8136,61 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                     onClick={[Function]}
                     title="components.StopViewer.zoomToStop"
                   >
-                    <Icon
+                    <injectIntl(Icon)
                       type="search"
                     >
-                      <FontAwesome
-                        fixedWidth={true}
-                        name="search"
+                      <Icon
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en-US",
+                            "defaultRichTextElements": undefined,
+                            "formatDate": [Function],
+                            "formatDateTimeRange": [Function],
+                            "formatDateToParts": [Function],
+                            "formatDisplayName": [Function],
+                            "formatList": [Function],
+                            "formatListToParts": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatNumberToParts": [Function],
+                            "formatPlural": [Function],
+                            "formatRelativeTime": [Function],
+                            "formatTime": [Function],
+                            "formatTimeToParts": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getDisplayNames": [Function],
+                              "getListFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralRules": [Function],
+                              "getRelativeTimeFormat": [Function],
+                            },
+                            "locale": "en-US",
+                            "messages": Object {},
+                            "onError": [Function],
+                            "textComponent": Symbol(react.fragment),
+                            "timeZone": undefined,
+                            "wrapRichTextChunksInFragment": undefined,
+                          }
+                        }
+                        type="search"
                       >
-                        <span
-                          aria-hidden={true}
-                          className="fa fa-search fa-fw"
-                        />
-                      </FontAwesome>
-                    </Icon>
+                        <FontAwesome
+                          aria-label=""
+                          fixedWidth={true}
+                          name="search"
+                        >
+                          <span
+                            aria-hidden={true}
+                            aria-label=""
+                            className="fa fa-search fa-fw"
+                          />
+                        </FontAwesome>
+                      </Icon>
+                    </injectIntl(Icon)>
                   </button>
                   <button
                     className="link-button pull-right"
@@ -7325,26 +8201,70 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                       }
                     }
                   >
-                    <Icon
+                    <injectIntl(Icon)
                       type="calendar"
                       withSpace={true}
                     >
-                      <Styled(FontAwesome)
-                        fixedWidth={true}
-                        name="calendar"
+                      <Icon
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en-US",
+                            "defaultRichTextElements": undefined,
+                            "formatDate": [Function],
+                            "formatDateTimeRange": [Function],
+                            "formatDateToParts": [Function],
+                            "formatDisplayName": [Function],
+                            "formatList": [Function],
+                            "formatListToParts": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatNumberToParts": [Function],
+                            "formatPlural": [Function],
+                            "formatRelativeTime": [Function],
+                            "formatTime": [Function],
+                            "formatTimeToParts": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getDisplayNames": [Function],
+                              "getListFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralRules": [Function],
+                              "getRelativeTimeFormat": [Function],
+                            },
+                            "locale": "en-US",
+                            "messages": Object {},
+                            "onError": [Function],
+                            "textComponent": Symbol(react.fragment),
+                            "timeZone": undefined,
+                            "wrapRichTextChunksInFragment": undefined,
+                          }
+                        }
+                        type="calendar"
+                        withSpace={true}
                       >
-                        <FontAwesome
-                          className="sc-gsTEea iqivwV"
+                        <Styled(FontAwesome)
+                          aria-label=""
                           fixedWidth={true}
                           name="calendar"
                         >
-                          <span
-                            aria-hidden={true}
-                            className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
-                          />
-                        </FontAwesome>
-                      </Styled(FontAwesome)>
-                    </Icon>
+                          <FontAwesome
+                            aria-label=""
+                            className="sc-gsTEea iqivwV"
+                            fixedWidth={true}
+                            name="calendar"
+                          >
+                            <span
+                              aria-hidden={true}
+                              aria-label=""
+                              className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
+                            />
+                          </FontAwesome>
+                        </Styled(FontAwesome)>
+                      </Icon>
+                    </injectIntl(Icon)>
                     <FormattedMessage
                       id="components.StopViewer.viewTypeBtnText"
                       values={
@@ -8364,7 +9284,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     <div
                                       className="pull-left"
                                     >
-                                      <Icon
+                                      <injectIntl(Icon)
                                         style={
                                           Object {
                                             "color": "#888",
@@ -8374,9 +9294,43 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         }
                                         type="clock-o"
                                       >
-                                        <FontAwesome
-                                          fixedWidth={true}
-                                          name="clock-o"
+                                        <Icon
+                                          intl={
+                                            Object {
+                                              "defaultFormats": Object {},
+                                              "defaultLocale": "en-US",
+                                              "defaultRichTextElements": undefined,
+                                              "formatDate": [Function],
+                                              "formatDateTimeRange": [Function],
+                                              "formatDateToParts": [Function],
+                                              "formatDisplayName": [Function],
+                                              "formatList": [Function],
+                                              "formatListToParts": [Function],
+                                              "formatMessage": [Function],
+                                              "formatNumber": [Function],
+                                              "formatNumberToParts": [Function],
+                                              "formatPlural": [Function],
+                                              "formatRelativeTime": [Function],
+                                              "formatTime": [Function],
+                                              "formatTimeToParts": [Function],
+                                              "formats": Object {},
+                                              "formatters": Object {
+                                                "getDateTimeFormat": [Function],
+                                                "getDisplayNames": [Function],
+                                                "getListFormat": [Function],
+                                                "getMessageFormat": [Function],
+                                                "getNumberFormat": [Function],
+                                                "getPluralRules": [Function],
+                                                "getRelativeTimeFormat": [Function],
+                                              },
+                                              "locale": "en-US",
+                                              "messages": Object {},
+                                              "onError": [Function],
+                                              "textComponent": Symbol(react.fragment),
+                                              "timeZone": undefined,
+                                              "wrapRichTextChunksInFragment": undefined,
+                                            }
+                                          }
                                           style={
                                             Object {
                                               "color": "#888",
@@ -8384,10 +9338,12 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                               "marginRight": 2,
                                             }
                                           }
+                                          type="clock-o"
                                         >
-                                          <span
-                                            aria-hidden={true}
-                                            className="fa fa-clock-o fa-fw"
+                                          <FontAwesome
+                                            aria-label=""
+                                            fixedWidth={true}
+                                            name="clock-o"
                                             style={
                                               Object {
                                                 "color": "#888",
@@ -8395,9 +9351,22 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                                 "marginRight": 2,
                                               }
                                             }
-                                          />
-                                        </FontAwesome>
-                                      </Icon>
+                                          >
+                                            <span
+                                              aria-hidden={true}
+                                              aria-label=""
+                                              className="fa fa-clock-o fa-fw"
+                                              style={
+                                                Object {
+                                                  "color": "#888",
+                                                  "fontSize": "0.8em",
+                                                  "marginRight": 2,
+                                                }
+                                              }
+                                            />
+                                          </FontAwesome>
+                                        </Icon>
+                                      </injectIntl(Icon)>
                                     </div>
                                     <div
                                       style={
@@ -8450,19 +9419,61 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   className="expansion-button"
                                   onClick={[Function]}
                                 >
-                                  <Icon
+                                  <injectIntl(Icon)
                                     type="chevron-down"
                                   >
-                                    <FontAwesome
-                                      fixedWidth={true}
-                                      name="chevron-down"
+                                    <Icon
+                                      intl={
+                                        Object {
+                                          "defaultFormats": Object {},
+                                          "defaultLocale": "en-US",
+                                          "defaultRichTextElements": undefined,
+                                          "formatDate": [Function],
+                                          "formatDateTimeRange": [Function],
+                                          "formatDateToParts": [Function],
+                                          "formatDisplayName": [Function],
+                                          "formatList": [Function],
+                                          "formatListToParts": [Function],
+                                          "formatMessage": [Function],
+                                          "formatNumber": [Function],
+                                          "formatNumberToParts": [Function],
+                                          "formatPlural": [Function],
+                                          "formatRelativeTime": [Function],
+                                          "formatTime": [Function],
+                                          "formatTimeToParts": [Function],
+                                          "formats": Object {},
+                                          "formatters": Object {
+                                            "getDateTimeFormat": [Function],
+                                            "getDisplayNames": [Function],
+                                            "getListFormat": [Function],
+                                            "getMessageFormat": [Function],
+                                            "getNumberFormat": [Function],
+                                            "getPluralRules": [Function],
+                                            "getRelativeTimeFormat": [Function],
+                                          },
+                                          "locale": "en-US",
+                                          "messages": Object {},
+                                          "onError": [Function],
+                                          "textComponent": Symbol(react.fragment),
+                                          "timeZone": undefined,
+                                          "wrapRichTextChunksInFragment": undefined,
+                                        }
+                                      }
+                                      type="chevron-down"
                                     >
-                                      <span
-                                        aria-hidden={true}
-                                        className="fa fa-chevron-down fa-fw"
-                                      />
-                                    </FontAwesome>
-                                  </Icon>
+                                      <FontAwesome
+                                        aria-label=""
+                                        fixedWidth={true}
+                                        name="chevron-down"
+                                      >
+                                        <span
+                                          aria-hidden={true}
+                                          aria-label=""
+                                          className="fa fa-chevron-down fa-fw"
+                                        />
+                                      </FontAwesome>
+                                    </Icon>
+                                  </injectIntl(Icon)>
                                 </button>
                               </div>
                             </div>
@@ -8763,7 +9774,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     <div
                                       className="pull-left"
                                     >
-                                      <Icon
+                                      <injectIntl(Icon)
                                         style={
                                           Object {
                                             "color": "#888",
@@ -8773,9 +9784,43 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         }
                                         type="clock-o"
                                       >
-                                        <FontAwesome
-                                          fixedWidth={true}
-                                          name="clock-o"
+                                        <Icon
+                                          intl={
+                                            Object {
+                                              "defaultFormats": Object {},
+                                              "defaultLocale": "en-US",
+                                              "defaultRichTextElements": undefined,
+                                              "formatDate": [Function],
+                                              "formatDateTimeRange": [Function],
+                                              "formatDateToParts": [Function],
+                                              "formatDisplayName": [Function],
+                                              "formatList": [Function],
+                                              "formatListToParts": [Function],
+                                              "formatMessage": [Function],
+                                              "formatNumber": [Function],
+                                              "formatNumberToParts": [Function],
+                                              "formatPlural": [Function],
+                                              "formatRelativeTime": [Function],
+                                              "formatTime": [Function],
+                                              "formatTimeToParts": [Function],
+                                              "formats": Object {},
+                                              "formatters": Object {
+                                                "getDateTimeFormat": [Function],
+                                                "getDisplayNames": [Function],
+                                                "getListFormat": [Function],
+                                                "getMessageFormat": [Function],
+                                                "getNumberFormat": [Function],
+                                                "getPluralRules": [Function],
+                                                "getRelativeTimeFormat": [Function],
+                                              },
+                                              "locale": "en-US",
+                                              "messages": Object {},
+                                              "onError": [Function],
+                                              "textComponent": Symbol(react.fragment),
+                                              "timeZone": undefined,
+                                              "wrapRichTextChunksInFragment": undefined,
+                                            }
+                                          }
                                           style={
                                             Object {
                                               "color": "#888",
@@ -8783,10 +9828,12 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                               "marginRight": 2,
                                             }
                                           }
+                                          type="clock-o"
                                         >
-                                          <span
-                                            aria-hidden={true}
-                                            className="fa fa-clock-o fa-fw"
+                                          <FontAwesome
+                                            aria-label=""
+                                            fixedWidth={true}
+                                            name="clock-o"
                                             style={
                                               Object {
                                                 "color": "#888",
@@ -8794,9 +9841,22 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                                 "marginRight": 2,
                                               }
                                             }
-                                          />
-                                        </FontAwesome>
-                                      </Icon>
+                                          >
+                                            <span
+                                              aria-hidden={true}
+                                              aria-label=""
+                                              className="fa fa-clock-o fa-fw"
+                                              style={
+                                                Object {
+                                                  "color": "#888",
+                                                  "fontSize": "0.8em",
+                                                  "marginRight": 2,
+                                                }
+                                              }
+                                            />
+                                          </FontAwesome>
+                                        </Icon>
+                                      </injectIntl(Icon)>
                                     </div>
                                     <div
                                       style={
@@ -8849,19 +9909,61 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   className="expansion-button"
                                   onClick={[Function]}
                                 >
-                                  <Icon
+                                  <injectIntl(Icon)
                                     type="chevron-down"
                                   >
-                                    <FontAwesome
-                                      fixedWidth={true}
-                                      name="chevron-down"
+                                    <Icon
+                                      intl={
+                                        Object {
+                                          "defaultFormats": Object {},
+                                          "defaultLocale": "en-US",
+                                          "defaultRichTextElements": undefined,
+                                          "formatDate": [Function],
+                                          "formatDateTimeRange": [Function],
+                                          "formatDateToParts": [Function],
+                                          "formatDisplayName": [Function],
+                                          "formatList": [Function],
+                                          "formatListToParts": [Function],
+                                          "formatMessage": [Function],
+                                          "formatNumber": [Function],
+                                          "formatNumberToParts": [Function],
+                                          "formatPlural": [Function],
+                                          "formatRelativeTime": [Function],
+                                          "formatTime": [Function],
+                                          "formatTimeToParts": [Function],
+                                          "formats": Object {},
+                                          "formatters": Object {
+                                            "getDateTimeFormat": [Function],
+                                            "getDisplayNames": [Function],
+                                            "getListFormat": [Function],
+                                            "getMessageFormat": [Function],
+                                            "getNumberFormat": [Function],
+                                            "getPluralRules": [Function],
+                                            "getRelativeTimeFormat": [Function],
+                                          },
+                                          "locale": "en-US",
+                                          "messages": Object {},
+                                          "onError": [Function],
+                                          "textComponent": Symbol(react.fragment),
+                                          "timeZone": undefined,
+                                          "wrapRichTextChunksInFragment": undefined,
+                                        }
+                                      }
+                                      type="chevron-down"
                                     >
-                                      <span
-                                        aria-hidden={true}
-                                        className="fa fa-chevron-down fa-fw"
-                                      />
-                                    </FontAwesome>
-                                  </Icon>
+                                      <FontAwesome
+                                        aria-label=""
+                                        fixedWidth={true}
+                                        name="chevron-down"
+                                      >
+                                        <span
+                                          aria-hidden={true}
+                                          aria-label=""
+                                          className="fa fa-chevron-down fa-fw"
+                                        />
+                                      </FontAwesome>
+                                    </Icon>
+                                  </injectIntl(Icon)>
                                 </button>
                               </div>
                             </div>
@@ -9162,7 +10264,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     <div
                                       className="pull-left"
                                     >
-                                      <Icon
+                                      <injectIntl(Icon)
                                         style={
                                           Object {
                                             "color": "#888",
@@ -9172,9 +10274,43 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         }
                                         type="clock-o"
                                       >
-                                        <FontAwesome
-                                          fixedWidth={true}
-                                          name="clock-o"
+                                        <Icon
+                                          intl={
+                                            Object {
+                                              "defaultFormats": Object {},
+                                              "defaultLocale": "en-US",
+                                              "defaultRichTextElements": undefined,
+                                              "formatDate": [Function],
+                                              "formatDateTimeRange": [Function],
+                                              "formatDateToParts": [Function],
+                                              "formatDisplayName": [Function],
+                                              "formatList": [Function],
+                                              "formatListToParts": [Function],
+                                              "formatMessage": [Function],
+                                              "formatNumber": [Function],
+                                              "formatNumberToParts": [Function],
+                                              "formatPlural": [Function],
+                                              "formatRelativeTime": [Function],
+                                              "formatTime": [Function],
+                                              "formatTimeToParts": [Function],
+                                              "formats": Object {},
+                                              "formatters": Object {
+                                                "getDateTimeFormat": [Function],
+                                                "getDisplayNames": [Function],
+                                                "getListFormat": [Function],
+                                                "getMessageFormat": [Function],
+                                                "getNumberFormat": [Function],
+                                                "getPluralRules": [Function],
+                                                "getRelativeTimeFormat": [Function],
+                                              },
+                                              "locale": "en-US",
+                                              "messages": Object {},
+                                              "onError": [Function],
+                                              "textComponent": Symbol(react.fragment),
+                                              "timeZone": undefined,
+                                              "wrapRichTextChunksInFragment": undefined,
+                                            }
+                                          }
                                           style={
                                             Object {
                                               "color": "#888",
@@ -9182,10 +10318,12 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                               "marginRight": 2,
                                             }
                                           }
+                                          type="clock-o"
                                         >
-                                          <span
-                                            aria-hidden={true}
-                                            className="fa fa-clock-o fa-fw"
+                                          <FontAwesome
+                                            aria-label=""
+                                            fixedWidth={true}
+                                            name="clock-o"
                                             style={
                                               Object {
                                                 "color": "#888",
@@ -9193,9 +10331,22 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                                 "marginRight": 2,
                                               }
                                             }
-                                          />
-                                        </FontAwesome>
-                                      </Icon>
+                                          >
+                                            <span
+                                              aria-hidden={true}
+                                              aria-label=""
+                                              className="fa fa-clock-o fa-fw"
+                                              style={
+                                                Object {
+                                                  "color": "#888",
+                                                  "fontSize": "0.8em",
+                                                  "marginRight": 2,
+                                                }
+                                              }
+                                            />
+                                          </FontAwesome>
+                                        </Icon>
+                                      </injectIntl(Icon)>
                                     </div>
                                     <div
                                       style={
@@ -9248,19 +10399,61 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   className="expansion-button"
                                   onClick={[Function]}
                                 >
-                                  <Icon
+                                  <injectIntl(Icon)
                                     type="chevron-down"
                                   >
-                                    <FontAwesome
-                                      fixedWidth={true}
-                                      name="chevron-down"
+                                    <Icon
+                                      intl={
+                                        Object {
+                                          "defaultFormats": Object {},
+                                          "defaultLocale": "en-US",
+                                          "defaultRichTextElements": undefined,
+                                          "formatDate": [Function],
+                                          "formatDateTimeRange": [Function],
+                                          "formatDateToParts": [Function],
+                                          "formatDisplayName": [Function],
+                                          "formatList": [Function],
+                                          "formatListToParts": [Function],
+                                          "formatMessage": [Function],
+                                          "formatNumber": [Function],
+                                          "formatNumberToParts": [Function],
+                                          "formatPlural": [Function],
+                                          "formatRelativeTime": [Function],
+                                          "formatTime": [Function],
+                                          "formatTimeToParts": [Function],
+                                          "formats": Object {},
+                                          "formatters": Object {
+                                            "getDateTimeFormat": [Function],
+                                            "getDisplayNames": [Function],
+                                            "getListFormat": [Function],
+                                            "getMessageFormat": [Function],
+                                            "getNumberFormat": [Function],
+                                            "getPluralRules": [Function],
+                                            "getRelativeTimeFormat": [Function],
+                                          },
+                                          "locale": "en-US",
+                                          "messages": Object {},
+                                          "onError": [Function],
+                                          "textComponent": Symbol(react.fragment),
+                                          "timeZone": undefined,
+                                          "wrapRichTextChunksInFragment": undefined,
+                                        }
+                                      }
+                                      type="chevron-down"
                                     >
-                                      <span
-                                        aria-hidden={true}
-                                        className="fa fa-chevron-down fa-fw"
-                                      />
-                                    </FontAwesome>
-                                  </Icon>
+                                      <FontAwesome
+                                        aria-label=""
+                                        fixedWidth={true}
+                                        name="chevron-down"
+                                      >
+                                        <span
+                                          aria-hidden={true}
+                                          aria-label=""
+                                          className="fa fa-chevron-down fa-fw"
+                                        />
+                                      </FontAwesome>
+                                    </Icon>
+                                  </injectIntl(Icon)>
                                 </button>
                               </div>
                             </div>
@@ -9669,7 +10862,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     <div
                                       className="pull-left"
                                     >
-                                      <Icon
+                                      <injectIntl(Icon)
                                         style={
                                           Object {
                                             "color": "#888",
@@ -9679,9 +10872,43 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         }
                                         type="clock-o"
                                       >
-                                        <FontAwesome
-                                          fixedWidth={true}
-                                          name="clock-o"
+                                        <Icon
+                                          intl={
+                                            Object {
+                                              "defaultFormats": Object {},
+                                              "defaultLocale": "en-US",
+                                              "defaultRichTextElements": undefined,
+                                              "formatDate": [Function],
+                                              "formatDateTimeRange": [Function],
+                                              "formatDateToParts": [Function],
+                                              "formatDisplayName": [Function],
+                                              "formatList": [Function],
+                                              "formatListToParts": [Function],
+                                              "formatMessage": [Function],
+                                              "formatNumber": [Function],
+                                              "formatNumberToParts": [Function],
+                                              "formatPlural": [Function],
+                                              "formatRelativeTime": [Function],
+                                              "formatTime": [Function],
+                                              "formatTimeToParts": [Function],
+                                              "formats": Object {},
+                                              "formatters": Object {
+                                                "getDateTimeFormat": [Function],
+                                                "getDisplayNames": [Function],
+                                                "getListFormat": [Function],
+                                                "getMessageFormat": [Function],
+                                                "getNumberFormat": [Function],
+                                                "getPluralRules": [Function],
+                                                "getRelativeTimeFormat": [Function],
+                                              },
+                                              "locale": "en-US",
+                                              "messages": Object {},
+                                              "onError": [Function],
+                                              "textComponent": Symbol(react.fragment),
+                                              "timeZone": undefined,
+                                              "wrapRichTextChunksInFragment": undefined,
+                                            }
+                                          }
                                           style={
                                             Object {
                                               "color": "#888",
@@ -9689,10 +10916,12 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                               "marginRight": 2,
                                             }
                                           }
+                                          type="clock-o"
                                         >
-                                          <span
-                                            aria-hidden={true}
-                                            className="fa fa-clock-o fa-fw"
+                                          <FontAwesome
+                                            aria-label=""
+                                            fixedWidth={true}
+                                            name="clock-o"
                                             style={
                                               Object {
                                                 "color": "#888",
@@ -9700,9 +10929,22 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                                 "marginRight": 2,
                                               }
                                             }
-                                          />
-                                        </FontAwesome>
-                                      </Icon>
+                                          >
+                                            <span
+                                              aria-hidden={true}
+                                              aria-label=""
+                                              className="fa fa-clock-o fa-fw"
+                                              style={
+                                                Object {
+                                                  "color": "#888",
+                                                  "fontSize": "0.8em",
+                                                  "marginRight": 2,
+                                                }
+                                              }
+                                            />
+                                          </FontAwesome>
+                                        </Icon>
+                                      </injectIntl(Icon)>
                                     </div>
                                     <div
                                       style={
@@ -9755,19 +10997,61 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   className="expansion-button"
                                   onClick={[Function]}
                                 >
-                                  <Icon
+                                  <injectIntl(Icon)
                                     type="chevron-down"
                                   >
-                                    <FontAwesome
-                                      fixedWidth={true}
-                                      name="chevron-down"
+                                    <Icon
+                                      intl={
+                                        Object {
+                                          "defaultFormats": Object {},
+                                          "defaultLocale": "en-US",
+                                          "defaultRichTextElements": undefined,
+                                          "formatDate": [Function],
+                                          "formatDateTimeRange": [Function],
+                                          "formatDateToParts": [Function],
+                                          "formatDisplayName": [Function],
+                                          "formatList": [Function],
+                                          "formatListToParts": [Function],
+                                          "formatMessage": [Function],
+                                          "formatNumber": [Function],
+                                          "formatNumberToParts": [Function],
+                                          "formatPlural": [Function],
+                                          "formatRelativeTime": [Function],
+                                          "formatTime": [Function],
+                                          "formatTimeToParts": [Function],
+                                          "formats": Object {},
+                                          "formatters": Object {
+                                            "getDateTimeFormat": [Function],
+                                            "getDisplayNames": [Function],
+                                            "getListFormat": [Function],
+                                            "getMessageFormat": [Function],
+                                            "getNumberFormat": [Function],
+                                            "getPluralRules": [Function],
+                                            "getRelativeTimeFormat": [Function],
+                                          },
+                                          "locale": "en-US",
+                                          "messages": Object {},
+                                          "onError": [Function],
+                                          "textComponent": Symbol(react.fragment),
+                                          "timeZone": undefined,
+                                          "wrapRichTextChunksInFragment": undefined,
+                                        }
+                                      }
+                                      type="chevron-down"
                                     >
-                                      <span
-                                        aria-hidden={true}
-                                        className="fa fa-chevron-down fa-fw"
-                                      />
-                                    </FontAwesome>
-                                  </Icon>
+                                      <FontAwesome
+                                        aria-label=""
+                                        fixedWidth={true}
+                                        name="chevron-down"
+                                      >
+                                        <span
+                                          aria-hidden={true}
+                                          aria-label=""
+                                          className="fa fa-chevron-down fa-fw"
+                                        />
+                                      </FontAwesome>
+                                    </Icon>
+                                  </injectIntl(Icon)>
                                 </button>
                               </div>
                             </div>
@@ -9848,28 +11132,73 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                           }
                         }
                       >
-                        <Icon
+                        <injectIntl(Icon)
                           className="fa-spin"
                           type="refresh"
                           withSpace={true}
                         >
-                          <Styled(FontAwesome)
+                          <Icon
                             className="fa-spin"
-                            fixedWidth={true}
-                            name="refresh"
+                            intl={
+                              Object {
+                                "defaultFormats": Object {},
+                                "defaultLocale": "en-US",
+                                "defaultRichTextElements": undefined,
+                                "formatDate": [Function],
+                                "formatDateTimeRange": [Function],
+                                "formatDateToParts": [Function],
+                                "formatDisplayName": [Function],
+                                "formatList": [Function],
+                                "formatListToParts": [Function],
+                                "formatMessage": [Function],
+                                "formatNumber": [Function],
+                                "formatNumberToParts": [Function],
+                                "formatPlural": [Function],
+                                "formatRelativeTime": [Function],
+                                "formatTime": [Function],
+                                "formatTimeToParts": [Function],
+                                "formats": Object {},
+                                "formatters": Object {
+                                  "getDateTimeFormat": [Function],
+                                  "getDisplayNames": [Function],
+                                  "getListFormat": [Function],
+                                  "getMessageFormat": [Function],
+                                  "getNumberFormat": [Function],
+                                  "getPluralRules": [Function],
+                                  "getRelativeTimeFormat": [Function],
+                                },
+                                "locale": "en-US",
+                                "messages": Object {},
+                                "onError": [Function],
+                                "textComponent": Symbol(react.fragment),
+                                "timeZone": undefined,
+                                "wrapRichTextChunksInFragment": undefined,
+                              }
+                            }
+                            type="refresh"
+                            withSpace={true}
                           >
-                            <FontAwesome
-                              className="sc-gsTEea iqivwV fa-spin"
+                            <Styled(FontAwesome)
+                              aria-label=""
+                              className="fa-spin"
                               fixedWidth={true}
                               name="refresh"
                             >
-                              <span
-                                aria-hidden={true}
-                                className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
-                              />
-                            </FontAwesome>
-                          </Styled(FontAwesome)>
-                        </Icon>
+                              <FontAwesome
+                                aria-label=""
+                                className="sc-gsTEea iqivwV fa-spin"
+                                fixedWidth={true}
+                                name="refresh"
+                              >
+                                <span
+                                  aria-hidden={true}
+                                  aria-label=""
+                                  className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
+                                />
+                              </FontAwesome>
+                            </Styled(FontAwesome)>
+                          </Icon>
+                        </injectIntl(Icon)>
                         <FormattedTime
                           timeStyle="short"
                           timeZone="America/Los_Angeles"
@@ -12719,19 +14048,61 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                     onClick={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <injectIntl(Icon)
                       type="arrow-left"
                     >
-                      <FontAwesome
-                        fixedWidth={true}
-                        name="arrow-left"
+                      <Icon
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en-US",
+                            "defaultRichTextElements": undefined,
+                            "formatDate": [Function],
+                            "formatDateTimeRange": [Function],
+                            "formatDateToParts": [Function],
+                            "formatDisplayName": [Function],
+                            "formatList": [Function],
+                            "formatListToParts": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatNumberToParts": [Function],
+                            "formatPlural": [Function],
+                            "formatRelativeTime": [Function],
+                            "formatTime": [Function],
+                            "formatTimeToParts": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getDisplayNames": [Function],
+                              "getListFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralRules": [Function],
+                              "getRelativeTimeFormat": [Function],
+                            },
+                            "locale": "en-US",
+                            "messages": Object {},
+                            "onError": [Function],
+                            "textComponent": Symbol(react.fragment),
+                            "timeZone": undefined,
+                            "wrapRichTextChunksInFragment": undefined,
+                          }
+                        }
+                        type="arrow-left"
                       >
-                        <span
-                          aria-hidden={true}
-                          className="fa fa-arrow-left fa-fw"
-                        />
-                      </FontAwesome>
-                    </Icon>
+                        <FontAwesome
+                          aria-label=""
+                          fixedWidth={true}
+                          name="arrow-left"
+                        >
+                          <span
+                            aria-hidden={true}
+                            aria-label=""
+                            className="fa fa-arrow-left fa-fw"
+                          />
+                        </FontAwesome>
+                      </Icon>
+                    </injectIntl(Icon)>
                     <FormattedMessage
                       id="common.forms.back"
                     >
@@ -12782,19 +14153,61 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                     onClick={[Function]}
                     title="components.StopViewer.zoomToStop"
                   >
-                    <Icon
+                    <injectIntl(Icon)
                       type="search"
                     >
-                      <FontAwesome
-                        fixedWidth={true}
-                        name="search"
+                      <Icon
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en-US",
+                            "defaultRichTextElements": undefined,
+                            "formatDate": [Function],
+                            "formatDateTimeRange": [Function],
+                            "formatDateToParts": [Function],
+                            "formatDisplayName": [Function],
+                            "formatList": [Function],
+                            "formatListToParts": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatNumberToParts": [Function],
+                            "formatPlural": [Function],
+                            "formatRelativeTime": [Function],
+                            "formatTime": [Function],
+                            "formatTimeToParts": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getDisplayNames": [Function],
+                              "getListFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralRules": [Function],
+                              "getRelativeTimeFormat": [Function],
+                            },
+                            "locale": "en-US",
+                            "messages": Object {},
+                            "onError": [Function],
+                            "textComponent": Symbol(react.fragment),
+                            "timeZone": undefined,
+                            "wrapRichTextChunksInFragment": undefined,
+                          }
+                        }
+                        type="search"
                       >
-                        <span
-                          aria-hidden={true}
-                          className="fa fa-search fa-fw"
-                        />
-                      </FontAwesome>
-                    </Icon>
+                        <FontAwesome
+                          aria-label=""
+                          fixedWidth={true}
+                          name="search"
+                        >
+                          <span
+                            aria-hidden={true}
+                            aria-label=""
+                            className="fa fa-search fa-fw"
+                          />
+                        </FontAwesome>
+                      </Icon>
+                    </injectIntl(Icon)>
                   </button>
                   <button
                     className="link-button pull-right"
@@ -12805,26 +14218,70 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                       }
                     }
                   >
-                    <Icon
+                    <injectIntl(Icon)
                       type="calendar"
                       withSpace={true}
                     >
-                      <Styled(FontAwesome)
-                        fixedWidth={true}
-                        name="calendar"
+                      <Icon
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en-US",
+                            "defaultRichTextElements": undefined,
+                            "formatDate": [Function],
+                            "formatDateTimeRange": [Function],
+                            "formatDateToParts": [Function],
+                            "formatDisplayName": [Function],
+                            "formatList": [Function],
+                            "formatListToParts": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatNumberToParts": [Function],
+                            "formatPlural": [Function],
+                            "formatRelativeTime": [Function],
+                            "formatTime": [Function],
+                            "formatTimeToParts": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getDisplayNames": [Function],
+                              "getListFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralRules": [Function],
+                              "getRelativeTimeFormat": [Function],
+                            },
+                            "locale": "en-US",
+                            "messages": Object {},
+                            "onError": [Function],
+                            "textComponent": Symbol(react.fragment),
+                            "timeZone": undefined,
+                            "wrapRichTextChunksInFragment": undefined,
+                          }
+                        }
+                        type="calendar"
+                        withSpace={true}
                       >
-                        <FontAwesome
-                          className="sc-gsTEea iqivwV"
+                        <Styled(FontAwesome)
+                          aria-label=""
                           fixedWidth={true}
                           name="calendar"
                         >
-                          <span
-                            aria-hidden={true}
-                            className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
-                          />
-                        </FontAwesome>
-                      </Styled(FontAwesome)>
-                    </Icon>
+                          <FontAwesome
+                            aria-label=""
+                            className="sc-gsTEea iqivwV"
+                            fixedWidth={true}
+                            name="calendar"
+                          >
+                            <span
+                              aria-hidden={true}
+                              aria-label=""
+                              className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
+                            />
+                          </FontAwesome>
+                        </Styled(FontAwesome)>
+                      </Icon>
+                    </injectIntl(Icon)>
                     <FormattedMessage
                       id="components.StopViewer.viewTypeBtnText"
                       values={
@@ -13843,7 +15300,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                     <div
                                       className="pull-left"
                                     >
-                                      <Icon
+                                      <injectIntl(Icon)
                                         style={
                                           Object {
                                             "color": "#888",
@@ -13853,9 +15310,43 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                         }
                                         type="clock-o"
                                       >
-                                        <FontAwesome
-                                          fixedWidth={true}
-                                          name="clock-o"
+                                        <Icon
+                                          intl={
+                                            Object {
+                                              "defaultFormats": Object {},
+                                              "defaultLocale": "en-US",
+                                              "defaultRichTextElements": undefined,
+                                              "formatDate": [Function],
+                                              "formatDateTimeRange": [Function],
+                                              "formatDateToParts": [Function],
+                                              "formatDisplayName": [Function],
+                                              "formatList": [Function],
+                                              "formatListToParts": [Function],
+                                              "formatMessage": [Function],
+                                              "formatNumber": [Function],
+                                              "formatNumberToParts": [Function],
+                                              "formatPlural": [Function],
+                                              "formatRelativeTime": [Function],
+                                              "formatTime": [Function],
+                                              "formatTimeToParts": [Function],
+                                              "formats": Object {},
+                                              "formatters": Object {
+                                                "getDateTimeFormat": [Function],
+                                                "getDisplayNames": [Function],
+                                                "getListFormat": [Function],
+                                                "getMessageFormat": [Function],
+                                                "getNumberFormat": [Function],
+                                                "getPluralRules": [Function],
+                                                "getRelativeTimeFormat": [Function],
+                                              },
+                                              "locale": "en-US",
+                                              "messages": Object {},
+                                              "onError": [Function],
+                                              "textComponent": Symbol(react.fragment),
+                                              "timeZone": undefined,
+                                              "wrapRichTextChunksInFragment": undefined,
+                                            }
+                                          }
                                           style={
                                             Object {
                                               "color": "#888",
@@ -13863,10 +15354,12 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                               "marginRight": 2,
                                             }
                                           }
+                                          type="clock-o"
                                         >
-                                          <span
-                                            aria-hidden={true}
-                                            className="fa fa-clock-o fa-fw"
+                                          <FontAwesome
+                                            aria-label=""
+                                            fixedWidth={true}
+                                            name="clock-o"
                                             style={
                                               Object {
                                                 "color": "#888",
@@ -13874,9 +15367,22 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                                 "marginRight": 2,
                                               }
                                             }
-                                          />
-                                        </FontAwesome>
-                                      </Icon>
+                                          >
+                                            <span
+                                              aria-hidden={true}
+                                              aria-label=""
+                                              className="fa fa-clock-o fa-fw"
+                                              style={
+                                                Object {
+                                                  "color": "#888",
+                                                  "fontSize": "0.8em",
+                                                  "marginRight": 2,
+                                                }
+                                              }
+                                            />
+                                          </FontAwesome>
+                                        </Icon>
+                                      </injectIntl(Icon)>
                                     </div>
                                     <div
                                       style={
@@ -13929,19 +15435,61 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                   className="expansion-button"
                                   onClick={[Function]}
                                 >
-                                  <Icon
+                                  <injectIntl(Icon)
                                     type="chevron-down"
                                   >
-                                    <FontAwesome
-                                      fixedWidth={true}
-                                      name="chevron-down"
+                                    <Icon
+                                      intl={
+                                        Object {
+                                          "defaultFormats": Object {},
+                                          "defaultLocale": "en-US",
+                                          "defaultRichTextElements": undefined,
+                                          "formatDate": [Function],
+                                          "formatDateTimeRange": [Function],
+                                          "formatDateToParts": [Function],
+                                          "formatDisplayName": [Function],
+                                          "formatList": [Function],
+                                          "formatListToParts": [Function],
+                                          "formatMessage": [Function],
+                                          "formatNumber": [Function],
+                                          "formatNumberToParts": [Function],
+                                          "formatPlural": [Function],
+                                          "formatRelativeTime": [Function],
+                                          "formatTime": [Function],
+                                          "formatTimeToParts": [Function],
+                                          "formats": Object {},
+                                          "formatters": Object {
+                                            "getDateTimeFormat": [Function],
+                                            "getDisplayNames": [Function],
+                                            "getListFormat": [Function],
+                                            "getMessageFormat": [Function],
+                                            "getNumberFormat": [Function],
+                                            "getPluralRules": [Function],
+                                            "getRelativeTimeFormat": [Function],
+                                          },
+                                          "locale": "en-US",
+                                          "messages": Object {},
+                                          "onError": [Function],
+                                          "textComponent": Symbol(react.fragment),
+                                          "timeZone": undefined,
+                                          "wrapRichTextChunksInFragment": undefined,
+                                        }
+                                      }
+                                      type="chevron-down"
                                     >
-                                      <span
-                                        aria-hidden={true}
-                                        className="fa fa-chevron-down fa-fw"
-                                      />
-                                    </FontAwesome>
-                                  </Icon>
+                                      <FontAwesome
+                                        aria-label=""
+                                        fixedWidth={true}
+                                        name="chevron-down"
+                                      >
+                                        <span
+                                          aria-hidden={true}
+                                          aria-label=""
+                                          className="fa fa-chevron-down fa-fw"
+                                        />
+                                      </FontAwesome>
+                                    </Icon>
+                                  </injectIntl(Icon)>
                                 </button>
                               </div>
                             </div>
@@ -14022,28 +15570,73 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                           }
                         }
                       >
-                        <Icon
+                        <injectIntl(Icon)
                           className="fa-spin"
                           type="refresh"
                           withSpace={true}
                         >
-                          <Styled(FontAwesome)
+                          <Icon
                             className="fa-spin"
-                            fixedWidth={true}
-                            name="refresh"
+                            intl={
+                              Object {
+                                "defaultFormats": Object {},
+                                "defaultLocale": "en-US",
+                                "defaultRichTextElements": undefined,
+                                "formatDate": [Function],
+                                "formatDateTimeRange": [Function],
+                                "formatDateToParts": [Function],
+                                "formatDisplayName": [Function],
+                                "formatList": [Function],
+                                "formatListToParts": [Function],
+                                "formatMessage": [Function],
+                                "formatNumber": [Function],
+                                "formatNumberToParts": [Function],
+                                "formatPlural": [Function],
+                                "formatRelativeTime": [Function],
+                                "formatTime": [Function],
+                                "formatTimeToParts": [Function],
+                                "formats": Object {},
+                                "formatters": Object {
+                                  "getDateTimeFormat": [Function],
+                                  "getDisplayNames": [Function],
+                                  "getListFormat": [Function],
+                                  "getMessageFormat": [Function],
+                                  "getNumberFormat": [Function],
+                                  "getPluralRules": [Function],
+                                  "getRelativeTimeFormat": [Function],
+                                },
+                                "locale": "en-US",
+                                "messages": Object {},
+                                "onError": [Function],
+                                "textComponent": Symbol(react.fragment),
+                                "timeZone": undefined,
+                                "wrapRichTextChunksInFragment": undefined,
+                              }
+                            }
+                            type="refresh"
+                            withSpace={true}
                           >
-                            <FontAwesome
-                              className="sc-gsTEea iqivwV fa-spin"
+                            <Styled(FontAwesome)
+                              aria-label=""
+                              className="fa-spin"
                               fixedWidth={true}
                               name="refresh"
                             >
-                              <span
-                                aria-hidden={true}
-                                className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
-                              />
-                            </FontAwesome>
-                          </Styled(FontAwesome)>
-                        </Icon>
+                              <FontAwesome
+                                aria-label=""
+                                className="sc-gsTEea iqivwV fa-spin"
+                                fixedWidth={true}
+                                name="refresh"
+                              >
+                                <span
+                                  aria-hidden={true}
+                                  aria-label=""
+                                  className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
+                                />
+                              </FontAwesome>
+                            </Styled(FontAwesome)>
+                          </Icon>
+                        </injectIntl(Icon)>
                         <FormattedTime
                           timeStyle="short"
                           timeZone="America/Los_Angeles"
@@ -16037,19 +17630,61 @@ exports[`components > viewers > stop viewer should render with initial stop id a
                     onClick={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <injectIntl(Icon)
                       type="arrow-left"
                     >
-                      <FontAwesome
-                        fixedWidth={true}
-                        name="arrow-left"
+                      <Icon
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en-US",
+                            "defaultRichTextElements": undefined,
+                            "formatDate": [Function],
+                            "formatDateTimeRange": [Function],
+                            "formatDateToParts": [Function],
+                            "formatDisplayName": [Function],
+                            "formatList": [Function],
+                            "formatListToParts": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatNumberToParts": [Function],
+                            "formatPlural": [Function],
+                            "formatRelativeTime": [Function],
+                            "formatTime": [Function],
+                            "formatTimeToParts": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getDisplayNames": [Function],
+                              "getListFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralRules": [Function],
+                              "getRelativeTimeFormat": [Function],
+                            },
+                            "locale": "en-US",
+                            "messages": Object {},
+                            "onError": [Function],
+                            "textComponent": Symbol(react.fragment),
+                            "timeZone": undefined,
+                            "wrapRichTextChunksInFragment": undefined,
+                          }
+                        }
+                        type="arrow-left"
                       >
-                        <span
-                          aria-hidden={true}
-                          className="fa fa-arrow-left fa-fw"
-                        />
-                      </FontAwesome>
-                    </Icon>
+                        <FontAwesome
+                          aria-label=""
+                          fixedWidth={true}
+                          name="arrow-left"
+                        >
+                          <span
+                            aria-hidden={true}
+                            aria-label=""
+                            className="fa fa-arrow-left fa-fw"
+                          />
+                        </FontAwesome>
+                      </Icon>
+                    </injectIntl(Icon)>
                     <FormattedMessage
                       id="common.forms.back"
                     >

--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -471,61 +471,21 @@ exports[`components > viewers > stop viewer should render countdown times after 
                     onClick={[Function]}
                     type="button"
                   >
-                    <injectIntl(Icon)
+                    <Icon
                       type="arrow-left"
                     >
-                      <Icon
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en-US",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en-US",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
-                            "wrapRichTextChunksInFragment": undefined,
-                          }
-                        }
-                        type="arrow-left"
+                      <FontAwesome
+                        aria-label=""
+                        fixedWidth={true}
+                        name="arrow-left"
                       >
-                        <FontAwesome
+                        <span
+                          aria-hidden={true}
                           aria-label=""
-                          fixedWidth={true}
-                          name="arrow-left"
-                        >
-                          <span
-                            aria-hidden={true}
-                            aria-label=""
-                            className="fa fa-arrow-left fa-fw"
-                          />
-                        </FontAwesome>
-                      </Icon>
-                    </injectIntl(Icon)>
+                          className="fa fa-arrow-left fa-fw"
+                        />
+                      </FontAwesome>
+                    </Icon>
                     <FormattedMessage
                       id="common.forms.back"
                     >
@@ -576,61 +536,21 @@ exports[`components > viewers > stop viewer should render countdown times after 
                     onClick={[Function]}
                     title="components.StopViewer.zoomToStop"
                   >
-                    <injectIntl(Icon)
+                    <Icon
                       type="search"
                     >
-                      <Icon
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en-US",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en-US",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
-                            "wrapRichTextChunksInFragment": undefined,
-                          }
-                        }
-                        type="search"
+                      <FontAwesome
+                        aria-label=""
+                        fixedWidth={true}
+                        name="search"
                       >
-                        <FontAwesome
+                        <span
+                          aria-hidden={true}
                           aria-label=""
-                          fixedWidth={true}
-                          name="search"
-                        >
-                          <span
-                            aria-hidden={true}
-                            aria-label=""
-                            className="fa fa-search fa-fw"
-                          />
-                        </FontAwesome>
-                      </Icon>
-                    </injectIntl(Icon)>
+                          className="fa fa-search fa-fw"
+                        />
+                      </FontAwesome>
+                    </Icon>
                   </button>
                   <button
                     className="link-button pull-right"
@@ -641,70 +561,29 @@ exports[`components > viewers > stop viewer should render countdown times after 
                       }
                     }
                   >
-                    <injectIntl(Icon)
+                    <Icon
                       type="calendar"
                       withSpace={true}
                     >
-                      <Icon
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en-US",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en-US",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
-                            "wrapRichTextChunksInFragment": undefined,
-                          }
-                        }
-                        type="calendar"
-                        withSpace={true}
+                      <Styled(FontAwesome)
+                        aria-label=""
+                        fixedWidth={true}
+                        name="calendar"
                       >
-                        <Styled(FontAwesome)
+                        <FontAwesome
                           aria-label=""
+                          className="sc-gsTEea iqivwV"
                           fixedWidth={true}
                           name="calendar"
                         >
-                          <FontAwesome
+                          <span
+                            aria-hidden={true}
                             aria-label=""
-                            className="sc-gsTEea iqivwV"
-                            fixedWidth={true}
-                            name="calendar"
-                          >
-                            <span
-                              aria-hidden={true}
-                              aria-label=""
-                              className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
-                            />
-                          </FontAwesome>
-                        </Styled(FontAwesome)>
-                      </Icon>
-                    </injectIntl(Icon)>
+                            className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
+                          />
+                        </FontAwesome>
+                      </Styled(FontAwesome)>
+                    </Icon>
                     <FormattedMessage
                       id="components.StopViewer.viewTypeBtnText"
                       values={
@@ -1470,7 +1349,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                     <div
                                       className="pull-left"
                                     >
-                                      <injectIntl(Icon)
+                                      <Icon
                                         style={
                                           Object {
                                             "color": "#888",
@@ -1480,43 +1359,10 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                         }
                                         type="clock-o"
                                       >
-                                        <Icon
-                                          intl={
-                                            Object {
-                                              "defaultFormats": Object {},
-                                              "defaultLocale": "en-US",
-                                              "defaultRichTextElements": undefined,
-                                              "formatDate": [Function],
-                                              "formatDateTimeRange": [Function],
-                                              "formatDateToParts": [Function],
-                                              "formatDisplayName": [Function],
-                                              "formatList": [Function],
-                                              "formatListToParts": [Function],
-                                              "formatMessage": [Function],
-                                              "formatNumber": [Function],
-                                              "formatNumberToParts": [Function],
-                                              "formatPlural": [Function],
-                                              "formatRelativeTime": [Function],
-                                              "formatTime": [Function],
-                                              "formatTimeToParts": [Function],
-                                              "formats": Object {},
-                                              "formatters": Object {
-                                                "getDateTimeFormat": [Function],
-                                                "getDisplayNames": [Function],
-                                                "getListFormat": [Function],
-                                                "getMessageFormat": [Function],
-                                                "getNumberFormat": [Function],
-                                                "getPluralRules": [Function],
-                                                "getRelativeTimeFormat": [Function],
-                                              },
-                                              "locale": "en-US",
-                                              "messages": Object {},
-                                              "onError": [Function],
-                                              "textComponent": Symbol(react.fragment),
-                                              "timeZone": undefined,
-                                              "wrapRichTextChunksInFragment": undefined,
-                                            }
-                                          }
+                                        <FontAwesome
+                                          aria-label=""
+                                          fixedWidth={true}
+                                          name="clock-o"
                                           style={
                                             Object {
                                               "color": "#888",
@@ -1524,12 +1370,11 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                               "marginRight": 2,
                                             }
                                           }
-                                          type="clock-o"
                                         >
-                                          <FontAwesome
+                                          <span
+                                            aria-hidden={true}
                                             aria-label=""
-                                            fixedWidth={true}
-                                            name="clock-o"
+                                            className="fa fa-clock-o fa-fw"
                                             style={
                                               Object {
                                                 "color": "#888",
@@ -1537,22 +1382,9 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                                 "marginRight": 2,
                                               }
                                             }
-                                          >
-                                            <span
-                                              aria-hidden={true}
-                                              aria-label=""
-                                              className="fa fa-clock-o fa-fw"
-                                              style={
-                                                Object {
-                                                  "color": "#888",
-                                                  "fontSize": "0.8em",
-                                                  "marginRight": 2,
-                                                }
-                                              }
-                                            />
-                                          </FontAwesome>
-                                        </Icon>
-                                      </injectIntl(Icon)>
+                                          />
+                                        </FontAwesome>
+                                      </Icon>
                                     </div>
                                     <div
                                       style={
@@ -1593,61 +1425,21 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                   className="expansion-button"
                                   onClick={[Function]}
                                 >
-                                  <injectIntl(Icon)
+                                  <Icon
                                     type="chevron-down"
                                   >
-                                    <Icon
-                                      intl={
-                                        Object {
-                                          "defaultFormats": Object {},
-                                          "defaultLocale": "en-US",
-                                          "defaultRichTextElements": undefined,
-                                          "formatDate": [Function],
-                                          "formatDateTimeRange": [Function],
-                                          "formatDateToParts": [Function],
-                                          "formatDisplayName": [Function],
-                                          "formatList": [Function],
-                                          "formatListToParts": [Function],
-                                          "formatMessage": [Function],
-                                          "formatNumber": [Function],
-                                          "formatNumberToParts": [Function],
-                                          "formatPlural": [Function],
-                                          "formatRelativeTime": [Function],
-                                          "formatTime": [Function],
-                                          "formatTimeToParts": [Function],
-                                          "formats": Object {},
-                                          "formatters": Object {
-                                            "getDateTimeFormat": [Function],
-                                            "getDisplayNames": [Function],
-                                            "getListFormat": [Function],
-                                            "getMessageFormat": [Function],
-                                            "getNumberFormat": [Function],
-                                            "getPluralRules": [Function],
-                                            "getRelativeTimeFormat": [Function],
-                                          },
-                                          "locale": "en-US",
-                                          "messages": Object {},
-                                          "onError": [Function],
-                                          "textComponent": Symbol(react.fragment),
-                                          "timeZone": undefined,
-                                          "wrapRichTextChunksInFragment": undefined,
-                                        }
-                                      }
-                                      type="chevron-down"
+                                    <FontAwesome
+                                      aria-label=""
+                                      fixedWidth={true}
+                                      name="chevron-down"
                                     >
-                                      <FontAwesome
+                                      <span
+                                        aria-hidden={true}
                                         aria-label=""
-                                        fixedWidth={true}
-                                        name="chevron-down"
-                                      >
-                                        <span
-                                          aria-hidden={true}
-                                          aria-label=""
-                                          className="fa fa-chevron-down fa-fw"
-                                        />
-                                      </FontAwesome>
-                                    </Icon>
-                                  </injectIntl(Icon)>
+                                        className="fa fa-chevron-down fa-fw"
+                                      />
+                                    </FontAwesome>
+                                  </Icon>
                                 </button>
                               </div>
                             </div>
@@ -1728,73 +1520,31 @@ exports[`components > viewers > stop viewer should render countdown times after 
                           }
                         }
                       >
-                        <injectIntl(Icon)
+                        <Icon
                           className="fa-spin"
                           type="refresh"
                           withSpace={true}
                         >
-                          <Icon
+                          <Styled(FontAwesome)
+                            aria-label=""
                             className="fa-spin"
-                            intl={
-                              Object {
-                                "defaultFormats": Object {},
-                                "defaultLocale": "en-US",
-                                "defaultRichTextElements": undefined,
-                                "formatDate": [Function],
-                                "formatDateTimeRange": [Function],
-                                "formatDateToParts": [Function],
-                                "formatDisplayName": [Function],
-                                "formatList": [Function],
-                                "formatListToParts": [Function],
-                                "formatMessage": [Function],
-                                "formatNumber": [Function],
-                                "formatNumberToParts": [Function],
-                                "formatPlural": [Function],
-                                "formatRelativeTime": [Function],
-                                "formatTime": [Function],
-                                "formatTimeToParts": [Function],
-                                "formats": Object {},
-                                "formatters": Object {
-                                  "getDateTimeFormat": [Function],
-                                  "getDisplayNames": [Function],
-                                  "getListFormat": [Function],
-                                  "getMessageFormat": [Function],
-                                  "getNumberFormat": [Function],
-                                  "getPluralRules": [Function],
-                                  "getRelativeTimeFormat": [Function],
-                                },
-                                "locale": "en-US",
-                                "messages": Object {},
-                                "onError": [Function],
-                                "textComponent": Symbol(react.fragment),
-                                "timeZone": undefined,
-                                "wrapRichTextChunksInFragment": undefined,
-                              }
-                            }
-                            type="refresh"
-                            withSpace={true}
+                            fixedWidth={true}
+                            name="refresh"
                           >
-                            <Styled(FontAwesome)
+                            <FontAwesome
                               aria-label=""
-                              className="fa-spin"
+                              className="sc-gsTEea iqivwV fa-spin"
                               fixedWidth={true}
                               name="refresh"
                             >
-                              <FontAwesome
+                              <span
+                                aria-hidden={true}
                                 aria-label=""
-                                className="sc-gsTEea iqivwV fa-spin"
-                                fixedWidth={true}
-                                name="refresh"
-                              >
-                                <span
-                                  aria-hidden={true}
-                                  aria-label=""
-                                  className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
-                                />
-                              </FontAwesome>
-                            </Styled(FontAwesome)>
-                          </Icon>
-                        </injectIntl(Icon)>
+                                className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
+                              />
+                            </FontAwesome>
+                          </Styled(FontAwesome)>
+                        </Icon>
                         <FormattedTime
                           timeStyle="short"
                           timeZone="America/Los_Angeles"
@@ -2908,61 +2658,21 @@ exports[`components > viewers > stop viewer should render countdown times for st
                     onClick={[Function]}
                     type="button"
                   >
-                    <injectIntl(Icon)
+                    <Icon
                       type="arrow-left"
                     >
-                      <Icon
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en-US",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en-US",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
-                            "wrapRichTextChunksInFragment": undefined,
-                          }
-                        }
-                        type="arrow-left"
+                      <FontAwesome
+                        aria-label=""
+                        fixedWidth={true}
+                        name="arrow-left"
                       >
-                        <FontAwesome
+                        <span
+                          aria-hidden={true}
                           aria-label=""
-                          fixedWidth={true}
-                          name="arrow-left"
-                        >
-                          <span
-                            aria-hidden={true}
-                            aria-label=""
-                            className="fa fa-arrow-left fa-fw"
-                          />
-                        </FontAwesome>
-                      </Icon>
-                    </injectIntl(Icon)>
+                          className="fa fa-arrow-left fa-fw"
+                        />
+                      </FontAwesome>
+                    </Icon>
                     <FormattedMessage
                       id="common.forms.back"
                     >
@@ -3013,61 +2723,21 @@ exports[`components > viewers > stop viewer should render countdown times for st
                     onClick={[Function]}
                     title="components.StopViewer.zoomToStop"
                   >
-                    <injectIntl(Icon)
+                    <Icon
                       type="search"
                     >
-                      <Icon
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en-US",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en-US",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
-                            "wrapRichTextChunksInFragment": undefined,
-                          }
-                        }
-                        type="search"
+                      <FontAwesome
+                        aria-label=""
+                        fixedWidth={true}
+                        name="search"
                       >
-                        <FontAwesome
+                        <span
+                          aria-hidden={true}
                           aria-label=""
-                          fixedWidth={true}
-                          name="search"
-                        >
-                          <span
-                            aria-hidden={true}
-                            aria-label=""
-                            className="fa fa-search fa-fw"
-                          />
-                        </FontAwesome>
-                      </Icon>
-                    </injectIntl(Icon)>
+                          className="fa fa-search fa-fw"
+                        />
+                      </FontAwesome>
+                    </Icon>
                   </button>
                   <button
                     className="link-button pull-right"
@@ -3078,70 +2748,29 @@ exports[`components > viewers > stop viewer should render countdown times for st
                       }
                     }
                   >
-                    <injectIntl(Icon)
+                    <Icon
                       type="calendar"
                       withSpace={true}
                     >
-                      <Icon
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en-US",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en-US",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
-                            "wrapRichTextChunksInFragment": undefined,
-                          }
-                        }
-                        type="calendar"
-                        withSpace={true}
+                      <Styled(FontAwesome)
+                        aria-label=""
+                        fixedWidth={true}
+                        name="calendar"
                       >
-                        <Styled(FontAwesome)
+                        <FontAwesome
                           aria-label=""
+                          className="sc-gsTEea iqivwV"
                           fixedWidth={true}
                           name="calendar"
                         >
-                          <FontAwesome
+                          <span
+                            aria-hidden={true}
                             aria-label=""
-                            className="sc-gsTEea iqivwV"
-                            fixedWidth={true}
-                            name="calendar"
-                          >
-                            <span
-                              aria-hidden={true}
-                              aria-label=""
-                              className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
-                            />
-                          </FontAwesome>
-                        </Styled(FontAwesome)>
-                      </Icon>
-                    </injectIntl(Icon)>
+                            className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
+                          />
+                        </FontAwesome>
+                      </Styled(FontAwesome)>
+                    </Icon>
                     <FormattedMessage
                       id="components.StopViewer.viewTypeBtnText"
                       values={
@@ -3628,7 +3257,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                     <div
                                       className="pull-left"
                                     >
-                                      <injectIntl(Icon)
+                                      <Icon
                                         style={
                                           Object {
                                             "color": "#888",
@@ -3638,43 +3267,10 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                         }
                                         type="clock-o"
                                       >
-                                        <Icon
-                                          intl={
-                                            Object {
-                                              "defaultFormats": Object {},
-                                              "defaultLocale": "en-US",
-                                              "defaultRichTextElements": undefined,
-                                              "formatDate": [Function],
-                                              "formatDateTimeRange": [Function],
-                                              "formatDateToParts": [Function],
-                                              "formatDisplayName": [Function],
-                                              "formatList": [Function],
-                                              "formatListToParts": [Function],
-                                              "formatMessage": [Function],
-                                              "formatNumber": [Function],
-                                              "formatNumberToParts": [Function],
-                                              "formatPlural": [Function],
-                                              "formatRelativeTime": [Function],
-                                              "formatTime": [Function],
-                                              "formatTimeToParts": [Function],
-                                              "formats": Object {},
-                                              "formatters": Object {
-                                                "getDateTimeFormat": [Function],
-                                                "getDisplayNames": [Function],
-                                                "getListFormat": [Function],
-                                                "getMessageFormat": [Function],
-                                                "getNumberFormat": [Function],
-                                                "getPluralRules": [Function],
-                                                "getRelativeTimeFormat": [Function],
-                                              },
-                                              "locale": "en-US",
-                                              "messages": Object {},
-                                              "onError": [Function],
-                                              "textComponent": Symbol(react.fragment),
-                                              "timeZone": undefined,
-                                              "wrapRichTextChunksInFragment": undefined,
-                                            }
-                                          }
+                                        <FontAwesome
+                                          aria-label=""
+                                          fixedWidth={true}
+                                          name="clock-o"
                                           style={
                                             Object {
                                               "color": "#888",
@@ -3682,12 +3278,11 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                               "marginRight": 2,
                                             }
                                           }
-                                          type="clock-o"
                                         >
-                                          <FontAwesome
+                                          <span
+                                            aria-hidden={true}
                                             aria-label=""
-                                            fixedWidth={true}
-                                            name="clock-o"
+                                            className="fa fa-clock-o fa-fw"
                                             style={
                                               Object {
                                                 "color": "#888",
@@ -3695,22 +3290,9 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                                 "marginRight": 2,
                                               }
                                             }
-                                          >
-                                            <span
-                                              aria-hidden={true}
-                                              aria-label=""
-                                              className="fa fa-clock-o fa-fw"
-                                              style={
-                                                Object {
-                                                  "color": "#888",
-                                                  "fontSize": "0.8em",
-                                                  "marginRight": 2,
-                                                }
-                                              }
-                                            />
-                                          </FontAwesome>
-                                        </Icon>
-                                      </injectIntl(Icon)>
+                                          />
+                                        </FontAwesome>
+                                      </Icon>
                                     </div>
                                     <div
                                       style={
@@ -3751,61 +3333,21 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                   className="expansion-button"
                                   onClick={[Function]}
                                 >
-                                  <injectIntl(Icon)
+                                  <Icon
                                     type="chevron-down"
                                   >
-                                    <Icon
-                                      intl={
-                                        Object {
-                                          "defaultFormats": Object {},
-                                          "defaultLocale": "en-US",
-                                          "defaultRichTextElements": undefined,
-                                          "formatDate": [Function],
-                                          "formatDateTimeRange": [Function],
-                                          "formatDateToParts": [Function],
-                                          "formatDisplayName": [Function],
-                                          "formatList": [Function],
-                                          "formatListToParts": [Function],
-                                          "formatMessage": [Function],
-                                          "formatNumber": [Function],
-                                          "formatNumberToParts": [Function],
-                                          "formatPlural": [Function],
-                                          "formatRelativeTime": [Function],
-                                          "formatTime": [Function],
-                                          "formatTimeToParts": [Function],
-                                          "formats": Object {},
-                                          "formatters": Object {
-                                            "getDateTimeFormat": [Function],
-                                            "getDisplayNames": [Function],
-                                            "getListFormat": [Function],
-                                            "getMessageFormat": [Function],
-                                            "getNumberFormat": [Function],
-                                            "getPluralRules": [Function],
-                                            "getRelativeTimeFormat": [Function],
-                                          },
-                                          "locale": "en-US",
-                                          "messages": Object {},
-                                          "onError": [Function],
-                                          "textComponent": Symbol(react.fragment),
-                                          "timeZone": undefined,
-                                          "wrapRichTextChunksInFragment": undefined,
-                                        }
-                                      }
-                                      type="chevron-down"
+                                    <FontAwesome
+                                      aria-label=""
+                                      fixedWidth={true}
+                                      name="chevron-down"
                                     >
-                                      <FontAwesome
+                                      <span
+                                        aria-hidden={true}
                                         aria-label=""
-                                        fixedWidth={true}
-                                        name="chevron-down"
-                                      >
-                                        <span
-                                          aria-hidden={true}
-                                          aria-label=""
-                                          className="fa fa-chevron-down fa-fw"
-                                        />
-                                      </FontAwesome>
-                                    </Icon>
-                                  </injectIntl(Icon)>
+                                        className="fa fa-chevron-down fa-fw"
+                                      />
+                                    </FontAwesome>
+                                  </Icon>
                                 </button>
                               </div>
                             </div>
@@ -3886,73 +3428,31 @@ exports[`components > viewers > stop viewer should render countdown times for st
                           }
                         }
                       >
-                        <injectIntl(Icon)
+                        <Icon
                           className="fa-spin"
                           type="refresh"
                           withSpace={true}
                         >
-                          <Icon
+                          <Styled(FontAwesome)
+                            aria-label=""
                             className="fa-spin"
-                            intl={
-                              Object {
-                                "defaultFormats": Object {},
-                                "defaultLocale": "en-US",
-                                "defaultRichTextElements": undefined,
-                                "formatDate": [Function],
-                                "formatDateTimeRange": [Function],
-                                "formatDateToParts": [Function],
-                                "formatDisplayName": [Function],
-                                "formatList": [Function],
-                                "formatListToParts": [Function],
-                                "formatMessage": [Function],
-                                "formatNumber": [Function],
-                                "formatNumberToParts": [Function],
-                                "formatPlural": [Function],
-                                "formatRelativeTime": [Function],
-                                "formatTime": [Function],
-                                "formatTimeToParts": [Function],
-                                "formats": Object {},
-                                "formatters": Object {
-                                  "getDateTimeFormat": [Function],
-                                  "getDisplayNames": [Function],
-                                  "getListFormat": [Function],
-                                  "getMessageFormat": [Function],
-                                  "getNumberFormat": [Function],
-                                  "getPluralRules": [Function],
-                                  "getRelativeTimeFormat": [Function],
-                                },
-                                "locale": "en-US",
-                                "messages": Object {},
-                                "onError": [Function],
-                                "textComponent": Symbol(react.fragment),
-                                "timeZone": undefined,
-                                "wrapRichTextChunksInFragment": undefined,
-                              }
-                            }
-                            type="refresh"
-                            withSpace={true}
+                            fixedWidth={true}
+                            name="refresh"
                           >
-                            <Styled(FontAwesome)
+                            <FontAwesome
                               aria-label=""
-                              className="fa-spin"
+                              className="sc-gsTEea iqivwV fa-spin"
                               fixedWidth={true}
                               name="refresh"
                             >
-                              <FontAwesome
+                              <span
+                                aria-hidden={true}
                                 aria-label=""
-                                className="sc-gsTEea iqivwV fa-spin"
-                                fixedWidth={true}
-                                name="refresh"
-                              >
-                                <span
-                                  aria-hidden={true}
-                                  aria-label=""
-                                  className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
-                                />
-                              </FontAwesome>
-                            </Styled(FontAwesome)>
-                          </Icon>
-                        </injectIntl(Icon)>
+                                className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
+                              />
+                            </FontAwesome>
+                          </Styled(FontAwesome)>
+                        </Icon>
                         <FormattedTime
                           timeStyle="short"
                           timeZone="America/Los_Angeles"
@@ -4868,61 +4368,21 @@ exports[`components > viewers > stop viewer should render times after midnight w
                     onClick={[Function]}
                     type="button"
                   >
-                    <injectIntl(Icon)
+                    <Icon
                       type="arrow-left"
                     >
-                      <Icon
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en-US",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en-US",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
-                            "wrapRichTextChunksInFragment": undefined,
-                          }
-                        }
-                        type="arrow-left"
+                      <FontAwesome
+                        aria-label=""
+                        fixedWidth={true}
+                        name="arrow-left"
                       >
-                        <FontAwesome
+                        <span
+                          aria-hidden={true}
                           aria-label=""
-                          fixedWidth={true}
-                          name="arrow-left"
-                        >
-                          <span
-                            aria-hidden={true}
-                            aria-label=""
-                            className="fa fa-arrow-left fa-fw"
-                          />
-                        </FontAwesome>
-                      </Icon>
-                    </injectIntl(Icon)>
+                          className="fa fa-arrow-left fa-fw"
+                        />
+                      </FontAwesome>
+                    </Icon>
                     <FormattedMessage
                       id="common.forms.back"
                     >
@@ -4973,61 +4433,21 @@ exports[`components > viewers > stop viewer should render times after midnight w
                     onClick={[Function]}
                     title="components.StopViewer.zoomToStop"
                   >
-                    <injectIntl(Icon)
+                    <Icon
                       type="search"
                     >
-                      <Icon
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en-US",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en-US",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
-                            "wrapRichTextChunksInFragment": undefined,
-                          }
-                        }
-                        type="search"
+                      <FontAwesome
+                        aria-label=""
+                        fixedWidth={true}
+                        name="search"
                       >
-                        <FontAwesome
+                        <span
+                          aria-hidden={true}
                           aria-label=""
-                          fixedWidth={true}
-                          name="search"
-                        >
-                          <span
-                            aria-hidden={true}
-                            aria-label=""
-                            className="fa fa-search fa-fw"
-                          />
-                        </FontAwesome>
-                      </Icon>
-                    </injectIntl(Icon)>
+                          className="fa fa-search fa-fw"
+                        />
+                      </FontAwesome>
+                    </Icon>
                   </button>
                   <button
                     className="link-button pull-right"
@@ -5038,70 +4458,29 @@ exports[`components > viewers > stop viewer should render times after midnight w
                       }
                     }
                   >
-                    <injectIntl(Icon)
+                    <Icon
                       type="calendar"
                       withSpace={true}
                     >
-                      <Icon
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en-US",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en-US",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
-                            "wrapRichTextChunksInFragment": undefined,
-                          }
-                        }
-                        type="calendar"
-                        withSpace={true}
+                      <Styled(FontAwesome)
+                        aria-label=""
+                        fixedWidth={true}
+                        name="calendar"
                       >
-                        <Styled(FontAwesome)
+                        <FontAwesome
                           aria-label=""
+                          className="sc-gsTEea iqivwV"
                           fixedWidth={true}
                           name="calendar"
                         >
-                          <FontAwesome
+                          <span
+                            aria-hidden={true}
                             aria-label=""
-                            className="sc-gsTEea iqivwV"
-                            fixedWidth={true}
-                            name="calendar"
-                          >
-                            <span
-                              aria-hidden={true}
-                              aria-label=""
-                              className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
-                            />
-                          </FontAwesome>
-                        </Styled(FontAwesome)>
-                      </Icon>
-                    </injectIntl(Icon)>
+                            className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
+                          />
+                        </FontAwesome>
+                      </Styled(FontAwesome)>
+                    </Icon>
                     <FormattedMessage
                       id="components.StopViewer.viewTypeBtnText"
                       values={
@@ -5867,7 +5246,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                     <div
                                       className="pull-left"
                                     >
-                                      <injectIntl(Icon)
+                                      <Icon
                                         style={
                                           Object {
                                             "color": "#888",
@@ -5877,43 +5256,10 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                         }
                                         type="clock-o"
                                       >
-                                        <Icon
-                                          intl={
-                                            Object {
-                                              "defaultFormats": Object {},
-                                              "defaultLocale": "en-US",
-                                              "defaultRichTextElements": undefined,
-                                              "formatDate": [Function],
-                                              "formatDateTimeRange": [Function],
-                                              "formatDateToParts": [Function],
-                                              "formatDisplayName": [Function],
-                                              "formatList": [Function],
-                                              "formatListToParts": [Function],
-                                              "formatMessage": [Function],
-                                              "formatNumber": [Function],
-                                              "formatNumberToParts": [Function],
-                                              "formatPlural": [Function],
-                                              "formatRelativeTime": [Function],
-                                              "formatTime": [Function],
-                                              "formatTimeToParts": [Function],
-                                              "formats": Object {},
-                                              "formatters": Object {
-                                                "getDateTimeFormat": [Function],
-                                                "getDisplayNames": [Function],
-                                                "getListFormat": [Function],
-                                                "getMessageFormat": [Function],
-                                                "getNumberFormat": [Function],
-                                                "getPluralRules": [Function],
-                                                "getRelativeTimeFormat": [Function],
-                                              },
-                                              "locale": "en-US",
-                                              "messages": Object {},
-                                              "onError": [Function],
-                                              "textComponent": Symbol(react.fragment),
-                                              "timeZone": undefined,
-                                              "wrapRichTextChunksInFragment": undefined,
-                                            }
-                                          }
+                                        <FontAwesome
+                                          aria-label=""
+                                          fixedWidth={true}
+                                          name="clock-o"
                                           style={
                                             Object {
                                               "color": "#888",
@@ -5921,12 +5267,11 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                               "marginRight": 2,
                                             }
                                           }
-                                          type="clock-o"
                                         >
-                                          <FontAwesome
+                                          <span
+                                            aria-hidden={true}
                                             aria-label=""
-                                            fixedWidth={true}
-                                            name="clock-o"
+                                            className="fa fa-clock-o fa-fw"
                                             style={
                                               Object {
                                                 "color": "#888",
@@ -5934,22 +5279,9 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                                 "marginRight": 2,
                                               }
                                             }
-                                          >
-                                            <span
-                                              aria-hidden={true}
-                                              aria-label=""
-                                              className="fa fa-clock-o fa-fw"
-                                              style={
-                                                Object {
-                                                  "color": "#888",
-                                                  "fontSize": "0.8em",
-                                                  "marginRight": 2,
-                                                }
-                                              }
-                                            />
-                                          </FontAwesome>
-                                        </Icon>
-                                      </injectIntl(Icon)>
+                                          />
+                                        </FontAwesome>
+                                      </Icon>
                                     </div>
                                     <div
                                       style={
@@ -6002,61 +5334,21 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                   className="expansion-button"
                                   onClick={[Function]}
                                 >
-                                  <injectIntl(Icon)
+                                  <Icon
                                     type="chevron-down"
                                   >
-                                    <Icon
-                                      intl={
-                                        Object {
-                                          "defaultFormats": Object {},
-                                          "defaultLocale": "en-US",
-                                          "defaultRichTextElements": undefined,
-                                          "formatDate": [Function],
-                                          "formatDateTimeRange": [Function],
-                                          "formatDateToParts": [Function],
-                                          "formatDisplayName": [Function],
-                                          "formatList": [Function],
-                                          "formatListToParts": [Function],
-                                          "formatMessage": [Function],
-                                          "formatNumber": [Function],
-                                          "formatNumberToParts": [Function],
-                                          "formatPlural": [Function],
-                                          "formatRelativeTime": [Function],
-                                          "formatTime": [Function],
-                                          "formatTimeToParts": [Function],
-                                          "formats": Object {},
-                                          "formatters": Object {
-                                            "getDateTimeFormat": [Function],
-                                            "getDisplayNames": [Function],
-                                            "getListFormat": [Function],
-                                            "getMessageFormat": [Function],
-                                            "getNumberFormat": [Function],
-                                            "getPluralRules": [Function],
-                                            "getRelativeTimeFormat": [Function],
-                                          },
-                                          "locale": "en-US",
-                                          "messages": Object {},
-                                          "onError": [Function],
-                                          "textComponent": Symbol(react.fragment),
-                                          "timeZone": undefined,
-                                          "wrapRichTextChunksInFragment": undefined,
-                                        }
-                                      }
-                                      type="chevron-down"
+                                    <FontAwesome
+                                      aria-label=""
+                                      fixedWidth={true}
+                                      name="chevron-down"
                                     >
-                                      <FontAwesome
+                                      <span
+                                        aria-hidden={true}
                                         aria-label=""
-                                        fixedWidth={true}
-                                        name="chevron-down"
-                                      >
-                                        <span
-                                          aria-hidden={true}
-                                          aria-label=""
-                                          className="fa fa-chevron-down fa-fw"
-                                        />
-                                      </FontAwesome>
-                                    </Icon>
-                                  </injectIntl(Icon)>
+                                        className="fa fa-chevron-down fa-fw"
+                                      />
+                                    </FontAwesome>
+                                  </Icon>
                                 </button>
                               </div>
                             </div>
@@ -6137,73 +5429,31 @@ exports[`components > viewers > stop viewer should render times after midnight w
                           }
                         }
                       >
-                        <injectIntl(Icon)
+                        <Icon
                           className="fa-spin"
                           type="refresh"
                           withSpace={true}
                         >
-                          <Icon
+                          <Styled(FontAwesome)
+                            aria-label=""
                             className="fa-spin"
-                            intl={
-                              Object {
-                                "defaultFormats": Object {},
-                                "defaultLocale": "en-US",
-                                "defaultRichTextElements": undefined,
-                                "formatDate": [Function],
-                                "formatDateTimeRange": [Function],
-                                "formatDateToParts": [Function],
-                                "formatDisplayName": [Function],
-                                "formatList": [Function],
-                                "formatListToParts": [Function],
-                                "formatMessage": [Function],
-                                "formatNumber": [Function],
-                                "formatNumberToParts": [Function],
-                                "formatPlural": [Function],
-                                "formatRelativeTime": [Function],
-                                "formatTime": [Function],
-                                "formatTimeToParts": [Function],
-                                "formats": Object {},
-                                "formatters": Object {
-                                  "getDateTimeFormat": [Function],
-                                  "getDisplayNames": [Function],
-                                  "getListFormat": [Function],
-                                  "getMessageFormat": [Function],
-                                  "getNumberFormat": [Function],
-                                  "getPluralRules": [Function],
-                                  "getRelativeTimeFormat": [Function],
-                                },
-                                "locale": "en-US",
-                                "messages": Object {},
-                                "onError": [Function],
-                                "textComponent": Symbol(react.fragment),
-                                "timeZone": undefined,
-                                "wrapRichTextChunksInFragment": undefined,
-                              }
-                            }
-                            type="refresh"
-                            withSpace={true}
+                            fixedWidth={true}
+                            name="refresh"
                           >
-                            <Styled(FontAwesome)
+                            <FontAwesome
                               aria-label=""
-                              className="fa-spin"
+                              className="sc-gsTEea iqivwV fa-spin"
                               fixedWidth={true}
                               name="refresh"
                             >
-                              <FontAwesome
+                              <span
+                                aria-hidden={true}
                                 aria-label=""
-                                className="sc-gsTEea iqivwV fa-spin"
-                                fixedWidth={true}
-                                name="refresh"
-                              >
-                                <span
-                                  aria-hidden={true}
-                                  aria-label=""
-                                  className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
-                                />
-                              </FontAwesome>
-                            </Styled(FontAwesome)>
-                          </Icon>
-                        </injectIntl(Icon)>
+                                className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
+                              />
+                            </FontAwesome>
+                          </Styled(FontAwesome)>
+                        </Icon>
                         <FormattedTime
                           timeStyle="short"
                           timeZone="America/Los_Angeles"
@@ -8031,61 +7281,21 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                     onClick={[Function]}
                     type="button"
                   >
-                    <injectIntl(Icon)
+                    <Icon
                       type="arrow-left"
                     >
-                      <Icon
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en-US",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en-US",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
-                            "wrapRichTextChunksInFragment": undefined,
-                          }
-                        }
-                        type="arrow-left"
+                      <FontAwesome
+                        aria-label=""
+                        fixedWidth={true}
+                        name="arrow-left"
                       >
-                        <FontAwesome
+                        <span
+                          aria-hidden={true}
                           aria-label=""
-                          fixedWidth={true}
-                          name="arrow-left"
-                        >
-                          <span
-                            aria-hidden={true}
-                            aria-label=""
-                            className="fa fa-arrow-left fa-fw"
-                          />
-                        </FontAwesome>
-                      </Icon>
-                    </injectIntl(Icon)>
+                          className="fa fa-arrow-left fa-fw"
+                        />
+                      </FontAwesome>
+                    </Icon>
                     <FormattedMessage
                       id="common.forms.back"
                     >
@@ -8136,61 +7346,21 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                     onClick={[Function]}
                     title="components.StopViewer.zoomToStop"
                   >
-                    <injectIntl(Icon)
+                    <Icon
                       type="search"
                     >
-                      <Icon
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en-US",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en-US",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
-                            "wrapRichTextChunksInFragment": undefined,
-                          }
-                        }
-                        type="search"
+                      <FontAwesome
+                        aria-label=""
+                        fixedWidth={true}
+                        name="search"
                       >
-                        <FontAwesome
+                        <span
+                          aria-hidden={true}
                           aria-label=""
-                          fixedWidth={true}
-                          name="search"
-                        >
-                          <span
-                            aria-hidden={true}
-                            aria-label=""
-                            className="fa fa-search fa-fw"
-                          />
-                        </FontAwesome>
-                      </Icon>
-                    </injectIntl(Icon)>
+                          className="fa fa-search fa-fw"
+                        />
+                      </FontAwesome>
+                    </Icon>
                   </button>
                   <button
                     className="link-button pull-right"
@@ -8201,70 +7371,29 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                       }
                     }
                   >
-                    <injectIntl(Icon)
+                    <Icon
                       type="calendar"
                       withSpace={true}
                     >
-                      <Icon
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en-US",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en-US",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
-                            "wrapRichTextChunksInFragment": undefined,
-                          }
-                        }
-                        type="calendar"
-                        withSpace={true}
+                      <Styled(FontAwesome)
+                        aria-label=""
+                        fixedWidth={true}
+                        name="calendar"
                       >
-                        <Styled(FontAwesome)
+                        <FontAwesome
                           aria-label=""
+                          className="sc-gsTEea iqivwV"
                           fixedWidth={true}
                           name="calendar"
                         >
-                          <FontAwesome
+                          <span
+                            aria-hidden={true}
                             aria-label=""
-                            className="sc-gsTEea iqivwV"
-                            fixedWidth={true}
-                            name="calendar"
-                          >
-                            <span
-                              aria-hidden={true}
-                              aria-label=""
-                              className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
-                            />
-                          </FontAwesome>
-                        </Styled(FontAwesome)>
-                      </Icon>
-                    </injectIntl(Icon)>
+                            className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
+                          />
+                        </FontAwesome>
+                      </Styled(FontAwesome)>
+                    </Icon>
                     <FormattedMessage
                       id="components.StopViewer.viewTypeBtnText"
                       values={
@@ -9284,7 +8413,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     <div
                                       className="pull-left"
                                     >
-                                      <injectIntl(Icon)
+                                      <Icon
                                         style={
                                           Object {
                                             "color": "#888",
@@ -9294,43 +8423,10 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         }
                                         type="clock-o"
                                       >
-                                        <Icon
-                                          intl={
-                                            Object {
-                                              "defaultFormats": Object {},
-                                              "defaultLocale": "en-US",
-                                              "defaultRichTextElements": undefined,
-                                              "formatDate": [Function],
-                                              "formatDateTimeRange": [Function],
-                                              "formatDateToParts": [Function],
-                                              "formatDisplayName": [Function],
-                                              "formatList": [Function],
-                                              "formatListToParts": [Function],
-                                              "formatMessage": [Function],
-                                              "formatNumber": [Function],
-                                              "formatNumberToParts": [Function],
-                                              "formatPlural": [Function],
-                                              "formatRelativeTime": [Function],
-                                              "formatTime": [Function],
-                                              "formatTimeToParts": [Function],
-                                              "formats": Object {},
-                                              "formatters": Object {
-                                                "getDateTimeFormat": [Function],
-                                                "getDisplayNames": [Function],
-                                                "getListFormat": [Function],
-                                                "getMessageFormat": [Function],
-                                                "getNumberFormat": [Function],
-                                                "getPluralRules": [Function],
-                                                "getRelativeTimeFormat": [Function],
-                                              },
-                                              "locale": "en-US",
-                                              "messages": Object {},
-                                              "onError": [Function],
-                                              "textComponent": Symbol(react.fragment),
-                                              "timeZone": undefined,
-                                              "wrapRichTextChunksInFragment": undefined,
-                                            }
-                                          }
+                                        <FontAwesome
+                                          aria-label=""
+                                          fixedWidth={true}
+                                          name="clock-o"
                                           style={
                                             Object {
                                               "color": "#888",
@@ -9338,12 +8434,11 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                               "marginRight": 2,
                                             }
                                           }
-                                          type="clock-o"
                                         >
-                                          <FontAwesome
+                                          <span
+                                            aria-hidden={true}
                                             aria-label=""
-                                            fixedWidth={true}
-                                            name="clock-o"
+                                            className="fa fa-clock-o fa-fw"
                                             style={
                                               Object {
                                                 "color": "#888",
@@ -9351,22 +8446,9 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                                 "marginRight": 2,
                                               }
                                             }
-                                          >
-                                            <span
-                                              aria-hidden={true}
-                                              aria-label=""
-                                              className="fa fa-clock-o fa-fw"
-                                              style={
-                                                Object {
-                                                  "color": "#888",
-                                                  "fontSize": "0.8em",
-                                                  "marginRight": 2,
-                                                }
-                                              }
-                                            />
-                                          </FontAwesome>
-                                        </Icon>
-                                      </injectIntl(Icon)>
+                                          />
+                                        </FontAwesome>
+                                      </Icon>
                                     </div>
                                     <div
                                       style={
@@ -9419,61 +8501,21 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   className="expansion-button"
                                   onClick={[Function]}
                                 >
-                                  <injectIntl(Icon)
+                                  <Icon
                                     type="chevron-down"
                                   >
-                                    <Icon
-                                      intl={
-                                        Object {
-                                          "defaultFormats": Object {},
-                                          "defaultLocale": "en-US",
-                                          "defaultRichTextElements": undefined,
-                                          "formatDate": [Function],
-                                          "formatDateTimeRange": [Function],
-                                          "formatDateToParts": [Function],
-                                          "formatDisplayName": [Function],
-                                          "formatList": [Function],
-                                          "formatListToParts": [Function],
-                                          "formatMessage": [Function],
-                                          "formatNumber": [Function],
-                                          "formatNumberToParts": [Function],
-                                          "formatPlural": [Function],
-                                          "formatRelativeTime": [Function],
-                                          "formatTime": [Function],
-                                          "formatTimeToParts": [Function],
-                                          "formats": Object {},
-                                          "formatters": Object {
-                                            "getDateTimeFormat": [Function],
-                                            "getDisplayNames": [Function],
-                                            "getListFormat": [Function],
-                                            "getMessageFormat": [Function],
-                                            "getNumberFormat": [Function],
-                                            "getPluralRules": [Function],
-                                            "getRelativeTimeFormat": [Function],
-                                          },
-                                          "locale": "en-US",
-                                          "messages": Object {},
-                                          "onError": [Function],
-                                          "textComponent": Symbol(react.fragment),
-                                          "timeZone": undefined,
-                                          "wrapRichTextChunksInFragment": undefined,
-                                        }
-                                      }
-                                      type="chevron-down"
+                                    <FontAwesome
+                                      aria-label=""
+                                      fixedWidth={true}
+                                      name="chevron-down"
                                     >
-                                      <FontAwesome
+                                      <span
+                                        aria-hidden={true}
                                         aria-label=""
-                                        fixedWidth={true}
-                                        name="chevron-down"
-                                      >
-                                        <span
-                                          aria-hidden={true}
-                                          aria-label=""
-                                          className="fa fa-chevron-down fa-fw"
-                                        />
-                                      </FontAwesome>
-                                    </Icon>
-                                  </injectIntl(Icon)>
+                                        className="fa fa-chevron-down fa-fw"
+                                      />
+                                    </FontAwesome>
+                                  </Icon>
                                 </button>
                               </div>
                             </div>
@@ -9774,7 +8816,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     <div
                                       className="pull-left"
                                     >
-                                      <injectIntl(Icon)
+                                      <Icon
                                         style={
                                           Object {
                                             "color": "#888",
@@ -9784,43 +8826,10 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         }
                                         type="clock-o"
                                       >
-                                        <Icon
-                                          intl={
-                                            Object {
-                                              "defaultFormats": Object {},
-                                              "defaultLocale": "en-US",
-                                              "defaultRichTextElements": undefined,
-                                              "formatDate": [Function],
-                                              "formatDateTimeRange": [Function],
-                                              "formatDateToParts": [Function],
-                                              "formatDisplayName": [Function],
-                                              "formatList": [Function],
-                                              "formatListToParts": [Function],
-                                              "formatMessage": [Function],
-                                              "formatNumber": [Function],
-                                              "formatNumberToParts": [Function],
-                                              "formatPlural": [Function],
-                                              "formatRelativeTime": [Function],
-                                              "formatTime": [Function],
-                                              "formatTimeToParts": [Function],
-                                              "formats": Object {},
-                                              "formatters": Object {
-                                                "getDateTimeFormat": [Function],
-                                                "getDisplayNames": [Function],
-                                                "getListFormat": [Function],
-                                                "getMessageFormat": [Function],
-                                                "getNumberFormat": [Function],
-                                                "getPluralRules": [Function],
-                                                "getRelativeTimeFormat": [Function],
-                                              },
-                                              "locale": "en-US",
-                                              "messages": Object {},
-                                              "onError": [Function],
-                                              "textComponent": Symbol(react.fragment),
-                                              "timeZone": undefined,
-                                              "wrapRichTextChunksInFragment": undefined,
-                                            }
-                                          }
+                                        <FontAwesome
+                                          aria-label=""
+                                          fixedWidth={true}
+                                          name="clock-o"
                                           style={
                                             Object {
                                               "color": "#888",
@@ -9828,12 +8837,11 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                               "marginRight": 2,
                                             }
                                           }
-                                          type="clock-o"
                                         >
-                                          <FontAwesome
+                                          <span
+                                            aria-hidden={true}
                                             aria-label=""
-                                            fixedWidth={true}
-                                            name="clock-o"
+                                            className="fa fa-clock-o fa-fw"
                                             style={
                                               Object {
                                                 "color": "#888",
@@ -9841,22 +8849,9 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                                 "marginRight": 2,
                                               }
                                             }
-                                          >
-                                            <span
-                                              aria-hidden={true}
-                                              aria-label=""
-                                              className="fa fa-clock-o fa-fw"
-                                              style={
-                                                Object {
-                                                  "color": "#888",
-                                                  "fontSize": "0.8em",
-                                                  "marginRight": 2,
-                                                }
-                                              }
-                                            />
-                                          </FontAwesome>
-                                        </Icon>
-                                      </injectIntl(Icon)>
+                                          />
+                                        </FontAwesome>
+                                      </Icon>
                                     </div>
                                     <div
                                       style={
@@ -9909,61 +8904,21 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   className="expansion-button"
                                   onClick={[Function]}
                                 >
-                                  <injectIntl(Icon)
+                                  <Icon
                                     type="chevron-down"
                                   >
-                                    <Icon
-                                      intl={
-                                        Object {
-                                          "defaultFormats": Object {},
-                                          "defaultLocale": "en-US",
-                                          "defaultRichTextElements": undefined,
-                                          "formatDate": [Function],
-                                          "formatDateTimeRange": [Function],
-                                          "formatDateToParts": [Function],
-                                          "formatDisplayName": [Function],
-                                          "formatList": [Function],
-                                          "formatListToParts": [Function],
-                                          "formatMessage": [Function],
-                                          "formatNumber": [Function],
-                                          "formatNumberToParts": [Function],
-                                          "formatPlural": [Function],
-                                          "formatRelativeTime": [Function],
-                                          "formatTime": [Function],
-                                          "formatTimeToParts": [Function],
-                                          "formats": Object {},
-                                          "formatters": Object {
-                                            "getDateTimeFormat": [Function],
-                                            "getDisplayNames": [Function],
-                                            "getListFormat": [Function],
-                                            "getMessageFormat": [Function],
-                                            "getNumberFormat": [Function],
-                                            "getPluralRules": [Function],
-                                            "getRelativeTimeFormat": [Function],
-                                          },
-                                          "locale": "en-US",
-                                          "messages": Object {},
-                                          "onError": [Function],
-                                          "textComponent": Symbol(react.fragment),
-                                          "timeZone": undefined,
-                                          "wrapRichTextChunksInFragment": undefined,
-                                        }
-                                      }
-                                      type="chevron-down"
+                                    <FontAwesome
+                                      aria-label=""
+                                      fixedWidth={true}
+                                      name="chevron-down"
                                     >
-                                      <FontAwesome
+                                      <span
+                                        aria-hidden={true}
                                         aria-label=""
-                                        fixedWidth={true}
-                                        name="chevron-down"
-                                      >
-                                        <span
-                                          aria-hidden={true}
-                                          aria-label=""
-                                          className="fa fa-chevron-down fa-fw"
-                                        />
-                                      </FontAwesome>
-                                    </Icon>
-                                  </injectIntl(Icon)>
+                                        className="fa fa-chevron-down fa-fw"
+                                      />
+                                    </FontAwesome>
+                                  </Icon>
                                 </button>
                               </div>
                             </div>
@@ -10264,7 +9219,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     <div
                                       className="pull-left"
                                     >
-                                      <injectIntl(Icon)
+                                      <Icon
                                         style={
                                           Object {
                                             "color": "#888",
@@ -10274,43 +9229,10 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         }
                                         type="clock-o"
                                       >
-                                        <Icon
-                                          intl={
-                                            Object {
-                                              "defaultFormats": Object {},
-                                              "defaultLocale": "en-US",
-                                              "defaultRichTextElements": undefined,
-                                              "formatDate": [Function],
-                                              "formatDateTimeRange": [Function],
-                                              "formatDateToParts": [Function],
-                                              "formatDisplayName": [Function],
-                                              "formatList": [Function],
-                                              "formatListToParts": [Function],
-                                              "formatMessage": [Function],
-                                              "formatNumber": [Function],
-                                              "formatNumberToParts": [Function],
-                                              "formatPlural": [Function],
-                                              "formatRelativeTime": [Function],
-                                              "formatTime": [Function],
-                                              "formatTimeToParts": [Function],
-                                              "formats": Object {},
-                                              "formatters": Object {
-                                                "getDateTimeFormat": [Function],
-                                                "getDisplayNames": [Function],
-                                                "getListFormat": [Function],
-                                                "getMessageFormat": [Function],
-                                                "getNumberFormat": [Function],
-                                                "getPluralRules": [Function],
-                                                "getRelativeTimeFormat": [Function],
-                                              },
-                                              "locale": "en-US",
-                                              "messages": Object {},
-                                              "onError": [Function],
-                                              "textComponent": Symbol(react.fragment),
-                                              "timeZone": undefined,
-                                              "wrapRichTextChunksInFragment": undefined,
-                                            }
-                                          }
+                                        <FontAwesome
+                                          aria-label=""
+                                          fixedWidth={true}
+                                          name="clock-o"
                                           style={
                                             Object {
                                               "color": "#888",
@@ -10318,12 +9240,11 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                               "marginRight": 2,
                                             }
                                           }
-                                          type="clock-o"
                                         >
-                                          <FontAwesome
+                                          <span
+                                            aria-hidden={true}
                                             aria-label=""
-                                            fixedWidth={true}
-                                            name="clock-o"
+                                            className="fa fa-clock-o fa-fw"
                                             style={
                                               Object {
                                                 "color": "#888",
@@ -10331,22 +9252,9 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                                 "marginRight": 2,
                                               }
                                             }
-                                          >
-                                            <span
-                                              aria-hidden={true}
-                                              aria-label=""
-                                              className="fa fa-clock-o fa-fw"
-                                              style={
-                                                Object {
-                                                  "color": "#888",
-                                                  "fontSize": "0.8em",
-                                                  "marginRight": 2,
-                                                }
-                                              }
-                                            />
-                                          </FontAwesome>
-                                        </Icon>
-                                      </injectIntl(Icon)>
+                                          />
+                                        </FontAwesome>
+                                      </Icon>
                                     </div>
                                     <div
                                       style={
@@ -10399,61 +9307,21 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   className="expansion-button"
                                   onClick={[Function]}
                                 >
-                                  <injectIntl(Icon)
+                                  <Icon
                                     type="chevron-down"
                                   >
-                                    <Icon
-                                      intl={
-                                        Object {
-                                          "defaultFormats": Object {},
-                                          "defaultLocale": "en-US",
-                                          "defaultRichTextElements": undefined,
-                                          "formatDate": [Function],
-                                          "formatDateTimeRange": [Function],
-                                          "formatDateToParts": [Function],
-                                          "formatDisplayName": [Function],
-                                          "formatList": [Function],
-                                          "formatListToParts": [Function],
-                                          "formatMessage": [Function],
-                                          "formatNumber": [Function],
-                                          "formatNumberToParts": [Function],
-                                          "formatPlural": [Function],
-                                          "formatRelativeTime": [Function],
-                                          "formatTime": [Function],
-                                          "formatTimeToParts": [Function],
-                                          "formats": Object {},
-                                          "formatters": Object {
-                                            "getDateTimeFormat": [Function],
-                                            "getDisplayNames": [Function],
-                                            "getListFormat": [Function],
-                                            "getMessageFormat": [Function],
-                                            "getNumberFormat": [Function],
-                                            "getPluralRules": [Function],
-                                            "getRelativeTimeFormat": [Function],
-                                          },
-                                          "locale": "en-US",
-                                          "messages": Object {},
-                                          "onError": [Function],
-                                          "textComponent": Symbol(react.fragment),
-                                          "timeZone": undefined,
-                                          "wrapRichTextChunksInFragment": undefined,
-                                        }
-                                      }
-                                      type="chevron-down"
+                                    <FontAwesome
+                                      aria-label=""
+                                      fixedWidth={true}
+                                      name="chevron-down"
                                     >
-                                      <FontAwesome
+                                      <span
+                                        aria-hidden={true}
                                         aria-label=""
-                                        fixedWidth={true}
-                                        name="chevron-down"
-                                      >
-                                        <span
-                                          aria-hidden={true}
-                                          aria-label=""
-                                          className="fa fa-chevron-down fa-fw"
-                                        />
-                                      </FontAwesome>
-                                    </Icon>
-                                  </injectIntl(Icon)>
+                                        className="fa fa-chevron-down fa-fw"
+                                      />
+                                    </FontAwesome>
+                                  </Icon>
                                 </button>
                               </div>
                             </div>
@@ -10862,7 +9730,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     <div
                                       className="pull-left"
                                     >
-                                      <injectIntl(Icon)
+                                      <Icon
                                         style={
                                           Object {
                                             "color": "#888",
@@ -10872,43 +9740,10 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         }
                                         type="clock-o"
                                       >
-                                        <Icon
-                                          intl={
-                                            Object {
-                                              "defaultFormats": Object {},
-                                              "defaultLocale": "en-US",
-                                              "defaultRichTextElements": undefined,
-                                              "formatDate": [Function],
-                                              "formatDateTimeRange": [Function],
-                                              "formatDateToParts": [Function],
-                                              "formatDisplayName": [Function],
-                                              "formatList": [Function],
-                                              "formatListToParts": [Function],
-                                              "formatMessage": [Function],
-                                              "formatNumber": [Function],
-                                              "formatNumberToParts": [Function],
-                                              "formatPlural": [Function],
-                                              "formatRelativeTime": [Function],
-                                              "formatTime": [Function],
-                                              "formatTimeToParts": [Function],
-                                              "formats": Object {},
-                                              "formatters": Object {
-                                                "getDateTimeFormat": [Function],
-                                                "getDisplayNames": [Function],
-                                                "getListFormat": [Function],
-                                                "getMessageFormat": [Function],
-                                                "getNumberFormat": [Function],
-                                                "getPluralRules": [Function],
-                                                "getRelativeTimeFormat": [Function],
-                                              },
-                                              "locale": "en-US",
-                                              "messages": Object {},
-                                              "onError": [Function],
-                                              "textComponent": Symbol(react.fragment),
-                                              "timeZone": undefined,
-                                              "wrapRichTextChunksInFragment": undefined,
-                                            }
-                                          }
+                                        <FontAwesome
+                                          aria-label=""
+                                          fixedWidth={true}
+                                          name="clock-o"
                                           style={
                                             Object {
                                               "color": "#888",
@@ -10916,12 +9751,11 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                               "marginRight": 2,
                                             }
                                           }
-                                          type="clock-o"
                                         >
-                                          <FontAwesome
+                                          <span
+                                            aria-hidden={true}
                                             aria-label=""
-                                            fixedWidth={true}
-                                            name="clock-o"
+                                            className="fa fa-clock-o fa-fw"
                                             style={
                                               Object {
                                                 "color": "#888",
@@ -10929,22 +9763,9 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                                 "marginRight": 2,
                                               }
                                             }
-                                          >
-                                            <span
-                                              aria-hidden={true}
-                                              aria-label=""
-                                              className="fa fa-clock-o fa-fw"
-                                              style={
-                                                Object {
-                                                  "color": "#888",
-                                                  "fontSize": "0.8em",
-                                                  "marginRight": 2,
-                                                }
-                                              }
-                                            />
-                                          </FontAwesome>
-                                        </Icon>
-                                      </injectIntl(Icon)>
+                                          />
+                                        </FontAwesome>
+                                      </Icon>
                                     </div>
                                     <div
                                       style={
@@ -10997,61 +9818,21 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   className="expansion-button"
                                   onClick={[Function]}
                                 >
-                                  <injectIntl(Icon)
+                                  <Icon
                                     type="chevron-down"
                                   >
-                                    <Icon
-                                      intl={
-                                        Object {
-                                          "defaultFormats": Object {},
-                                          "defaultLocale": "en-US",
-                                          "defaultRichTextElements": undefined,
-                                          "formatDate": [Function],
-                                          "formatDateTimeRange": [Function],
-                                          "formatDateToParts": [Function],
-                                          "formatDisplayName": [Function],
-                                          "formatList": [Function],
-                                          "formatListToParts": [Function],
-                                          "formatMessage": [Function],
-                                          "formatNumber": [Function],
-                                          "formatNumberToParts": [Function],
-                                          "formatPlural": [Function],
-                                          "formatRelativeTime": [Function],
-                                          "formatTime": [Function],
-                                          "formatTimeToParts": [Function],
-                                          "formats": Object {},
-                                          "formatters": Object {
-                                            "getDateTimeFormat": [Function],
-                                            "getDisplayNames": [Function],
-                                            "getListFormat": [Function],
-                                            "getMessageFormat": [Function],
-                                            "getNumberFormat": [Function],
-                                            "getPluralRules": [Function],
-                                            "getRelativeTimeFormat": [Function],
-                                          },
-                                          "locale": "en-US",
-                                          "messages": Object {},
-                                          "onError": [Function],
-                                          "textComponent": Symbol(react.fragment),
-                                          "timeZone": undefined,
-                                          "wrapRichTextChunksInFragment": undefined,
-                                        }
-                                      }
-                                      type="chevron-down"
+                                    <FontAwesome
+                                      aria-label=""
+                                      fixedWidth={true}
+                                      name="chevron-down"
                                     >
-                                      <FontAwesome
+                                      <span
+                                        aria-hidden={true}
                                         aria-label=""
-                                        fixedWidth={true}
-                                        name="chevron-down"
-                                      >
-                                        <span
-                                          aria-hidden={true}
-                                          aria-label=""
-                                          className="fa fa-chevron-down fa-fw"
-                                        />
-                                      </FontAwesome>
-                                    </Icon>
-                                  </injectIntl(Icon)>
+                                        className="fa fa-chevron-down fa-fw"
+                                      />
+                                    </FontAwesome>
+                                  </Icon>
                                 </button>
                               </div>
                             </div>
@@ -11132,73 +9913,31 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                           }
                         }
                       >
-                        <injectIntl(Icon)
+                        <Icon
                           className="fa-spin"
                           type="refresh"
                           withSpace={true}
                         >
-                          <Icon
+                          <Styled(FontAwesome)
+                            aria-label=""
                             className="fa-spin"
-                            intl={
-                              Object {
-                                "defaultFormats": Object {},
-                                "defaultLocale": "en-US",
-                                "defaultRichTextElements": undefined,
-                                "formatDate": [Function],
-                                "formatDateTimeRange": [Function],
-                                "formatDateToParts": [Function],
-                                "formatDisplayName": [Function],
-                                "formatList": [Function],
-                                "formatListToParts": [Function],
-                                "formatMessage": [Function],
-                                "formatNumber": [Function],
-                                "formatNumberToParts": [Function],
-                                "formatPlural": [Function],
-                                "formatRelativeTime": [Function],
-                                "formatTime": [Function],
-                                "formatTimeToParts": [Function],
-                                "formats": Object {},
-                                "formatters": Object {
-                                  "getDateTimeFormat": [Function],
-                                  "getDisplayNames": [Function],
-                                  "getListFormat": [Function],
-                                  "getMessageFormat": [Function],
-                                  "getNumberFormat": [Function],
-                                  "getPluralRules": [Function],
-                                  "getRelativeTimeFormat": [Function],
-                                },
-                                "locale": "en-US",
-                                "messages": Object {},
-                                "onError": [Function],
-                                "textComponent": Symbol(react.fragment),
-                                "timeZone": undefined,
-                                "wrapRichTextChunksInFragment": undefined,
-                              }
-                            }
-                            type="refresh"
-                            withSpace={true}
+                            fixedWidth={true}
+                            name="refresh"
                           >
-                            <Styled(FontAwesome)
+                            <FontAwesome
                               aria-label=""
-                              className="fa-spin"
+                              className="sc-gsTEea iqivwV fa-spin"
                               fixedWidth={true}
                               name="refresh"
                             >
-                              <FontAwesome
+                              <span
+                                aria-hidden={true}
                                 aria-label=""
-                                className="sc-gsTEea iqivwV fa-spin"
-                                fixedWidth={true}
-                                name="refresh"
-                              >
-                                <span
-                                  aria-hidden={true}
-                                  aria-label=""
-                                  className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
-                                />
-                              </FontAwesome>
-                            </Styled(FontAwesome)>
-                          </Icon>
-                        </injectIntl(Icon)>
+                                className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
+                              />
+                            </FontAwesome>
+                          </Styled(FontAwesome)>
+                        </Icon>
                         <FormattedTime
                           timeStyle="short"
                           timeZone="America/Los_Angeles"
@@ -14048,61 +12787,21 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                     onClick={[Function]}
                     type="button"
                   >
-                    <injectIntl(Icon)
+                    <Icon
                       type="arrow-left"
                     >
-                      <Icon
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en-US",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en-US",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
-                            "wrapRichTextChunksInFragment": undefined,
-                          }
-                        }
-                        type="arrow-left"
+                      <FontAwesome
+                        aria-label=""
+                        fixedWidth={true}
+                        name="arrow-left"
                       >
-                        <FontAwesome
+                        <span
+                          aria-hidden={true}
                           aria-label=""
-                          fixedWidth={true}
-                          name="arrow-left"
-                        >
-                          <span
-                            aria-hidden={true}
-                            aria-label=""
-                            className="fa fa-arrow-left fa-fw"
-                          />
-                        </FontAwesome>
-                      </Icon>
-                    </injectIntl(Icon)>
+                          className="fa fa-arrow-left fa-fw"
+                        />
+                      </FontAwesome>
+                    </Icon>
                     <FormattedMessage
                       id="common.forms.back"
                     >
@@ -14153,61 +12852,21 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                     onClick={[Function]}
                     title="components.StopViewer.zoomToStop"
                   >
-                    <injectIntl(Icon)
+                    <Icon
                       type="search"
                     >
-                      <Icon
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en-US",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en-US",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
-                            "wrapRichTextChunksInFragment": undefined,
-                          }
-                        }
-                        type="search"
+                      <FontAwesome
+                        aria-label=""
+                        fixedWidth={true}
+                        name="search"
                       >
-                        <FontAwesome
+                        <span
+                          aria-hidden={true}
                           aria-label=""
-                          fixedWidth={true}
-                          name="search"
-                        >
-                          <span
-                            aria-hidden={true}
-                            aria-label=""
-                            className="fa fa-search fa-fw"
-                          />
-                        </FontAwesome>
-                      </Icon>
-                    </injectIntl(Icon)>
+                          className="fa fa-search fa-fw"
+                        />
+                      </FontAwesome>
+                    </Icon>
                   </button>
                   <button
                     className="link-button pull-right"
@@ -14218,70 +12877,29 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                       }
                     }
                   >
-                    <injectIntl(Icon)
+                    <Icon
                       type="calendar"
                       withSpace={true}
                     >
-                      <Icon
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en-US",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en-US",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
-                            "wrapRichTextChunksInFragment": undefined,
-                          }
-                        }
-                        type="calendar"
-                        withSpace={true}
+                      <Styled(FontAwesome)
+                        aria-label=""
+                        fixedWidth={true}
+                        name="calendar"
                       >
-                        <Styled(FontAwesome)
+                        <FontAwesome
                           aria-label=""
+                          className="sc-gsTEea iqivwV"
                           fixedWidth={true}
                           name="calendar"
                         >
-                          <FontAwesome
+                          <span
+                            aria-hidden={true}
                             aria-label=""
-                            className="sc-gsTEea iqivwV"
-                            fixedWidth={true}
-                            name="calendar"
-                          >
-                            <span
-                              aria-hidden={true}
-                              aria-label=""
-                              className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
-                            />
-                          </FontAwesome>
-                        </Styled(FontAwesome)>
-                      </Icon>
-                    </injectIntl(Icon)>
+                            className="fa fa-calendar fa-fw sc-gsTEea iqivwV"
+                          />
+                        </FontAwesome>
+                      </Styled(FontAwesome)>
+                    </Icon>
                     <FormattedMessage
                       id="components.StopViewer.viewTypeBtnText"
                       values={
@@ -15300,7 +13918,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                     <div
                                       className="pull-left"
                                     >
-                                      <injectIntl(Icon)
+                                      <Icon
                                         style={
                                           Object {
                                             "color": "#888",
@@ -15310,43 +13928,10 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                         }
                                         type="clock-o"
                                       >
-                                        <Icon
-                                          intl={
-                                            Object {
-                                              "defaultFormats": Object {},
-                                              "defaultLocale": "en-US",
-                                              "defaultRichTextElements": undefined,
-                                              "formatDate": [Function],
-                                              "formatDateTimeRange": [Function],
-                                              "formatDateToParts": [Function],
-                                              "formatDisplayName": [Function],
-                                              "formatList": [Function],
-                                              "formatListToParts": [Function],
-                                              "formatMessage": [Function],
-                                              "formatNumber": [Function],
-                                              "formatNumberToParts": [Function],
-                                              "formatPlural": [Function],
-                                              "formatRelativeTime": [Function],
-                                              "formatTime": [Function],
-                                              "formatTimeToParts": [Function],
-                                              "formats": Object {},
-                                              "formatters": Object {
-                                                "getDateTimeFormat": [Function],
-                                                "getDisplayNames": [Function],
-                                                "getListFormat": [Function],
-                                                "getMessageFormat": [Function],
-                                                "getNumberFormat": [Function],
-                                                "getPluralRules": [Function],
-                                                "getRelativeTimeFormat": [Function],
-                                              },
-                                              "locale": "en-US",
-                                              "messages": Object {},
-                                              "onError": [Function],
-                                              "textComponent": Symbol(react.fragment),
-                                              "timeZone": undefined,
-                                              "wrapRichTextChunksInFragment": undefined,
-                                            }
-                                          }
+                                        <FontAwesome
+                                          aria-label=""
+                                          fixedWidth={true}
+                                          name="clock-o"
                                           style={
                                             Object {
                                               "color": "#888",
@@ -15354,12 +13939,11 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                               "marginRight": 2,
                                             }
                                           }
-                                          type="clock-o"
                                         >
-                                          <FontAwesome
+                                          <span
+                                            aria-hidden={true}
                                             aria-label=""
-                                            fixedWidth={true}
-                                            name="clock-o"
+                                            className="fa fa-clock-o fa-fw"
                                             style={
                                               Object {
                                                 "color": "#888",
@@ -15367,22 +13951,9 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                                 "marginRight": 2,
                                               }
                                             }
-                                          >
-                                            <span
-                                              aria-hidden={true}
-                                              aria-label=""
-                                              className="fa fa-clock-o fa-fw"
-                                              style={
-                                                Object {
-                                                  "color": "#888",
-                                                  "fontSize": "0.8em",
-                                                  "marginRight": 2,
-                                                }
-                                              }
-                                            />
-                                          </FontAwesome>
-                                        </Icon>
-                                      </injectIntl(Icon)>
+                                          />
+                                        </FontAwesome>
+                                      </Icon>
                                     </div>
                                     <div
                                       style={
@@ -15435,61 +14006,21 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                   className="expansion-button"
                                   onClick={[Function]}
                                 >
-                                  <injectIntl(Icon)
+                                  <Icon
                                     type="chevron-down"
                                   >
-                                    <Icon
-                                      intl={
-                                        Object {
-                                          "defaultFormats": Object {},
-                                          "defaultLocale": "en-US",
-                                          "defaultRichTextElements": undefined,
-                                          "formatDate": [Function],
-                                          "formatDateTimeRange": [Function],
-                                          "formatDateToParts": [Function],
-                                          "formatDisplayName": [Function],
-                                          "formatList": [Function],
-                                          "formatListToParts": [Function],
-                                          "formatMessage": [Function],
-                                          "formatNumber": [Function],
-                                          "formatNumberToParts": [Function],
-                                          "formatPlural": [Function],
-                                          "formatRelativeTime": [Function],
-                                          "formatTime": [Function],
-                                          "formatTimeToParts": [Function],
-                                          "formats": Object {},
-                                          "formatters": Object {
-                                            "getDateTimeFormat": [Function],
-                                            "getDisplayNames": [Function],
-                                            "getListFormat": [Function],
-                                            "getMessageFormat": [Function],
-                                            "getNumberFormat": [Function],
-                                            "getPluralRules": [Function],
-                                            "getRelativeTimeFormat": [Function],
-                                          },
-                                          "locale": "en-US",
-                                          "messages": Object {},
-                                          "onError": [Function],
-                                          "textComponent": Symbol(react.fragment),
-                                          "timeZone": undefined,
-                                          "wrapRichTextChunksInFragment": undefined,
-                                        }
-                                      }
-                                      type="chevron-down"
+                                    <FontAwesome
+                                      aria-label=""
+                                      fixedWidth={true}
+                                      name="chevron-down"
                                     >
-                                      <FontAwesome
+                                      <span
+                                        aria-hidden={true}
                                         aria-label=""
-                                        fixedWidth={true}
-                                        name="chevron-down"
-                                      >
-                                        <span
-                                          aria-hidden={true}
-                                          aria-label=""
-                                          className="fa fa-chevron-down fa-fw"
-                                        />
-                                      </FontAwesome>
-                                    </Icon>
-                                  </injectIntl(Icon)>
+                                        className="fa fa-chevron-down fa-fw"
+                                      />
+                                    </FontAwesome>
+                                  </Icon>
                                 </button>
                               </div>
                             </div>
@@ -15570,73 +14101,31 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                           }
                         }
                       >
-                        <injectIntl(Icon)
+                        <Icon
                           className="fa-spin"
                           type="refresh"
                           withSpace={true}
                         >
-                          <Icon
+                          <Styled(FontAwesome)
+                            aria-label=""
                             className="fa-spin"
-                            intl={
-                              Object {
-                                "defaultFormats": Object {},
-                                "defaultLocale": "en-US",
-                                "defaultRichTextElements": undefined,
-                                "formatDate": [Function],
-                                "formatDateTimeRange": [Function],
-                                "formatDateToParts": [Function],
-                                "formatDisplayName": [Function],
-                                "formatList": [Function],
-                                "formatListToParts": [Function],
-                                "formatMessage": [Function],
-                                "formatNumber": [Function],
-                                "formatNumberToParts": [Function],
-                                "formatPlural": [Function],
-                                "formatRelativeTime": [Function],
-                                "formatTime": [Function],
-                                "formatTimeToParts": [Function],
-                                "formats": Object {},
-                                "formatters": Object {
-                                  "getDateTimeFormat": [Function],
-                                  "getDisplayNames": [Function],
-                                  "getListFormat": [Function],
-                                  "getMessageFormat": [Function],
-                                  "getNumberFormat": [Function],
-                                  "getPluralRules": [Function],
-                                  "getRelativeTimeFormat": [Function],
-                                },
-                                "locale": "en-US",
-                                "messages": Object {},
-                                "onError": [Function],
-                                "textComponent": Symbol(react.fragment),
-                                "timeZone": undefined,
-                                "wrapRichTextChunksInFragment": undefined,
-                              }
-                            }
-                            type="refresh"
-                            withSpace={true}
+                            fixedWidth={true}
+                            name="refresh"
                           >
-                            <Styled(FontAwesome)
+                            <FontAwesome
                               aria-label=""
-                              className="fa-spin"
+                              className="sc-gsTEea iqivwV fa-spin"
                               fixedWidth={true}
                               name="refresh"
                             >
-                              <FontAwesome
+                              <span
+                                aria-hidden={true}
                                 aria-label=""
-                                className="sc-gsTEea iqivwV fa-spin"
-                                fixedWidth={true}
-                                name="refresh"
-                              >
-                                <span
-                                  aria-hidden={true}
-                                  aria-label=""
-                                  className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
-                                />
-                              </FontAwesome>
-                            </Styled(FontAwesome)>
-                          </Icon>
-                        </injectIntl(Icon)>
+                                className="fa fa-refresh fa-fw sc-gsTEea iqivwV fa-spin"
+                              />
+                            </FontAwesome>
+                          </Styled(FontAwesome)>
+                        </Icon>
                         <FormattedTime
                           timeStyle="short"
                           timeZone="America/Los_Angeles"
@@ -17630,61 +16119,21 @@ exports[`components > viewers > stop viewer should render with initial stop id a
                     onClick={[Function]}
                     type="button"
                   >
-                    <injectIntl(Icon)
+                    <Icon
                       type="arrow-left"
                     >
-                      <Icon
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en-US",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en-US",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
-                            "wrapRichTextChunksInFragment": undefined,
-                          }
-                        }
-                        type="arrow-left"
+                      <FontAwesome
+                        aria-label=""
+                        fixedWidth={true}
+                        name="arrow-left"
                       >
-                        <FontAwesome
+                        <span
+                          aria-hidden={true}
                           aria-label=""
-                          fixedWidth={true}
-                          name="arrow-left"
-                        >
-                          <span
-                            aria-hidden={true}
-                            aria-label=""
-                            className="fa fa-arrow-left fa-fw"
-                          />
-                        </FontAwesome>
-                      </Icon>
-                    </injectIntl(Icon)>
+                          className="fa fa-arrow-left fa-fw"
+                        />
+                      </FontAwesome>
+                    </Icon>
                     <FormattedMessage
                       id="common.forms.back"
                     >

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -456,6 +456,7 @@ components:
     hideSettings: " Hide Settings"
   TabbedItineraries:
     optionNumber: "Option {optionNum, number}"
+    optionDetails: "Itinerary details"
     # Note to translator: This text is width-constrained.
     mustCallAhead: Must call ahead!
     fareCost: >
@@ -593,6 +594,7 @@ components:
   TripViewer:
     accessible: Accessible
     bicyclesAllowed: Allowed
+    description: Trip Viewer showing all stops and stop times on route with stops served in trip itinerary highlighted
     header: Trip Viewer
     routeHeader: "Route: <strong>{routeShortName}</strong> {routeLongName}"
     viewStop: View

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -594,7 +594,7 @@ components:
   TripViewer:
     accessible: Accessible
     bicyclesAllowed: Allowed
-    description: Trip Viewer showing all stops and stop times on route with stops served in trip itinerary highlighted
+    description: The Trip Viewer highlights the subset of stops and stop times of a transit route traveled on the itinerary you selected.
     header: Trip Viewer
     routeHeader: "Route: <strong>{routeShortName}</strong> {routeLongName}"
     viewStop: View

--- a/lib/components/app/app-menu.tsx
+++ b/lib/components/app/app-menu.tsx
@@ -185,6 +185,7 @@ class AppMenu extends Component<
               ? intl.formatMessage({ id: 'components.AppMenu.closeMenu' })
               : intl.formatMessage({ id: 'components.AppMenu.openMenu' })
           }
+          aria-roledescription="button"
           className="app-menu-icon"
           onClick={this._togglePane}
           onKeyDown={this._togglePane}

--- a/lib/components/app/app-menu.tsx
+++ b/lib/components/app/app-menu.tsx
@@ -180,6 +180,7 @@ class AppMenu extends Component<
     return (
       <>
         <div
+          aria-expanded={isPaneOpen}
           aria-label={
             isPaneOpen
               ? intl.formatMessage({ id: 'components.AppMenu.closeMenu' })

--- a/lib/components/narrative/tabbed-itineraries.js
+++ b/lib/components/narrative/tabbed-itineraries.js
@@ -89,11 +89,11 @@ class TabButton extends Component {
     )
     return (
       <Button
-        aria-selected={isActive}
         ariaRole="tab"
         className={classNames.join(' ')}
         key={`tab-button-${index}`}
         onClick={this._onClick}
+        tabIndex={isActive ? '0' : '-1'}
       >
         <span className="title">
           {mustCallAhead && (

--- a/lib/components/narrative/tabbed-itineraries.js
+++ b/lib/components/narrative/tabbed-itineraries.js
@@ -90,6 +90,7 @@ class TabButton extends Component {
     return (
       <Button
         aria-selected={isActive}
+        ariaRole="tab"
         className={classNames.join(' ')}
         key={`tab-button-${index}`}
         onClick={this._onClick}

--- a/lib/components/narrative/tabbed-itineraries.js
+++ b/lib/components/narrative/tabbed-itineraries.js
@@ -2,7 +2,7 @@
 /* eslint-disable react/prop-types */
 import { Button } from 'react-bootstrap'
 import { connect } from 'react-redux'
-import { FormattedMessage, FormattedNumber } from 'react-intl'
+import { FormattedMessage, FormattedNumber, injectIntl } from 'react-intl'
 import coreUtils from '@opentripplanner/core-utils'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
@@ -40,7 +40,8 @@ class TabButton extends Component {
   }
 
   render() {
-    const { currency, defaultFareKey, index, isActive, itinerary } = this.props
+    const { currency, defaultFareKey, index, intl, isActive, itinerary } =
+      this.props
     const timezoneOffset = getTimeZoneOffset(itinerary)
     const classNames = ['tab-button', 'clear-button-formatting']
     const { caloriesBurned } = calculatePhysicalActivity(itinerary)
@@ -88,6 +89,7 @@ class TabButton extends Component {
     )
     return (
       <Button
+        aria-selected={isActive}
         className={classNames.join(' ')}
         key={`tab-button-${index}`}
         onClick={this._onClick}
@@ -101,7 +103,12 @@ class TabButton extends Component {
             values={{ optionNum: index + 1 }}
           />
         </span>
-        <span className="details">
+        <span
+          aria-label={intl.formatMessage({
+            id: 'components.TabbedItineraries.optionDetails'
+          })}
+          className="details"
+        >
           {mustCallAhead && (
             <span style={{ color: FLEX_COLOR }}>
               <FormattedMessage id="components.TabbedItineraries.mustCallAhead" />
@@ -188,6 +195,7 @@ class TabbedItineraries extends Component {
       currency,
       defaultFareKey,
       error,
+      intl,
       itineraries,
       realtimeEffects,
       setActiveItinerary,
@@ -212,6 +220,7 @@ class TabbedItineraries extends Component {
                 currency={currency}
                 defaultFareKey={defaultFareKey}
                 index={index}
+                intl={intl}
                 isActive={index === activeItinerary}
                 itinerary={itinerary}
                 key={index}
@@ -281,4 +290,7 @@ const mapDispatchToProps = (dispatch) => {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(TabbedItineraries)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(injectIntl(TabbedItineraries))

--- a/lib/components/util/icon.tsx
+++ b/lib/components/util/icon.tsx
@@ -1,10 +1,14 @@
+import { injectIntl, IntlShape, WithIntlProps } from 'react-intl'
 import FontAwesome from 'react-fontawesome'
 import React from 'react'
 import styled from 'styled-components'
 
+import { getFormattedMode } from '../../util/i18n'
+
 export type IconProps = {
   className?: string
   fixedWidth?: boolean
+  intl: IntlShape
   style?: Record<string, unknown>
   type: string
   withSpace?: boolean
@@ -28,12 +32,20 @@ const FontAwesomeWithSpace = styled(FontAwesome)`
  */
 const Icon = ({
   fixedWidth = true,
+  intl,
   type,
   withSpace = false,
   ...props
 }: IconProps): JSX.Element => {
   const FontComponent = withSpace ? FontAwesomeWithSpace : FontAwesome
-  return <FontComponent fixedWidth={fixedWidth} name={type} {...props} />
+  return (
+    <FontComponent
+      aria-label={getFormattedMode(type, intl)}
+      fixedWidth={fixedWidth}
+      name={type}
+      {...props}
+    />
+  )
 }
 
-export default Icon
+export default injectIntl(Icon)

--- a/lib/components/util/icon.tsx
+++ b/lib/components/util/icon.tsx
@@ -1,4 +1,4 @@
-import { injectIntl, IntlShape } from 'react-intl'
+import { IntlShape } from 'react-intl'
 import FontAwesome from 'react-fontawesome'
 import React from 'react'
 import styled from 'styled-components'
@@ -8,6 +8,7 @@ import { getFormattedMode } from '../../util/i18n'
 export type IconProps = {
   className?: string
   fixedWidth?: boolean
+  intl?: IntlShape
   style?: Record<string, unknown>
   type: string
   withSpace?: boolean
@@ -35,11 +36,11 @@ const Icon = ({
   type,
   withSpace = false,
   ...props
-}: IconProps & { intl: IntlShape }): JSX.Element => {
+}: IconProps): JSX.Element => {
   const FontComponent = withSpace ? FontAwesomeWithSpace : FontAwesome
   return (
     <FontComponent
-      aria-label={getFormattedMode(type, intl, true)}
+      aria-label={intl ? getFormattedMode(type, intl, true) : ''}
       fixedWidth={fixedWidth}
       name={type}
       {...props}
@@ -47,4 +48,4 @@ const Icon = ({
   )
 }
 
-export default injectIntl(Icon)
+export default Icon

--- a/lib/components/util/icon.tsx
+++ b/lib/components/util/icon.tsx
@@ -1,4 +1,4 @@
-import { injectIntl, IntlShape, WithIntlProps } from 'react-intl'
+import { injectIntl, IntlShape } from 'react-intl'
 import FontAwesome from 'react-fontawesome'
 import React from 'react'
 import styled from 'styled-components'
@@ -8,7 +8,6 @@ import { getFormattedMode } from '../../util/i18n'
 export type IconProps = {
   className?: string
   fixedWidth?: boolean
-  intl: IntlShape
   style?: Record<string, unknown>
   type: string
   withSpace?: boolean
@@ -36,7 +35,7 @@ const Icon = ({
   type,
   withSpace = false,
   ...props
-}: IconProps): JSX.Element => {
+}: IconProps & { intl: IntlShape }): JSX.Element => {
   const FontComponent = withSpace ? FontAwesomeWithSpace : FontAwesome
   return (
     <FontComponent

--- a/lib/components/util/icon.tsx
+++ b/lib/components/util/icon.tsx
@@ -40,7 +40,7 @@ const Icon = ({
   const FontComponent = withSpace ? FontAwesomeWithSpace : FontAwesome
   return (
     <FontComponent
-      aria-label={getFormattedMode(type, intl)}
+      aria-label={getFormattedMode(type, intl, true)}
       fixedWidth={fixedWidth}
       name={type}
       {...props}

--- a/lib/components/viewers/trip-viewer.js
+++ b/lib/components/viewers/trip-viewer.js
@@ -2,7 +2,7 @@
 /* eslint-disable jsx-a11y/label-has-for */
 import { Button, Label } from 'react-bootstrap'
 import { connect } from 'react-redux'
-import { FormattedMessage, FormattedTime } from 'react-intl'
+import { FormattedMessage, FormattedTime, injectIntl } from 'react-intl'
 import coreUtils from '@opentripplanner/core-utils'
 import moment from 'moment'
 import PropTypes from 'prop-types'
@@ -23,6 +23,7 @@ class TripViewer extends Component {
   static propTypes = {
     findTrip: apiActions.findTrip.type,
     hideBackButton: PropTypes.bool,
+    intl: PropTypes.object,
     setViewedTrip: uiActions.setViewedTrip.type,
     tripData: PropTypes.object,
     viewedTrip: PropTypes.object
@@ -39,7 +40,7 @@ class TripViewer extends Component {
   }
 
   render() {
-    const { hideBackButton, tripData, viewedTrip } = this.props
+    const { hideBackButton, intl, tripData, viewedTrip } = this.props
 
     return (
       <div className="trip-viewer">
@@ -62,7 +63,12 @@ class TripViewer extends Component {
           <div style={{ clear: 'both' }} />
         </div>
 
-        <div className="trip-viewer-body">
+        <div
+          aria-label={intl.formatMessage({
+            id: 'components.TripViewer.description'
+          })}
+          className="trip-viewer-body"
+        >
           {/* Basic Trip Info */}
           {tripData && (
             <div>
@@ -184,4 +190,7 @@ const mapDispatchToProps = {
   setViewedTrip: uiActions.setViewedTrip
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(TripViewer)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(injectIntl(TripViewer))

--- a/lib/components/viewers/trip-viewer.js
+++ b/lib/components/viewers/trip-viewer.js
@@ -97,7 +97,7 @@ class TripViewer extends Component {
                 <SpanWithSpace margin={0.25} />
                 {tripData.bikesAllowed === 1 && (
                   <Label bsStyle="success">
-                    <Icon type="bicycle" withSpace />
+                    <Icon intl={intl} type="bicycle" withSpace />
                     <FormattedMessage id="components.TripViewer.bicyclesAllowed" />
                   </Label>
                 )}

--- a/lib/util/i18n.js
+++ b/lib/util/i18n.js
@@ -159,7 +159,7 @@ export function getTimeFormat(state) {
  * such that i18n IDs are hardcoded and can be kept track of by format.js CLI tools
  */
 // eslint-disable-next-line complexity
-export function getFormattedMode(mode, intl) {
+export function getFormattedMode(mode, intl, allowBlank = false) {
   switch (mode?.toLowerCase()) {
     case 'bicycle':
       return intl.formatMessage({ id: 'common.modes.bike' })
@@ -204,7 +204,7 @@ export function getFormattedMode(mode, intl) {
       return intl.formatMessage({ id: 'common.modes.walk' })
     default:
       console.warn(`Mode ${mode} does not have a corresponding translation.`)
-      return mode
+      return allowBlank ? '' : mode
   }
 }
 


### PR DESCRIPTION
Some elements had issues with screen readers. This PR addresses these by adding relevant aria tags.

### TODO
- [ ] bikes allowed label must be labeled in its entirety and then the children `labelledby`
- [ ] the app-menu-icon should become a button, and then styled appropriately (don't forget that the lines will need a `width: 100%`)
- [ ] app menu is described strangely