### PR TITLE
Localize mode names

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -800,6 +800,12 @@ config:
     car_park: Park & Ride
     micromobility: Transit + Personal scooter
     micromobility_rent: Transit + E-scooter rental
+  bicycleModes:
+    bicycle: Own Bike
+    bicycle_rent: Bikeshare
+  micromobilityModes:
+    micromobility: Own E-scooter
+    micromobility_rent: Rented E-scooter
   # Default values for Flex Indicator (set in configuration as well)
   flex:
     flex-service: Flex Service

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -711,7 +711,7 @@ common:
     car_park: Park and Ride
     drive: Drive
     ferry: Ferry
-    flex: Flexible Routes
+    flex: Flex Routes
     funicular: Funicular
     gondola: Gondola
     micromobility: E-Scooter
@@ -792,8 +792,15 @@ util:
     titleBarStopId: "Stop {stopId}"
     titleBarWithStatus: "{title} | {status}"
 
-# Default values for Flex Indicator (set in configuration as well)
 config:
+  accessModes:
+    bicycle: Transit + Personal bike
+    bicycle_rent: Transit + Bikeshare
+    car_hail: Ride Hail
+    car_park: Park & Ride
+    micromobility: Transit + Personal scooter
+    micromobility_rent: Transit + E-scooter rental
+  # Default values for Flex Indicator (set in configuration as well)
   flex:
     flex-service: Flex Service
     both: See bottom of itinerary for details

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -838,6 +838,12 @@ config:
     car_park: Parc relais
     micromobility: Transports + Trottinnette pers.
     micromobility_rent: Transports + Trottinette partagée
+  bicycleModes:
+    bicycle: Vélo pers.
+    bicycle_rent: Vélo partagé
+  micromobilityModes:
+    micromobility: Trottinnette pers.
+    micromobility_rent: Trottinette partagée
   # Default values for Flex Indicator (set in configuration as well)
   flex:
     flex-service: Service Flex

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -751,9 +751,10 @@ common:
     # The original OTP mode id is CABLE_CAR. Lowercase makes it cable_car.
     cable_car: Tram tiré par câble
     car: Voiture
-    car_park: En voiture + parc relais
+    car_park: Parc relais
     drive: Voiture
     ferry: Ferry
+    flex: Service Flex
     funicular: Funiculaire
     gondola: Téléphérique
     micromobility: En trottinette électrique
@@ -829,8 +830,15 @@ util:
     titleBarStopId: "Arrêt {stopId}"
     titleBarWithStatus: "{title} | {status}"
 
-# Default values for Flex Indicator (set in configuration as well)
 config:
+  accessModes:
+    bicycle: Transports + Vélo personnel
+    bicycle_rent: Transports + Vélo partagé
+    car_hail: Course en voiture
+    car_park: Parc relais
+    micromobility: Transports + Trottinnette pers.
+    micromobility_rent: Transports + Trottinette partagée
+  # Default values for Flex Indicator (set in configuration as well)
   flex:
     flex-service: Service Flex
     both: Plus de détails au bas de l'itinéraire

--- a/lib/components/form/batch-preferences.tsx
+++ b/lib/components/form/batch-preferences.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // import {DropdownSelector} from '@opentripplanner/trip-form'
 import { connect } from 'react-redux'
-import { injectIntl } from 'react-intl'
+import { injectIntl, IntlShape } from 'react-intl'
 import React, { Component } from 'react'
 
 import { ComponentContext } from '../../util/contexts'
@@ -12,6 +12,14 @@ import { setQueryParam } from '../../actions/form'
 import { combinationFilter } from './batch-settings'
 import { defaultModeOptions, Mode } from './mode-buttons'
 import { StyledBatchPreferences } from './batch-styled'
+
+interface Props {
+  config: any
+  intl: IntlShape
+  modeOptions: Mode[]
+  query: any
+  setQueryParam: (newQueryParam: any) => void
+}
 
 // TODO: Central type source
 export type Combination = {
@@ -30,12 +38,7 @@ export const replaceTransitMode =
     return { ...combination, mode }
   }
 
