### PR TITLE
fix(actions/form): Use correct local user default query params

### DIFF
--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -40,8 +40,9 @@ export function resetForm(full = false) {
   return function (dispatch, getState) {
     const state = getState()
     const { transitModes } = state.otp.config.modes
-    if (state.otp.user.defaults) {
-      dispatch(settingQueryParam(state.otp.user.defaults))
+    const defaultLocalQueryParams = state.user.localUser.defaults
+    if (defaultLocalQueryParams) {
+      dispatch(settingQueryParam(defaultLocalQueryParams))
     } else {
       // Get user overrides and apply to default query
       const userOverrides = coreUtils.storage.getItem('defaultQuery', {})

--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -40,9 +40,9 @@ export function resetForm(full = false) {
   return function (dispatch, getState) {
     const state = getState()
     const { transitModes } = state.otp.config.modes
-    const defaultLocalQueryParams = state.user.localUser.defaults
-    if (defaultLocalQueryParams) {
-      dispatch(settingQueryParam(defaultLocalQueryParams))
+    const { defaults: localUserDefaults } = state.user.localUser
+    if (localUserDefaults) {
+      dispatch(settingQueryParam(localUserDefaults))
     } else {
       // Get user overrides and apply to default query
       const userOverrides = coreUtils.storage.getItem('defaultQuery', {})


### PR DESCRIPTION
Fix #619 

This PR removes the last uses of `state.otp.user` and replaces them with `state.user.localUser` introduced by #329.
