### PR TITLE
Localize overlay names

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -220,7 +220,7 @@ components:
   MainMobile:
     invalidScreen: Invalid mobile screen
   MapLayers:
-    bike-rental: "{conpanies} Shared Bikes"
+    bike-rental: "{companies} Shared Bikes"
     car-rental: Rental Car Locations
     micromobility-rental: "{companies} E-Scooters"
     park-and-ride: Park & Ride Locations

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -219,6 +219,14 @@ components:
     setOrigin: Set Origin
   MainMobile:
     invalidScreen: Invalid mobile screen
+  MapLayers:
+    bike-rental: Bikeshare Locations
+    car-rental: Rental Car Locations
+    micromobility-rental: E-Scooter Locations
+    park-and-ride: Park & Ride Locations
+    satellite: Satellite
+    stops: Transit Stops
+    streets: Streets    
   MobileOptions:
     header: Set Search Options
   ModeDropdown:

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -220,9 +220,9 @@ components:
   MainMobile:
     invalidScreen: Invalid mobile screen
   MapLayers:
-    bike-rental: Bikeshare Locations
+    bike-rental: "{conpanies} Shared Bikes"
     car-rental: Rental Car Locations
-    micromobility-rental: E-Scooter Locations
+    micromobility-rental: "{companies} E-Scooters"
     park-and-ride: Park & Ride Locations
     satellite: Satellite
     stops: Transit Stops

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -207,6 +207,14 @@ components:
     setOrigin: Choisissez le point de départ
   MainMobile:
     invalidScreen: Écran non valable.
+  MapLayers:
+    bike-rental: Vélos partagés
+    car-rental: Voitures en location
+    micromobility-rental: Trottinettes électriques
+    park-and-ride: Parcs relais
+    satellite: Satellite
+    stops: Arrêts et stations
+    streets: Plan des rues    
   MobileOptions:
     header: Options de recherche
   ModeDropdown:

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -208,9 +208,9 @@ components:
   MainMobile:
     invalidScreen: Écran non valable.
   MapLayers:
-    bike-rental: Vélos partagés
+    bike-rental: Vélos partagés {companies}
     car-rental: Voitures en location
-    micromobility-rental: Trottinettes électriques
+    micromobility-rental: Trottinettes {companies}
     park-and-ride: Parcs relais
     satellite: Satellite
     stops: Arrêts et stations

--- a/lib/components/map/default-map.js
+++ b/lib/components/map/default-map.js
@@ -232,7 +232,7 @@ class DefaultMap extends Component {
       location: [mapPopupLocation.lat, mapPopupLocation.lon]
     }
 