-class BatchPreferences extends Component<{
-  config: any
-  modeOptions: Mode[]
-  query: any
-  setQueryParam: (newQueryParam: any) => void
-}> {
+class BatchPreferences extends Component<Props> {
   static contextType = ComponentContext
 
   /**

--- a/lib/components/form/batch-preferences.tsx
+++ b/lib/components/form/batch-preferences.tsx
@@ -2,9 +2,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // import {DropdownSelector} from '@opentripplanner/trip-form'
 import { connect } from 'react-redux'
+import { injectIntl } from 'react-intl'
 import React, { Component } from 'react'
 
 import { ComponentContext } from '../../util/contexts'
+import { getSupportedModes } from '../../util/i18n'
 import { setQueryParam } from '../../actions/form'
 
 import { combinationFilter } from './batch-settings'
@@ -55,7 +57,7 @@ class BatchPreferences extends Component<{
   }
 
   render() {
-    const { config, query } = this.props
+    const { config, intl, query } = this.props
     const { ModeIcon } = this.context
 
     return (
@@ -66,7 +68,7 @@ class BatchPreferences extends Component<{
             onQueryParamChange={this.onQueryParamChange}
             queryParams={query}
             supportedCompanies={config.companies}
-            supportedModes={config.modes}
+            supportedModes={getSupportedModes(config, intl)}
           />
           {/*
             FIXME: use these instead? They're currently cut off by the short
@@ -145,4 +147,7 @@ const mapDispatchToProps = {
   setQueryParam
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(BatchPreferences)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(injectIntl(BatchPreferences))

--- a/lib/components/form/connected-settings-selector-panel.js
+++ b/lib/components/form/connected-settings-selector-panel.js
@@ -1,9 +1,12 @@
-import React, { Component } from 'react'
+/* eslint-disable react/prop-types */
 import { connect } from 'react-redux'
+import { injectIntl } from 'react-intl'
+import React, { Component } from 'react'
 
-import { setQueryParam } from '../../actions/form'
 import { ComponentContext } from '../../util/contexts'
 import { getShowUserSettings } from '../../util/state'
+import { getSupportedModes } from '../../util/i18n'
+import { setQueryParam } from '../../actions/form'
 
 import { StyledSettingsSelectorPanel } from './styled'
 import UserTripSettings from './user-trip-settings'
@@ -13,18 +16,12 @@ import UserTripSettings from './user-trip-settings'
 class ConnectedSettingsSelectorPanel extends Component {
   static contextType = ComponentContext
 
-  render () {
-    const {
-      config,
-      query,
-      setQueryParam,
-      showUserSettings
-    } = this.props
+  render() {
+    const { config, intl, query, setQueryParam, showUserSettings } = this.props
     const { ModeIcon } = this.context
-
     return (
-      <div className='settings-selector-panel'>
-        <div className='modes-panel'>
+      <div className="settings-selector-panel">
+        <div className="modes-panel">
           {showUserSettings && <UserTripSettings />}
 
           <StyledSettingsSelectorPanel
@@ -32,7 +29,7 @@ class ConnectedSettingsSelectorPanel extends Component {
             onQueryParamChange={setQueryParam}
             queryParams={query}
             supportedCompanies={config.companies}
-            supportedModes={config.modes}
+            supportedModes={getSupportedModes(config, intl)}
           />
         </div>
       </div>
@@ -42,7 +39,7 @@ class ConnectedSettingsSelectorPanel extends Component {
 
 // connect to redux store
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   const { config, currentQuery } = state.otp
   return {
     config,
@@ -55,4 +52,7 @@ const mapDispatchToProps = {
   setQueryParam
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(ConnectedSettingsSelectorPanel)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(injectIntl(ConnectedSettingsSelectorPanel))

--- a/lib/components/util/formatted-mode.js
+++ b/lib/components/util/formatted-mode.js
@@ -35,10 +35,9 @@ const FormattedMode = ({ mode }) => {
     case 'gondola':
       return <FormattedMessage id="common.modes.gondola" />
     case 'micromobility':
-    case 'scooter':
       return <FormattedMessage id="common.modes.micromobility" />
     case 'micromobility_rent':
-    case 'scooter_rent':
+    case 'scooter':
       return <FormattedMessage id="common.modes.micromobility_rent" />
     case 'rail':
       return <FormattedMessage id="common.modes.rail" />

--- a/lib/components/util/formatted-mode.js
+++ b/lib/components/util/formatted-mode.js
@@ -35,8 +35,10 @@ const FormattedMode = ({ mode }) => {
     case 'gondola':
       return <FormattedMessage id="common.modes.gondola" />
     case 'micromobility':
+    case 'scooter':
       return <FormattedMessage id="common.modes.micromobility" />
     case 'micromobility_rent':
+    case 'scooter_rent':
       return <FormattedMessage id="common.modes.micromobility_rent" />
     case 'rail':
       return <FormattedMessage id="common.modes.rail" />

--- a/lib/util/i18n.js
+++ b/lib/util/i18n.js
@@ -1,3 +1,4 @@
+import clone from 'clone'
 import flatten from 'flat'
 
 // deepmerge must be imported via `require`: see https://github.com/TehShrike/deepmerge#include
@@ -209,6 +210,33 @@ export function getFormattedMode(mode, intl) {
 }
 
 /**
+ * Returns a FormattedMessage string for the common mode via the react-intl imperative API
+ * such that i18n IDs are hardcoded and can be kept track of by format.js CLI tools
+ */
+// eslint-disable-next-line complexity
+export function getFormattedConfiguredAccessMode(mode, intl) {
+  switch (mode?.toLowerCase()) {
+    case 'bicycle':
+      return intl.formatMessage({ id: 'config.accessModes.bicycle' })
+    case 'bicycle_rent':
+      // TODO: support company names so this reads e.g. "Transit + BCycle"
+      return intl.formatMessage({ id: 'config.accessModes.bicycle_rent' })
+    case 'car_hail':
+      return intl.formatMessage({ id: 'config.accessModes.car_hail' })
+    case 'car_park':
+      return intl.formatMessage({ id: 'config.accessModes.car_park' })
+    case 'micromobility':
+      return intl.formatMessage({ id: 'config.accessModes.micromobility' })
+    case 'micromobility_rent':
+    case 'scooter_rent':
+      return intl.formatMessage({ id: 'config.accessModes.micromobility_rent' })
+    default:
+      console.warn(`Mode ${mode} does not have a corresponding translation.`)
+      return mode
+  }
+}
+
+/**
  * Returns a FormattedMessage string for the common places messages via the react-intl imperative API
  * such that i18n IDs are hardcoded and can be kept track of by format.js CLI tools
  */
@@ -224,4 +252,22 @@ export function getFormattedPlaces(place, intl) {
     case 'work':
       return intl.formatMessage({ id: 'common.places.work' })
   }
+}
+
+/**
+ * @returns A copy of the configured travel modes with the labels set in the desired locale.
+ */
+export function getSupportedModes(config, intl) {
+  // TODO: (Perf.) Potentially memoize the result (the locale doesn't change often).
+  const supportedModes = clone(config.modes)
+  supportedModes?.transitModes?.forEach((mode) => {
+    if (!mode.label) mode.label = getFormattedMode(mode.mode, intl)
+  })
+  supportedModes?.accessModes?.forEach((mode) => {
+    if (!mode.label) {
+      mode.label = getFormattedConfiguredAccessMode(mode.mode, intl)
+    }
+  })
+
+  return supportedModes
 }

--- a/lib/util/i18n.js
+++ b/lib/util/i18n.js
@@ -188,8 +188,10 @@ export function getFormattedMode(mode, intl) {
     case 'gondola':
       return intl.formatMessage({ id: 'common.modes.gondola' })
     case 'micromobility':
+    case 'scooter':
       return intl.formatMessage({ id: 'common.modes.micromobility' })
     case 'micromobility_rent':
+    case 'scooter_rent':
       return intl.formatMessage({ id: 'common.modes.micromobility_rent' })
     case 'rail':
       return intl.formatMessage({ id: 'common.modes.rail' })
@@ -210,10 +212,9 @@ export function getFormattedMode(mode, intl) {
 }
 
 /**
- * Returns a FormattedMessage string for the common mode via the react-intl imperative API
+ * Returns a FormattedMessage string for the configured access mode via the react-intl imperative API
  * such that i18n IDs are hardcoded and can be kept track of by format.js CLI tools
  */
-// eslint-disable-next-line complexity
 export function getFormattedConfiguredAccessMode(mode, intl) {
   switch (mode?.toLowerCase()) {
     case 'bicycle':
@@ -230,6 +231,36 @@ export function getFormattedConfiguredAccessMode(mode, intl) {
     case 'micromobility_rent':
     case 'scooter_rent':
       return intl.formatMessage({ id: 'config.accessModes.micromobility_rent' })
+    default:
+      console.warn(`Mode ${mode} does not have a corresponding translation.`)
+      return mode
+  }
+}
+
+/**
+ * Returns a FormattedMessage string for the configured bicycle mode via the react-intl imperative API
+ * such that i18n IDs are hardcoded and can be kept track of by format.js CLI tools
+ */
+export function getFormattedConfiguredBicycleOrScooterMode(mode, intl) {
+  switch (mode?.toLowerCase()) {
+    case 'bicycle':
+      return intl.formatMessage({ id: 'config.bicycleModes.bicycle' })
+    case 'bicycle_rent':
+      // This is the generic Bikeshare only.
+      // (If needed, add a separate bicycle mode with the desired label in the config for each rental company.)
+      return intl.formatMessage({ id: 'config.bicycleModes.bicycle_rent' })
+    case 'micromobility':
+    case 'scooter':
+      return intl.formatMessage({
+        id: 'config.micromobilityModes.micromobility'
+      })
+    case 'micromobility_rent':
+    case 'scooter_rent':
+      // This is the generic E-scooter rental only.
+      // (If needed, add a separate micromobility/scooter mode with the desired label in the config for each rental company.)
+      return intl.formatMessage({
+        id: 'config.micromobilityModes.micromobility_rent'
+      })
     default:
       console.warn(`Mode ${mode} does not have a corresponding translation.`)
       return mode
@@ -260,12 +291,24 @@ export function getFormattedPlaces(place, intl) {
 export function getSupportedModes(config, intl) {
   // TODO: (Perf.) Potentially memoize the result (the locale doesn't change often).
   const supportedModes = clone(config.modes)
-  supportedModes?.transitModes?.forEach((mode) => {
+  const { accessModes, bicycleModes, micromobilityModes, transitModes } =
+    supportedModes
+  transitModes?.forEach((mode) => {
     if (!mode.label) mode.label = getFormattedMode(mode.mode, intl)
   })
-  supportedModes?.accessModes?.forEach((mode) => {
+  accessModes?.forEach((mode) => {
     if (!mode.label) {
       mode.label = getFormattedConfiguredAccessMode(mode.mode, intl)
+    }
+  })
+  bicycleModes?.forEach((mode) => {
+    if (!mode.label) {
+      mode.label = getFormattedConfiguredBicycleOrScooterMode(mode.mode, intl)
+    }
+  })
+  micromobilityModes?.forEach((mode) => {
+    if (!mode.label) {
+      mode.label = getFormattedConfiguredBicycleOrScooterMode(mode.mode, intl)
     }
   })
 

--- a/lib/util/i18n.js
+++ b/lib/util/i18n.js
@@ -188,10 +188,9 @@ export function getFormattedMode(mode, intl) {
     case 'gondola':
       return intl.formatMessage({ id: 'common.modes.gondola' })
     case 'micromobility':
-    case 'scooter':
       return intl.formatMessage({ id: 'common.modes.micromobility' })
     case 'micromobility_rent':
-    case 'scooter_rent':
+    case 'scooter':
       return intl.formatMessage({ id: 'common.modes.micromobility_rent' })
     case 'rail':
       return intl.formatMessage({ id: 'common.modes.rail' })
@@ -229,7 +228,7 @@ export function getFormattedConfiguredAccessMode(mode, intl) {
     case 'micromobility':
       return intl.formatMessage({ id: 'config.accessModes.micromobility' })
     case 'micromobility_rent':
-    case 'scooter_rent':
+    case 'scooter':
       return intl.formatMessage({ id: 'config.accessModes.micromobility_rent' })
     default:
       console.warn(`Mode ${mode} does not have a corresponding translation.`)
@@ -250,12 +249,11 @@ export function getFormattedConfiguredBicycleOrScooterMode(mode, intl) {
       // (If needed, add a separate bicycle mode with the desired label in the config for each rental company.)
       return intl.formatMessage({ id: 'config.bicycleModes.bicycle_rent' })
     case 'micromobility':
-    case 'scooter':
       return intl.formatMessage({
         id: 'config.micromobilityModes.micromobility'
       })
     case 'micromobility_rent':
-    case 'scooter_rent':
+    case 'scooter':
       // This is the generic E-scooter rental only.
       // (If needed, add a separate micromobility/scooter mode with the desired label in the config for each rental company.)
       return intl.formatMessage({


### PR DESCRIPTION
This PR adds support for localizing travel mode names (transit modes, bike modes, micromobility).
Existing configs that define a `label` attribute for each travel mode continue to be supported.

Visually, the changes appear for labels in the transit mode selector (under the pinwheel button) and in the itinerary results (If configured accordingly, you can see results such as "Walk/Bike to MARTA Rail", "A pied + MARTA (métro)"... instead of the generic "Walk to Subway" in the title for each result and for the desired language).
