### PR TITLE
Fix from/to picker not populating location-field

### DIFF
--- a/lib/components/map/enhanced-stop-marker.js
+++ b/lib/components/map/enhanced-stop-marker.js
@@ -91,7 +91,11 @@ class EnhancedStopMarker extends Component {
   setLocation(locationType) {
     const { setLocation, stop } = this.props
     const { lat, lon, name } = stop
-    setLocation({ location: { lat, lon, name }, locationType })
+    setLocation({
+      location: { lat, lon, name },
+      locationType,
+      reverseGeocode: false
+    })
   }
 
   render() {

--- a/lib/components/user/places/place-shortcut.js
+++ b/lib/components/user/places/place-shortcut.js
@@ -26,13 +26,13 @@ class PlaceShortcut extends Component {
     const { query, setLocation } = this.props
     // If 'to' not set and 'from' does not match location, set as 'to'.
     if (!query.to && (!query.from || !matchLatLon(location, query.from))) {
-      setLocation({ location, locationType: 'to' })
+      setLocation({ location, locationType: 'to', reverseGeocode: false })
     } else if (
       // Vice versa for setting as 'from'.
       !query.from &&
       !matchLatLon(location, query.to)
     ) {
-      setLocation({ location, locationType: 'from' })
+      setLocation({ location, locationType: 'from', reverseGeocode: false })
     }
   }
 

--- a/lib/components/viewers/stop-viewer.js
+++ b/lib/components/viewers/stop-viewer.js
@@ -64,7 +64,7 @@ class StopViewer extends Component {
       lon: stopData.lon,
       name: stopData.name
     }
-    setLocation({ location, locationType, reverseGeocode: true })
+    setLocation({ location, locationType, reverseGeocode: false })
     this.setState({ popupPosition: null })
   }
 


### PR DESCRIPTION
There were some bugs with the location field not being updated correctly when using the from/to picker in the stop viewer. 

I think this was due to some unnecessary reverse geocoding, which this PR removes.