-    const baseLayersWithNames = mapConfig.baseLayers.map((baseLayer) => ({
+    const baseLayersWithNames = mapConfig.baseLayers?.map((baseLayer) => ({
       ...baseLayer,
       name: getLayerName(baseLayer, config, intl)
     }))

--- a/lib/components/map/default-map.js
+++ b/lib/components/map/default-map.js
@@ -47,6 +47,9 @@ const MapContainer = styled.div`
   }
 `
 
+/**
+ * Determines the localized name of a map layer by its type.
+ */
 function getLayerName(type, intl) {
   switch (type) {
     case 'streets':
@@ -65,6 +68,8 @@ function getLayerName(type, intl) {
       return intl.formatMessage({ id: 'components.MapLayers.park-and-ride' })
     case 'stops':
       return intl.formatMessage({ id: 'components.MapLayers.stops' })
+    default:
+      return null
   }
 }
 
@@ -205,79 +210,49 @@ class DefaultMap extends Component {
           <ElevationPointMarker />
 
           {/* The configurable overlays */}
-          {mapConfig.overlays &&
-            // eslint-disable-next-line complexity
-            mapConfig.overlays.map((overlayConfig, k) => {
-              switch (overlayConfig.type) {
-                case 'bike-rental':
-                  return (
-                    <VehicleRentalOverlay
-                      key={k}
-                      {...overlayConfig}
-                      name={
-                        overlayConfig.name ||
-                        getLayerName(overlayConfig.type, intl)
-                      }
-                      refreshVehicles={bikeRentalQuery}
-                      stations={bikeRentalStations}
-                    />
-                  )
-                case 'car-rental':
-                  return (
-                    <VehicleRentalOverlay
-                      key={k}
-                      {...overlayConfig}
-                      name={
-                        overlayConfig.name ||
-                        getLayerName(overlayConfig.type, intl)
-                      }
-                      refreshVehicles={carRentalQuery}
-                      stations={carRentalStations}
-                    />
-                  )
-                case 'park-and-ride':
-                  return (
-                    <ParkAndRideOverlay
-                      key={k}
-                      {...overlayConfig}
-                      name={
-                        overlayConfig.name ||
-                        getLayerName(overlayConfig.type, intl)
-                      }
-                    />
-                  )
-                case 'stops':
-                  return (
-                    <StopsOverlay
-                      key={k}
-                      {...overlayConfig}
-                      name={
-                        overlayConfig.name ||
-                        getLayerName(overlayConfig.type, intl)
-                      }
-                    />
-                  )
-                case 'tile':
-                  return <TileOverlay key={k} {...overlayConfig} />
-                case 'micromobility-rental':
-                  return (
-                    <VehicleRentalOverlay
-                      key={k}
-                      {...overlayConfig}
-                      name={
-                        overlayConfig.name ||
-                        getLayerName(overlayConfig.type, intl)
-                      }
-                      refreshVehicles={vehicleRentalQuery}
-                      stations={vehicleRentalStations}
-                    />
-                  )
-                case 'zipcar':
-                  return <ZipcarOverlay key={k} {...overlayConfig} />
-                default:
-                  return null
-              }
-            })}
+          {mapConfig.overlays?.map((overlayConfig, k) => {
+            const namedLayerProps = {
+              ...overlayConfig,
+              key: k,
+              name: overlayConfig.name || getLayerName(overlayConfig.type, intl)
+            }
+            switch (overlayConfig.type) {
+              case 'bike-rental':
+                return (
+                  <VehicleRentalOverlay
+                    {...namedLayerProps}
+                    refreshVehicles={bikeRentalQuery}
+                    stations={bikeRentalStations}
+                  />
+                )
+              case 'car-rental':
+                return (
+                  <VehicleRentalOverlay
+                    {...namedLayerProps}
+                    refreshVehicles={carRentalQuery}
+                    stations={carRentalStations}
+                  />
+                )
+              case 'park-and-ride':
+                return <ParkAndRideOverlay {...namedLayerProps} />
+              case 'stops':
+                return <StopsOverlay {...namedLayerProps} />
+              case 'tile':
+                return <TileOverlay key={k} {...overlayConfig} />
+              case 'micromobility-rental':
+                return (
+                  <VehicleRentalOverlay
+                    {...namedLayerProps}
+                    refreshVehicles={vehicleRentalQuery}
+                    stations={vehicleRentalStations}
+                  />
+                )
+              case 'zipcar':
+                return <ZipcarOverlay key={k} {...overlayConfig} />
+              default:
+                return null
+            }
+          })}
           {/* Render custom overlays, if set. */}
           {typeof getCustomMapOverlays === 'function' && getCustomMapOverlays()}
         </BaseMap>
@@ -288,7 +263,7 @@ class DefaultMap extends Component {
 
 // connect to the redux store
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   const overlays =
     state.otp.config.map && state.otp.config.map.overlays
       ? state.otp.config.map.overlays

--- a/lib/components/map/default-map.js
+++ b/lib/components/map/default-map.js
@@ -63,17 +63,20 @@ function getCompanyNames(companyIds, config, intl) {
  * Determines the localized name of a map layer by its type.
  */
 function getLayerName(overlay, config, intl) {
+  const { companies, name, type } = overlay
+
   // HACK: Support for street/satellite configs that use the name.
-  switch (overlay.name) {
+  switch (name) {
     case 'Streets':
       return intl.formatMessage({ id: 'components.MapLayers.streets' })
     case 'Satellite':
       return intl.formatMessage({ id: 'components.MapLayers.satellite' })
     default:
-    // No action in the default case.
+      if (name) return name
   }
 
-  switch (overlay.type) {
+  // If overlay.name is not specified, use the type to determine the name.
+  switch (type) {
     case 'streets':
       return intl.formatMessage({ id: 'components.MapLayers.streets' })
     case 'satellite':
@@ -82,7 +85,7 @@ function getLayerName(overlay, config, intl) {
       return intl.formatMessage(
         { id: 'components.MapLayers.bike-rental' },
         {
-          companies: getCompanyNames(overlay.companies, config, intl)
+          companies: getCompanyNames(companies, config, intl)
         }
       )
     case 'car-rental':
@@ -93,7 +96,7 @@ function getLayerName(overlay, config, intl) {
           id: 'components.MapLayers.micromobility-rental'
         },
         {
-          companies: getCompanyNames(overlay.companies, config, intl)
+          companies: getCompanyNames(companies, config, intl)
         }
       )
     case 'park-and-ride':
@@ -101,7 +104,8 @@ function getLayerName(overlay, config, intl) {
     case 'stops':
       return intl.formatMessage({ id: 'components.MapLayers.stops' })
     default:
-      return null
+      console.warn(`No name found for overlay type ${type}.`)
+      return type
   }
 }
 
@@ -269,8 +273,7 @@ class DefaultMap extends Component {
             const namedLayerProps = {
               ...overlayConfig,
               key: k,
-              name:
-                overlayConfig.name || getLayerName(overlayConfig, config, intl)
+              name: getLayerName(overlayConfig, config, intl)
             }
             switch (overlayConfig.type) {
               case 'bike-rental':

--- a/lib/components/map/default-map.js
+++ b/lib/components/map/default-map.js
@@ -46,24 +46,45 @@ const MapContainer = styled.div`
     box-sizing: unset;
   }
 `
+/**
+ * Get the configured display names for the specified company ids.
+ */
+function getCompanyNames(companyIds, config, intl) {
+  return intl.formatList(
+    companyIds.map(
+      (id) => config.companies.find((company) => company.id === id)?.label || id
+    ),
+    { type: 'conjunction' }
+  )
+}
 
 /**
  * Determines the localized name of a map layer by its type.
  */
-function getLayerName(type, intl) {
-  switch (type) {
+function getLayerName(overlay, config, intl) {
+  switch (overlay.type) {
     case 'streets':
       return intl.formatMessage({ id: 'components.MapLayers.streets' })
     case 'satellite':
       return intl.formatMessage({ id: 'components.MapLayers.satellite' })
     case 'bike-rental':
-      return intl.formatMessage({ id: 'components.MapLayers.bike-rental' })
+      return intl.formatMessage(
+        { id: 'components.MapLayers.bike-rental' },
+        {
+          companies: getCompanyNames(overlay.companies, config, intl)
+        }
+      )
     case 'car-rental':
       return intl.formatMessage({ id: 'components.MapLayers.car-rental' })
     case 'micromobility-rental':
-      return intl.formatMessage({
-        id: 'components.MapLayers.micromobility-rental'
-      })
+      return intl.formatMessage(
+        {
+          id: 'components.MapLayers.micromobility-rental'
+        },
+        {
+          companies: getCompanyNames(overlay.companies, config, intl)
+        }
+      )
     case 'park-and-ride':
       return intl.formatMessage({ id: 'components.MapLayers.park-and-ride' })
     case 'stops':
@@ -158,6 +179,7 @@ class DefaultMap extends Component {
       bikeRentalStations,
       carRentalQuery,
       carRentalStations,
+      config,
       intl,
       mapConfig,
       mapPopupLocation,
@@ -183,7 +205,7 @@ class DefaultMap extends Component {
 
     const baseLayersWithNames = mapConfig.baseLayers.map((baseLayer) => ({
       ...baseLayer,
-      name: getLayerName(baseLayer.type, intl)
+      name: getLayerName(baseLayer, config, intl)
     }))
 
     return (
@@ -214,7 +236,8 @@ class DefaultMap extends Component {
             const namedLayerProps = {
               ...overlayConfig,
               key: k,
-              name: overlayConfig.name || getLayerName(overlayConfig.type, intl)
+              name:
+                overlayConfig.name || getLayerName(overlayConfig, config, intl)
             }
             switch (overlayConfig.type) {
               case 'bike-rental':
@@ -272,6 +295,7 @@ const mapStateToProps = (state) => {
   return {
     bikeRentalStations: state.otp.overlay.bikeRental.stations,
     carRentalStations: state.otp.overlay.carRental.stations,
+    config: state.otp.config,
     mapConfig: state.otp.config.map,
     mapPopupLocation: state.otp.ui.mapPopupLocation,
     overlays,

--- a/lib/components/map/default-map.js
+++ b/lib/components/map/default-map.js
@@ -112,6 +112,10 @@ class DefaultMap extends Component {
    * Checks whether the modes have changed between old and new queries and
    * whether to update the map overlays accordingly (e.g., to show rental vehicle
    * options on the map).
+   *
+   * Note: This functionality only works for the tabbed interface,
+   * as that UI mode sets the access mode and company in the query params.
+   * TODO: Implement for the batch interface.
    */
   _handleQueryChange = (oldQuery, newQuery) => {
     const { overlays } = this.props

--- a/lib/components/map/default-map.js
+++ b/lib/components/map/default-map.js
@@ -63,6 +63,16 @@ function getCompanyNames(companyIds, config, intl) {
  * Determines the localized name of a map layer by its type.
  */
 function getLayerName(overlay, config, intl) {
+  // HACK: Support for street/satellite configs that use the name.
+  switch (overlay.name) {
+    case 'Streets':
+      return intl.formatMessage({ id: 'components.MapLayers.streets' })
+    case 'Satellite':
+      return intl.formatMessage({ id: 'components.MapLayers.satellite' })
+    default:
+    // No action in the default case.
+  }
+
   switch (overlay.type) {
     case 'streets':
       return intl.formatMessage({ id: 'components.MapLayers.streets' })
@@ -111,7 +121,7 @@ class DefaultMap extends Component {
       const newModes = newQuery.mode.split(',')
       const removed = oldModes.filter((m) => !newModes.includes(m))
       const added = newModes.filter((m) => !oldModes.includes(m))
-      const overlayVisibility = {}
+      const overlayVisibility = []
       for (const oConfig of overlays) {
         if (!oConfig.modes || oConfig.modes.length !== 1) continue
         // TODO: support multi-mode overlays
@@ -127,29 +137,47 @@ class DefaultMap extends Component {
           const overlayCompany = oConfig.companies[0] // TODO: handle multi-company overlays
           if (added.includes(overlayMode)) {
             // Company-based mode was just selected; enable overlay iff overlay's company is active
-            if (newQuery.companies.includes(overlayCompany))
-              overlayVisibility[oConfig.name] = true
+            if (newQuery.companies.includes(overlayCompany)) {
+              overlayVisibility.push({
+                overlay: oConfig,
+                visible: true
+              })
+            }
           } else if (removed.includes(overlayMode)) {
             // Company-based mode was just deselected; disable overlay (regardless of company)
-            overlayVisibility[oConfig.name] = false
+            overlayVisibility.push({
+              overlay: oConfig,
+              visible: false
+            })
           } else if (
             newModes.includes(overlayMode) &&
             oldQuery.companies !== newQuery.companies
           ) {
             // Company-based mode remains selected but companies change
-            overlayVisibility[oConfig.name] =
-              newQuery.companies.includes(overlayCompany)
+            overlayVisibility.push({
+              overlay: oConfig,
+              visible: newQuery.companies.includes(overlayCompany)
+            })
           }
         } else {
           // Default handling for other modes
-          if (added.includes(overlayMode))
-            overlayVisibility[oConfig.name] = true
-          if (removed.includes(overlayMode))
-            overlayVisibility[oConfig.name] = false
+          if (added.includes(overlayMode)) {
+            overlayVisibility.push({
+              overlay: oConfig,
+              visible: true
+            })
+          }
+          if (removed.includes(overlayMode)) {
+            overlayVisibility.push({
+              overlay: oConfig,
+              visible: false
+            })
+          }
         }
       }
+
       // Only trigger update action if there are overlays to update.
-      if (Object.keys(overlayVisibility).length > 0) {
+      if (overlayVisibility.length > 0) {
         this.props.updateOverlayVisibility(overlayVisibility)
       }
     }

--- a/lib/components/map/default-map.js
+++ b/lib/components/map/default-map.js
@@ -1,6 +1,8 @@
+/* eslint-disable react/prop-types */
+import { connect } from 'react-redux'
+import { injectIntl } from 'react-intl'
 import BaseMap from '@opentripplanner/base-map'
 import React, { Component } from 'react'
-import { connect } from 'react-redux'
 import styled from 'styled-components'
 
 import {
@@ -8,27 +10,27 @@ import {
   carRentalQuery,
   vehicleRentalQuery
 } from '../../actions/api'
-import { updateOverlayVisibility } from '../../actions/config'
+import { ComponentContext } from '../../util/contexts'
 import {
   setLocation,
   setMapPopupLocation,
   setMapPopupLocationAndGeocode
 } from '../../actions/map'
-import { ComponentContext } from '../../util/contexts'
+import { updateOverlayVisibility } from '../../actions/config'
 
 import BoundsUpdatingOverlay from './bounds-updating-overlay'
+import ElevationPointMarker from './elevation-point-marker'
 import EndpointsOverlay from './connected-endpoints-overlay'
 import ParkAndRideOverlay from './connected-park-and-ride-overlay'
+import PointPopup from './point-popup'
 import RouteViewerOverlay from './connected-route-viewer-overlay'
-import TransitVehicleOverlay from './connected-transit-vehicle-overlay'
-import StopViewerOverlay from './connected-stop-viewer-overlay'
 import StopsOverlay from './connected-stops-overlay'
+import StopViewerOverlay from './connected-stop-viewer-overlay'
+import TileOverlay from './tile-overlay'
 import TransitiveOverlay from './connected-transitive-overlay'
+import TransitVehicleOverlay from './connected-transit-vehicle-overlay'
 import TripViewerOverlay from './connected-trip-viewer-overlay'
 import VehicleRentalOverlay from './connected-vehicle-rental-overlay'
-import ElevationPointMarker from './elevation-point-marker'
-import PointPopup from './point-popup'
-import TileOverlay from './tile-overlay'
 import ZipcarOverlay from './zipcar-overlay'
 
 const MapContainer = styled.div`
@@ -45,6 +47,27 @@ const MapContainer = styled.div`
   }
 `
 
+function getLayerName(type, intl) {
+  switch (type) {
+    case 'streets':
+      return intl.formatMessage({ id: 'components.MapLayers.streets' })
+    case 'satellite':
+      return intl.formatMessage({ id: 'components.MapLayers.satellite' })
+    case 'bike-rental':
+      return intl.formatMessage({ id: 'components.MapLayers.bike-rental' })
+    case 'car-rental':
+      return intl.formatMessage({ id: 'components.MapLayers.car-rental' })
+    case 'micromobility-rental':
+      return intl.formatMessage({
+        id: 'components.MapLayers.micromobility-rental'
+      })
+    case 'park-and-ride':
+      return intl.formatMessage({ id: 'components.MapLayers.park-and-ride' })
+    case 'stops':
+      return intl.formatMessage({ id: 'components.MapLayers.stops' })
+  }
+}
+
 class DefaultMap extends Component {
   static contextType = ComponentContext
 
@@ -59,8 +82,8 @@ class DefaultMap extends Component {
       // Determine any added/removed modes
       const oldModes = oldQuery.mode.split(',')
       const newModes = newQuery.mode.split(',')
-      const removed = oldModes.filter(m => !newModes.includes(m))
-      const added = newModes.filter(m => !oldModes.includes(m))
+      const removed = oldModes.filter((m) => !newModes.includes(m))
+      const added = newModes.filter((m) => !oldModes.includes(m))
       const overlayVisibility = {}
       for (const oConfig of overlays) {
         if (!oConfig.modes || oConfig.modes.length !== 1) continue
@@ -68,28 +91,34 @@ class DefaultMap extends Component {
         const overlayMode = oConfig.modes[0]
 
         if (
-          (
-            overlayMode === 'CAR_RENT' ||
+          (overlayMode === 'CAR_RENT' ||
             overlayMode === 'CAR_HAIL' ||
-            overlayMode === 'MICROMOBILITY_RENT'
-          ) &&
+            overlayMode === 'MICROMOBILITY_RENT') &&
           oConfig.companies
         ) {
           // Special handling for company-based mode overlays (e.g. carshare, car-hail)
           const overlayCompany = oConfig.companies[0] // TODO: handle multi-company overlays
           if (added.includes(overlayMode)) {
             // Company-based mode was just selected; enable overlay iff overlay's company is active
-            if (newQuery.companies.includes(overlayCompany)) overlayVisibility[oConfig.name] = true
+            if (newQuery.companies.includes(overlayCompany))
+              overlayVisibility[oConfig.name] = true
           } else if (removed.includes(overlayMode)) {
             // Company-based mode was just deselected; disable overlay (regardless of company)
             overlayVisibility[oConfig.name] = false
-          } else if (newModes.includes(overlayMode) && oldQuery.companies !== newQuery.companies) {
+          } else if (
+            newModes.includes(overlayMode) &&
+            oldQuery.companies !== newQuery.companies
+          ) {
             // Company-based mode remains selected but companies change
-            overlayVisibility[oConfig.name] = newQuery.companies.includes(overlayCompany)
+            overlayVisibility[oConfig.name] =
+              newQuery.companies.includes(overlayCompany)
           }
-        } else { // Default handling for other modes
-          if (added.includes(overlayMode)) overlayVisibility[oConfig.name] = true
-          if (removed.includes(overlayMode)) overlayVisibility[oConfig.name] = false
+        } else {
+          // Default handling for other modes
+          if (added.includes(overlayMode))
+            overlayVisibility[oConfig.name] = true
+          if (removed.includes(overlayMode))
+            overlayVisibility[oConfig.name] = false
         }
       }
       // Only trigger update action if there are overlays to update.
@@ -113,17 +142,18 @@ class DefaultMap extends Component {
     setLocation(payload)
   }
 
-  componentDidUpdate (prevProps) {
+  componentDidUpdate(prevProps) {
     // Check if any overlays should be toggled due to mode change
     this._handleQueryChange(prevProps.query, this.props.query)
   }
 
-  render () {
+  render() {
     const {
       bikeRentalQuery,
       bikeRentalStations,
       carRentalQuery,
       carRentalStations,
+      intl,
       mapConfig,
       mapPopupLocation,
       vehicleRentalQuery,
@@ -131,9 +161,10 @@ class DefaultMap extends Component {
     } = this.props
     const { getCustomMapOverlays, getTransitiveRouteLabel } = this.context
 
-    const center = mapConfig && mapConfig.initLat && mapConfig.initLon
-      ? [mapConfig.initLat, mapConfig.initLon]
-      : null
+    const center =
+      mapConfig && mapConfig.initLat && mapConfig.initLon
+        ? [mapConfig.initLat, mapConfig.initLon]
+        : null
 
     const popup = mapPopupLocation && {
       contents: (
@@ -145,10 +176,15 @@ class DefaultMap extends Component {
       location: [mapPopupLocation.lat, mapPopupLocation.lon]
     }
 
+    const baseLayersWithNames = mapConfig.baseLayers.map((baseLayer) => ({
+      ...baseLayer,
+      name: getLayerName(baseLayer.type, intl)
+    }))
+
     return (
       <MapContainer>
         <BaseMap
-          baseLayers={mapConfig.baseLayers}
+          baseLayers={baseLayersWithNames}
           center={center}
           maxZoom={mapConfig.maxZoom}
           onClick={this.onMapClick}
@@ -162,45 +198,86 @@ class DefaultMap extends Component {
           <RouteViewerOverlay />
           <TransitVehicleOverlay />
           <StopViewerOverlay />
-          <TransitiveOverlay getTransitiveRouteLabel={getTransitiveRouteLabel} />
+          <TransitiveOverlay
+            getTransitiveRouteLabel={getTransitiveRouteLabel}
+          />
           <TripViewerOverlay />
           <ElevationPointMarker />
 
           {/* The configurable overlays */}
-          {mapConfig.overlays && mapConfig.overlays.map((overlayConfig, k) => {
-            switch (overlayConfig.type) {
-              case 'bike-rental': return (
-                <VehicleRentalOverlay
-                  key={k}
-                  {...overlayConfig}
-                  refreshVehicles={bikeRentalQuery}
-                  stations={bikeRentalStations}
-                />
-              )
-              case 'car-rental': return (
-                <VehicleRentalOverlay
-                  key={k}
-                  {...overlayConfig}
-                  refreshVehicles={carRentalQuery}
-                  stations={carRentalStations}
-                />
-              )
-              case 'park-and-ride':
-                return <ParkAndRideOverlay key={k} {...overlayConfig} />
-              case 'stops': return <StopsOverlay key={k} {...overlayConfig} />
-              case 'tile': return <TileOverlay key={k} {...overlayConfig} />
-              case 'micromobility-rental': return (
-                <VehicleRentalOverlay
-                  key={k}
-                  {...overlayConfig}
-                  refreshVehicles={vehicleRentalQuery}
-                  stations={vehicleRentalStations}
-                />
-              )
-              case 'zipcar': return <ZipcarOverlay key={k} {...overlayConfig} />
-              default: return null
-            }
-          })}
+          {mapConfig.overlays &&
+            // eslint-disable-next-line complexity
+            mapConfig.overlays.map((overlayConfig, k) => {
+              switch (overlayConfig.type) {
+                case 'bike-rental':
+                  return (
+                    <VehicleRentalOverlay
+                      key={k}
+                      {...overlayConfig}
+                      name={
+                        overlayConfig.name ||
+                        getLayerName(overlayConfig.type, intl)
+                      }
+                      refreshVehicles={bikeRentalQuery}
+                      stations={bikeRentalStations}
+                    />
+                  )
+                case 'car-rental':
+                  return (
+                    <VehicleRentalOverlay
+                      key={k}
+                      {...overlayConfig}
+                      name={
+                        overlayConfig.name ||
+                        getLayerName(overlayConfig.type, intl)
+                      }
+                      refreshVehicles={carRentalQuery}
+                      stations={carRentalStations}
+                    />
+                  )
+                case 'park-and-ride':
+                  return (
+                    <ParkAndRideOverlay
+                      key={k}
+                      {...overlayConfig}
+                      name={
+                        overlayConfig.name ||
+                        getLayerName(overlayConfig.type, intl)
+                      }
+                    />
+                  )
+                case 'stops':
+                  return (
+                    <StopsOverlay
+                      key={k}
+                      {...overlayConfig}
+                      name={
+                        overlayConfig.name ||
+                        getLayerName(overlayConfig.type, intl)
+                      }
+                    />
+                  )
+                case 'tile':
+                  return <TileOverlay key={k} {...overlayConfig} />
+                case 'micromobility-rental':
+                  return (
+                    <VehicleRentalOverlay
+                      key={k}
+                      {...overlayConfig}
+                      name={
+                        overlayConfig.name ||
+                        getLayerName(overlayConfig.type, intl)
+                      }
+                      refreshVehicles={vehicleRentalQuery}
+                      stations={vehicleRentalStations}
+                    />
+                  )
+                case 'zipcar':
+                  return <ZipcarOverlay key={k} {...overlayConfig} />
+                default:
+                  return null
+              }
+            })}
           {/* Render custom overlays, if set. */}
           {typeof getCustomMapOverlays === 'function' && getCustomMapOverlays()}
         </BaseMap>
@@ -212,9 +289,10 @@ class DefaultMap extends Component {
 // connect to the redux store
 
 const mapStateToProps = (state, ownProps) => {
-  const overlays = state.otp.config.map && state.otp.config.map.overlays
-    ? state.otp.config.map.overlays
-    : []
+  const overlays =
+    state.otp.config.map && state.otp.config.map.overlays
+      ? state.otp.config.map.overlays
+      : []
 
   return {
     bikeRentalStations: state.otp.overlay.bikeRental.stations,
@@ -237,4 +315,7 @@ const mapDispatchToProps = {
   vehicleRentalQuery
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DefaultMap)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(injectIntl(DefaultMap))

--- a/lib/components/map/default-map.js
+++ b/lib/components/map/default-map.js
@@ -51,8 +51,9 @@ const MapContainer = styled.div`
  */
 function getCompanyNames(companyIds, config, intl) {
   return intl.formatList(
-    companyIds.map(
-      (id) => config.companies.find((company) => company.id === id)?.label || id
+    (companyIds || []).map(
+      (id) =>
+        config.companies?.find((company) => company.id === id)?.label || id
     ),
     { type: 'conjunction' }
   )

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -939,12 +939,12 @@ function createOtpReducer(config) {
         })
       case 'UPDATE_OVERLAY_VISIBILITY':
         const mapOverlays = clone(state.config.map.overlays)
-        // FIXME: The overlay name can no longer be used as a key
-        // because it is no longer required in config, and it changes with i18n.
         for (const overlayInfo of action.payload) {
           const { overlay: targetOverlay, visible } = overlayInfo
           const targetCompanies = targetOverlay.companies?.join(',')
           const targetModes = targetOverlay.modes?.join(',')
+          // Find overlay to change not by name (name is no longer required in config and changes with i18n),
+          // but by type/companies/modes instead.
           const overlay = mapOverlays.find(
             (o) =>
               o.type === overlayInfo.overlay.type &&

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -939,9 +939,19 @@ function createOtpReducer(config) {
         })
       case 'UPDATE_OVERLAY_VISIBILITY':
         const mapOverlays = clone(state.config.map.overlays)
-        for (const key in action.payload) {
-          const overlay = mapOverlays.find((o) => o.name === key)
-          overlay.visible = action.payload[key]
+        // FIXME: The overlay name can no longer be used as a key
+        // because it is no longer required in config, and it changes with i18n.
+        for (const overlayInfo of action.payload) {
+          const { overlay: targetOverlay, visible } = overlayInfo
+          const targetCompanies = targetOverlay.companies?.join(',')
+          const targetModes = targetOverlay.modes?.join(',')
+          const overlay = mapOverlays.find(
+            (o) =>
+              o.type === overlayInfo.overlay.type &&
+              o.companies?.join(',') === targetCompanies &&
+              o.modes?.join(',') === targetModes
+          )
+          overlay.visible = visible
         }
         return update(state, {
           config: { map: { overlays: { $set: mapOverlays } } }


### PR DESCRIPTION
This PR adds i18n support to overlay names (streets, P/R locations...) under the map layer dropdown menu.

Config-specific (non-i18n) overlay names are still supported using the existing `name` attribute for each overlay.
