### PR TITLE
Render times in agency local time

### DIFF
--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -5285,13 +5285,36 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                       <div
                                         className="percy-hide"
                                       >
-                                        <FormattedTime
-                                          timeStyle="short"
-                                          timeZone="America/Los_Angeles"
-                                          value={1565250660000}
+                                        <DepartureTime
+                                          realTime={true}
+                                          stopTime={
+                                            Object {
+                                              "arrivalDelay": 0,
+                                              "blockId": "2041",
+                                              "departureDelay": 0,
+                                              "headsign": "Gresham TC",
+                                              "realtime": false,
+                                              "realtimeArrival": 89460,
+                                              "realtimeDeparture": 89460,
+                                              "realtimeState": "SCHEDULED",
+                                              "scheduledArrival": 89460,
+                                              "scheduledDeparture": 89460,
+                                              "serviceDay": 1565161200,
+                                              "stopCount": 132,
+                                              "stopId": "TriMet:9860",
+                                              "stopIndex": 38,
+                                              "timepoint": true,
+                                              "tripId": "TriMet:9230375",
+                                            }
+                                          }
                                         >
-                                          12:51 AM
-                                        </FormattedTime>
+                                          <FormattedTime
+                                            timeStyle="short"
+                                            value={2019-08-08T07:51:00.000Z}
+                                          >
+                                            12:51 AM
+                                          </FormattedTime>
+                                        </DepartureTime>
                                       </div>
                                     </div>
                                   </div>
@@ -8440,13 +8463,36 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                       <div
                                         className="percy-hide"
                                       >
-                                        <FormattedTime
-                                          timeStyle="short"
-                                          timeZone="America/Los_Angeles"
-                                          value={1565053259000}
+                                        <DepartureTime
+                                          realTime={true}
+                                          stopTime={
+                                            Object {
+                                              "arrivalDelay": 0,
+                                              "blockId": "2045",
+                                              "departureDelay": 0,
+                                              "headsign": "Gresham TC",
+                                              "realtime": false,
+                                              "realtimeArrival": 64859,
+                                              "realtimeDeparture": 64859,
+                                              "realtimeState": "SCHEDULED",
+                                              "scheduledArrival": 64859,
+                                              "scheduledDeparture": 64859,
+                                              "serviceDay": 1564988400,
+                                              "stopCount": 132,
+                                              "stopId": "TriMet:715",
+                                              "stopIndex": 42,
+                                              "timepoint": false,
+                                              "tripId": "TriMet:9230358",
+                                            }
+                                          }
                                         >
-                                          6:00 PM
-                                        </FormattedTime>
+                                          <FormattedTime
+                                            timeStyle="short"
+                                            value={2019-08-06T01:00:59.000Z}
+                                          >
+                                            6:00 PM
+                                          </FormattedTime>
+                                        </DepartureTime>
                                       </div>
                                     </div>
                                   </div>
@@ -8839,13 +8885,36 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                       <div
                                         className="percy-hide"
                                       >
-                                        <FormattedTime
-                                          timeStyle="short"
-                                          timeZone="America/Los_Angeles"
-                                          value={1565133060000}
+                                        <DepartureTime
+                                          realTime={true}
+                                          stopTime={
+                                            Object {
+                                              "arrivalDelay": 0,
+                                              "blockId": "3668",
+                                              "departureDelay": 0,
+                                              "headsign": "Tualatin Park & Ride",
+                                              "realtime": false,
+                                              "realtimeArrival": 58260,
+                                              "realtimeDeparture": 58260,
+                                              "realtimeState": "SCHEDULED",
+                                              "scheduledArrival": 58260,
+                                              "scheduledDeparture": 58260,
+                                              "serviceDay": 1565074800,
+                                              "stopCount": 63,
+                                              "stopId": "TriMet:715",
+                                              "stopIndex": 0,
+                                              "timepoint": true,
+                                              "tripId": "TriMet:9231858",
+                                            }
+                                          }
                                         >
-                                          4:11 PM
-                                        </FormattedTime>
+                                          <FormattedTime
+                                            timeStyle="short"
+                                            value={2019-08-06T23:11:00.000Z}
+                                          >
+                                            4:11 PM
+                                          </FormattedTime>
+                                        </DepartureTime>
                                       </div>
                                     </div>
                                   </div>
@@ -9238,13 +9307,36 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                       <div
                                         className="percy-hide"
                                       >
-                                        <FormattedTime
-                                          timeStyle="short"
-                                          timeZone="America/Los_Angeles"
-                                          value={1565130120000}
+                                        <DepartureTime
+                                          realTime={true}
+                                          stopTime={
+                                            Object {
+                                              "arrivalDelay": 0,
+                                              "blockId": "9472",
+                                              "departureDelay": 0,
+                                              "headsign": "King City",
+                                              "realtime": false,
+                                              "realtimeArrival": 55320,
+                                              "realtimeDeparture": 55320,
+                                              "realtimeState": "SCHEDULED",
+                                              "scheduledArrival": 55320,
+                                              "scheduledDeparture": 55320,
+                                              "serviceDay": 1565074800,
+                                              "stopCount": 23,
+                                              "stopId": "TriMet:715",
+                                              "stopIndex": 0,
+                                              "timepoint": true,
+                                              "tripId": "TriMet:9238192",
+                                            }
+                                          }
                                         >
-                                          3:22 PM
-                                        </FormattedTime>
+                                          <FormattedTime
+                                            timeStyle="short"
+                                            value={2019-08-06T22:22:00.000Z}
+                                          >
+                                            3:22 PM
+                                          </FormattedTime>
+                                        </DepartureTime>
                                       </div>
                                     </div>
                                   </div>
@@ -9745,13 +9837,36 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                       <div
                                         className="percy-hide"
                                       >
-                                        <FormattedTime
-                                          timeStyle="short"
-                                          timeZone="America/Los_Angeles"
-                                          value={1565126880000}
+                                        <DepartureTime
+                                          realTime={true}
+                                          stopTime={
+                                            Object {
+                                              "arrivalDelay": 0,
+                                              "blockId": "9468",
+                                              "departureDelay": 0,
+                                              "headsign": "Sherwood",
+                                              "realtime": false,
+                                              "realtimeArrival": 52080,
+                                              "realtimeDeparture": 52080,
+                                              "realtimeState": "SCHEDULED",
+                                              "scheduledArrival": 52080,
+                                              "scheduledDeparture": 52080,
+                                              "serviceDay": 1565074800,
+                                              "stopCount": 40,
+                                              "stopId": "TriMet:715",
+                                              "stopIndex": 0,
+                                              "timepoint": true,
+                                              "tripId": "TriMet:9238187",
+                                            }
+                                          }
                                         >
-                                          2:28 PM
-                                        </FormattedTime>
+                                          <FormattedTime
+                                            timeStyle="short"
+                                            value={2019-08-06T21:28:00.000Z}
+                                          >
+                                            2:28 PM
+                                          </FormattedTime>
+                                        </DepartureTime>
                                       </div>
                                     </div>
                                   </div>
@@ -13921,13 +14036,36 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                       <div
                                         className="percy-hide"
                                       >
-                                        <FormattedTime
-                                          timeStyle="short"
-                                          timeZone="America/Los_Angeles"
-                                          value={1565052359000}
+                                        <DepartureTime
+                                          realTime={true}
+                                          stopTime={
+                                            Object {
+                                              "arrivalDelay": 0,
+                                              "blockId": "2067",
+                                              "departureDelay": 0,
+                                              "headsign": "Gresham TC",
+                                              "realtime": false,
+                                              "realtimeArrival": 63959,
+                                              "realtimeDeparture": 63959,
+                                              "realtimeState": "SCHEDULED",
+                                              "scheduledArrival": 63959,
+                                              "scheduledDeparture": 63959,
+                                              "serviceDay": 1564988400,
+                                              "stopCount": 132,
+                                              "stopId": "TriMet:715",
+                                              "stopIndex": 42,
+                                              "timepoint": false,
+                                              "tripId": "TriMet:9230357",
+                                            }
+                                          }
                                         >
-                                          5:45 PM
-                                        </FormattedTime>
+                                          <FormattedTime
+                                            timeStyle="short"
+                                            value={2019-08-06T00:45:59.000Z}
+                                          >
+                                            5:45 PM
+                                          </FormattedTime>
+                                        </DepartureTime>
                                       </div>
                                     </div>
                                   </div>

--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -4,7 +4,6 @@ import { createAction } from 'redux-actions'
 import coreUtils from '@opentripplanner/core-utils'
 import debounce from 'lodash.debounce'
 import isEqual from 'lodash.isequal'
-import moment from 'moment'
 import qs from 'qs'
 
 import { queryIsValid } from '../util/state'
@@ -127,13 +126,13 @@ export function formChanged(oldQuery, newQuery) {
   return function (dispatch, getState) {
     const state = getState()
     const { config, currentQuery, ui } = state.otp
-    const { autoPlan, debouncePlanTimeMs } = config
+    const { autoPlan, debouncePlanTimeMs, homeTimezone } = config
     const isMobile = coreUtils.ui.isMobile()
     const { fromChanged, oneLocationChanged, shouldReplanTrip, toChanged } =
       checkShouldReplanTrip(autoPlan, isMobile, oldQuery, newQuery)
     // If departArrive is set to 'NOW', update the query time to current
     if (currentQuery.departArrive === 'NOW') {
-      const now = moment().format(coreUtils.time.OTP_API_TIME_FORMAT)
+      const now = coreUtils.time.getCurrentTime(homeTimezone)
       dispatch(settingQueryParam({ time: now }))
     }
     // Only clear the main panel if a single location changed. This prevents

--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -313,6 +313,7 @@ class RouterWrapperWithAuth0 extends Component {
       auth0Config,
       components,
       defaultLocale,
+      homeTimezone,
       locale,
       localizedMessages,
       processSignIn,
@@ -328,6 +329,7 @@ class RouterWrapperWithAuth0 extends Component {
           defaultLocale={defaultLocale}
           locale={locale || defaultLocale}
           messages={localizedMessages}
+          timeZone={homeTimezone}
         >
           <ConnectedRouter
             basename={routerConfig && routerConfig.basename}
@@ -387,10 +389,11 @@ class RouterWrapperWithAuth0 extends Component {
 }
 
 const mapStateToWrapperProps = (state) => {
-  const { persistence, reactRouter } = state.otp.config
+  const { homeTimezone, persistence, reactRouter } = state.otp.config
   return {
     auth0Config: getAuth0Config(persistence),
     defaultLocale: getDefaultLocale(state.otp.config, state.user.loggedInUser),
+    homeTimezone,
     locale: state.otp.ui.locale,
     localizedMessages: state.otp.ui.localizedMessages,
     routerConfig: reactRouter

--- a/lib/components/form/date-time-modal.js
+++ b/lib/components/form/date-time-modal.js
@@ -24,7 +24,7 @@ class DateTimeModal extends Component {
       time,
       timeFormatLegacy
     } = this.props
-    const { isTouchScreenOnDesktop } = config
+    const { homeTimezone, isTouchScreenOnDesktop } = config
     const touchClassName = isTouchScreenOnDesktop
       ? 'with-desktop-touchscreen'
       : ''
@@ -35,6 +35,7 @@ class DateTimeModal extends Component {
           <StyledDateTimeSelector
             className={`date-time-selector ${touchClassName}`}
             date={date}
+            dateFormatLegacy={dateFormatLegacy}
             departArrive={departArrive}
             onQueryParamChange={setQueryParam}
             time={time}
@@ -44,8 +45,8 @@ class DateTimeModal extends Component {
             // where `<input type="time|date">` already
             // formats the time|date according to the OS settings.
             // eslint-disable-next-line react/jsx-sort-props
-            dateFormatLegacy={dateFormatLegacy}
             timeFormatLegacy={timeFormatLegacy}
+            timeZone={homeTimezone}
           />
         </div>
       </div>

--- a/lib/components/form/date-time-preview.js
+++ b/lib/components/form/date-time-preview.js
@@ -4,8 +4,7 @@
 import { Button } from 'react-bootstrap'
 import { connect } from 'react-redux'
 import { injectIntl } from 'react-intl'
-import coreUtils from '@opentripplanner/core-utils'
-import moment from 'moment'
+import { toDate } from 'date-fns-tz'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
@@ -13,13 +12,13 @@ import FormattedCalendarString from '../util/formatted-calendar-string'
 import FormattedDateTimePreview from '../util/formatted-date-time-preview'
 import Icon from '../util/icon'
 
-const { getDateFormat, getTimeFormat, OTP_API_TIME_FORMAT } = coreUtils.time
-
 class DateTimePreview extends Component {
   static propTypes = {
     caret: PropTypes.string,
     className: PropTypes.string,
+    // FIXME: remove unused prop or implement prop passed from containing components.
     compressed: PropTypes.bool,
+    config: PropTypes.object,
     date: PropTypes.string,
     departArrive: PropTypes.string,
     editButtonText: PropTypes.element,
@@ -41,6 +40,7 @@ class DateTimePreview extends Component {
     const {
       caret,
       className,
+      config,
       date,
       departArrive,
       editButtonText,
@@ -53,9 +53,12 @@ class DateTimePreview extends Component {
       time
     } = this.props
 
-    const formattedTime = moment(time, OTP_API_TIME_FORMAT).valueOf()
-    const formattedEndTime = moment(endTime, OTP_API_TIME_FORMAT).valueOf()
-    const formattedStartTime = moment(startTime, OTP_API_TIME_FORMAT).valueOf()
+    const { homeTimezone: timeZone } = config
+    const toTimestamp = (t) => toDate(`${date} ${t}`, { timeZone }).valueOf()
+
+    const timestamp = toTimestamp(time)
+    const endTimestamp = toTimestamp(endTime)
+    const startTimestamp = toTimestamp(startTime)
 
     const summary = (
       <div className="summary">
@@ -65,10 +68,10 @@ class DateTimePreview extends Component {
         <Icon className="fa fa-clock-o" type="clock" withSpace />
         <FormattedDateTimePreview
           departArrive={departArrive}
-          endTime={formattedEndTime}
+          endTime={endTimestamp}
           routingType={routingType}
-          startTime={formattedStartTime}
-          time={formattedTime}
+          startTime={startTimestamp}
+          time={timestamp}
         />
       </div>
     )
@@ -102,20 +105,18 @@ class DateTimePreview extends Component {
   }
 }
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   const { date, departArrive, endTime, routingType, startTime, time } =
     state.otp.currentQuery
   const config = state.otp.config
   return {
     config,
     date,
-    dateFormat: getDateFormat(config),
     departArrive,
     endTime,
     routingType,
     startTime,
-    time,
-    timeFormat: getTimeFormat(config)
+    time
   }
 }
 

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -108,9 +108,7 @@ const ITINERARY_ATTRIBUTES = [
     alias: 'best',
     id: 'duration',
     order: 0,
-    render: (itinerary /*, options */) => (
-      <FormattedDuration duration={itinerary.duration} />
-    )
+    render: (itinerary) => <FormattedDuration duration={itinerary.duration} />
   },
   {
     alias: 'departureTime',

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -1,8 +1,8 @@
 // This is a large file being touched by open PRs. It should be typescripted
 // in a separate PR.
-/* eslint-disable */
-import coreUtils from '@opentripplanner/core-utils'
-import React from 'react'
+/* eslint-disable react/prop-types */
+import { AccessibilityRating } from '@opentripplanner/itinerary-body'
+import { connect } from 'react-redux'
 import {
   FormattedList,
   FormattedMessage,
@@ -10,27 +10,34 @@ import {
   FormattedTime,
   injectIntl
 } from 'react-intl'
-import { connect } from 'react-redux'
+import coreUtils from '@opentripplanner/core-utils'
+import React from 'react'
 import styled from 'styled-components'
-import { AccessibilityRating } from '@opentripplanner/itinerary-body'
 
-import FieldTripGroupSize from '../../admin/field-trip-itinerary-group-size'
-import NarrativeItinerary from '../narrative-itinerary'
-import ItineraryBody from '../line-itin/connected-itinerary-body'
-import SimpleRealtimeAnnotation from '../simple-realtime-annotation'
-import FormattedDuration from '../../util/formatted-duration'
-import FormattedMode from '../../util/formatted-mode'
-import { getTotalFare } from '../../../util/state'
 import {
   getAccessibilityScoreForItinerary,
   itineraryHasAccessibilityScores
 } from '../../../util/accessibility-routing'
+import { getTotalFare } from '../../../util/state'
+import FieldTripGroupSize from '../../admin/field-trip-itinerary-group-size'
+import FormattedDuration from '../../util/formatted-duration'
+import FormattedMode from '../../util/formatted-mode'
 import Icon from '../../util/icon'
+import ItineraryBody from '../line-itin/connected-itinerary-body'
+import NarrativeItinerary from '../narrative-itinerary'
+import SimpleRealtimeAnnotation from '../simple-realtime-annotation'
 
 import { FlexIndicator } from './flex-indicator'
 import ItinerarySummary from './itinerary-summary'
 
-const { isBicycle, isMicromobility, isTransit, isFlex, isOptional, isContinuousDropoff } = coreUtils.itinerary
+const {
+  isBicycle,
+  isContinuousDropoff,
+  isFlex,
+  isMicromobility,
+  isReservationRequired,
+  isTransit
+} = coreUtils.itinerary
 
 // Styled components
 const LegIconWrapper = styled.div`
@@ -42,12 +49,12 @@ const LegIconWrapper = styled.div`
 
   /* Equivalent of a single space before the leg icon. */
   &::before {
-    content: "";
+    content: '';
     margin: 0 0.125em;
   }
 
   &::before {
-    content: "";
+    content: '';
     margin: 0 0.125em;
   }
 `
@@ -71,14 +78,12 @@ function ItineraryDescription({ itinerary }) {
   let primaryTransitDuration = 0
   let accessModeId = 'walk'
   let transitMode
-  let primaryRoute
-  itinerary.legs.forEach((leg, i) => {
-    const { duration, mode, rentedBike, rentedVehicle, routeShortName } = leg
+  itinerary.legs.forEach((leg) => {
+    const { duration, mode, rentedBike, rentedVehicle } = leg
     if (isTransit(mode) && duration > primaryTransitDuration) {
       // TODO: convert OTP's TRAM mode to the correct wording for Portland
       primaryTransitDuration = duration
       transitMode = <FormattedMode mode={mode.toLowerCase()} />
-      primaryRoute = routeShortName
     }
     if (isBicycle(mode)) accessModeId = 'bicycle'
     if (isMicromobility(mode)) accessModeId = 'micromobility'
@@ -88,12 +93,14 @@ function ItineraryDescription({ itinerary }) {
   })
 
   const mainMode = <FormattedMode mode={accessModeId} />
-  return transitMode
-    ? <FormattedMessage
-      id='components.DefaultItinerary.multiModeSummary'
+  return transitMode ? (
+    <FormattedMessage
+      id="components.DefaultItinerary.multiModeSummary"
       values={{ accessMode: mainMode, transitMode }}
     />
-    : mainMode
+  ) : (
+    mainMode
+  )
 }
 
 const ITINERARY_ATTRIBUTES = [
@@ -101,7 +108,7 @@ const ITINERARY_ATTRIBUTES = [
     alias: 'best',
     id: 'duration',
     order: 0,
-    render: (itinerary, options) => (
+    render: (itinerary /*, options */) => (
       <FormattedDuration duration={itinerary.duration} />
     )
   },
@@ -117,8 +124,10 @@ const ITINERARY_ATTRIBUTES = [
         const allStartTimes = Array.from(itinerary.allStartTimes).sort()
         return (
           <FormattedList
-            type='conjunction'
-            value={allStartTimes.map(time => <FormattedTime value={time} />)}
+            type="conjunction"
+            value={allStartTimes.map((time, index) => (
+              <FormattedTime key={index} value={time} />
+            ))}
           />
         )
       }
@@ -129,17 +138,25 @@ const ITINERARY_ATTRIBUTES = [
     id: 'cost',
     order: 2,
     render: (itinerary, options, defaultFareKey = 'regular') => {
-      const fareInCents = getTotalFare(itinerary, options.configCosts, defaultFareKey)
+      const fareInCents = getTotalFare(
+        itinerary,
+        options.configCosts,
+        defaultFareKey
+      )
       const fareCurrency = itinerary.fare?.fare?.regular?.currency?.currencyCode
       const fare = fareInCents === null ? null : fareInCents / 100
-      if (fare === null || fare < 0) return <FormattedMessage id="common.itineraryDescriptions.noTransitFareProvided" />
+      if (fare === null || fare < 0)
+        return (
+          <FormattedMessage id="common.itineraryDescriptions.noTransitFareProvided" />
+        )
       return (
         <FormattedNumber
           // Currency from itinerary fare or from config.
           currency={fareCurrency || options.currency}
-          currencyDisplay='narrowSymbol'
-          style='currency'
-          value={fare} 
+          currencyDisplay="narrowSymbol"
+          // eslint-disable-next-line react/style-prop-object
+          style="currency"
+          value={fare}
         />
       )
     }
@@ -178,7 +195,10 @@ class DefaultItinerary extends NarrativeItinerary {
 
   _onMouseLeave = () => {
     const { index, setVisibleItinerary, visibleItinerary } = this.props
-    if (typeof setVisibleItinerary === 'function' && visibleItinerary === index) {
+    if (
+      typeof setVisibleItinerary === 'function' &&
+      visibleItinerary === index
+    ) {
       setVisibleItinerary({ index: null })
     }
   }
@@ -208,17 +228,19 @@ class DefaultItinerary extends NarrativeItinerary {
       setActiveLeg,
       showRealtimeAnnotation
     } = this.props
-    const isFlexItinerary = itinerary.legs.some(coreUtils.itinerary.isFlex)
-    const isCallAhead = itinerary.legs.some(coreUtils.itinerary.isReservationRequired)
-    const isContinuousDropoff = itinerary.legs.some(coreUtils.itinerary.isContinuousDropoff)
+    const isFlexItinerary = itinerary.legs.some(isFlex)
+    const isCallAhead = itinerary.legs.some(isReservationRequired)
+    const isContDropoff = itinerary.legs.some(isContinuousDropoff)
 
     // Use first leg's agency as a fallback
-    const agency = itinerary.legs.map(leg => leg?.agencyName).filter(name => !!name)[0]
+    const agency = itinerary.legs
+      .map((leg) => leg?.agencyName)
+      .filter((name) => !!name)[0]
     let phone = `contact ${agency}`
 
     if (isCallAhead) {
-    // Picking 0 ensures that if multiple flex legs with
-    // different phone numbers, the first leg is prioritized
+      // Picking 0 ensures that if multiple flex legs with
+      // different phone numbers, the first leg is prioritized
       phone = itinerary.legs
         .map((leg) => leg.pickupBookingInfo?.contactInfo?.phoneNumber)
         .filter((number) => !!number)[0]
@@ -230,16 +252,16 @@ class DefaultItinerary extends NarrativeItinerary {
         }`}
         onMouseEnter={this._onMouseEnter}
         onMouseLeave={this._onMouseLeave}
-        role='presentation'
+        role="presentation"
       >
         <button
-          className='header'
+          className="header"
           // _onHeaderClick comes from super component (NarrativeItinerary).
           onClick={this._onHeaderClick}
         >
           {/* FIXME: semantics - replace the divs with span (we are inside a button) */}
           <ItinerarySummaryWrapper>
-            <div className='title'>
+            <div className="title">
               <ItineraryDescription itinerary={itinerary} />
               <ItinerarySummary itinerary={itinerary} LegIcon={LegIcon} />
               {itineraryHasAccessibilityScores(itinerary) && (
@@ -253,11 +275,11 @@ class DefaultItinerary extends NarrativeItinerary {
             {isFlexItinerary && (
               <FlexIndicator
                 isCallAhead={isCallAhead}
-                isContinuousDropoff={isContinuousDropoff}
+                isContinuousDropoff={isContDropoff}
                 phoneNumber={phone}
               />
             )}
-            <ul className='list-unstyled itinerary-attributes'>
+            <ul className="list-unstyled itinerary-attributes">
               {ITINERARY_ATTRIBUTES.sort((a, b) => {
                 const aSelected = this._isSortingOnAttribute(a)
                 const bSelected = this._isSortingOnAttribute(b)
@@ -289,7 +311,7 @@ class DefaultItinerary extends NarrativeItinerary {
           </ItinerarySummaryWrapper>
           {active && !expanded && (
             <DetailsHint>
-              <FormattedMessage id='components.DefaultItinerary.clickDetails' />
+              <FormattedMessage id="components.DefaultItinerary.clickDetails" />
             </DetailsHint>
           )}
         </button>

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -110,11 +110,8 @@ const ITINERARY_ATTRIBUTES = [
     id: 'arrivalTime',
     order: 1,
     render: (itinerary, options) => {
-      const startTimeWithOffset = itinerary.startTime + options.offset
-      const endTimeWithOffset = itinerary.endTime + options.offset
-
       if (options.selection === 'ARRIVALTIME') {
-        return <FormattedTime value={endTimeWithOffset} />
+        return <FormattedTime value={itinerary.endTime} />
       }
       if (options.selection !== 'DEPARTURETIME' && itinerary.allStartTimes) {
         const allStartTimes = Array.from(itinerary.allStartTimes).sort()
@@ -125,7 +122,7 @@ const ITINERARY_ATTRIBUTES = [
           />
         )
       }
-      return <FormattedTime value={startTimeWithOffset} />
+      return <FormattedTime value={itinerary.startTime} />
     }
   },
   {
@@ -209,13 +206,8 @@ class DefaultItinerary extends NarrativeItinerary {
       itinerary,
       LegIcon,
       setActiveLeg,
-      showRealtimeAnnotation,
-      timeFormat
+      showRealtimeAnnotation
     } = this.props
-    const timeOptions = {
-      format: timeFormat,
-      offset: coreUtils.itinerary.getTimeZoneOffset(itinerary)
-    }
     const isFlexItinerary = itinerary.legs.some(coreUtils.itinerary.isFlex)
     const isCallAhead = itinerary.legs.some(coreUtils.itinerary.isReservationRequired)
     const isContinuousDropoff = itinerary.legs.some(coreUtils.itinerary.isContinuousDropoff)
@@ -274,14 +266,15 @@ class DefaultItinerary extends NarrativeItinerary {
                 return a.order - b.order
               }).map((attribute) => {
                 const isSelected = this._isSortingOnAttribute(attribute)
-                const options = attribute.id === 'arrivalTime' ? timeOptions : {}
+                const options = {
+                  configCosts,
+                  currency,
+                  LegIcon
+                }
                 if (isSelected) {
                   options.isSelected = true
                   options.selection = this.props.sort.type
                 }
-                options.LegIcon = LegIcon
-                options.configCosts = configCosts
-                options.currency = currency
                 return (
                   <li
                     className={`${attribute.id}${isSelected ? ' main' : ''}`}

--- a/lib/components/viewers/departure-time.tsx
+++ b/lib/components/viewers/departure-time.tsx
@@ -1,0 +1,26 @@
+import { FormattedTime } from 'react-intl'
+import addSeconds from 'date-fns/addSeconds'
+import React from 'react'
+
+import type { Time } from '../util/types'
+
+interface Props {
+  realTime?: boolean
+  stopTime: Time
+}
+
+/**
+ * Displays a formatted departure time (expressed in the agency time zone) for the given stop time.
+ */
+const DepartureTime = ({ realTime, stopTime }: Props): JSX.Element => {
+  // stopTime.serviceDay already corresponds to midnight in the agency's home timezone so no extra conversion is needed.
+  const startOfDate = new Date(stopTime.serviceDay * 1000)
+  const departureTimestamp = addSeconds(
+    startOfDate,
+    realTime ? stopTime.realtimeDeparture : stopTime.scheduledDeparture
+  )
+
+  return <FormattedTime timeStyle="short" value={departureTimestamp} />
+}
+
+export default DepartureTime

--- a/lib/components/viewers/departure-time.tsx
+++ b/lib/components/viewers/departure-time.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import type { Time } from '../util/types'
 
 interface Props {
+  originDate?: Date
   realTime?: boolean
   stopTime: Time
 }
@@ -12,9 +13,14 @@ interface Props {
 /**
  * Displays a formatted departure time (expressed in the agency time zone) for the given stop time.
  */
-const DepartureTime = ({ realTime, stopTime }: Props): JSX.Element => {
+const DepartureTime = ({
+  originDate,
+  realTime,
+  stopTime
+}: Props): JSX.Element => {
+  // If an originDate is defined, use that, otherwise use stopTime.serviceDay.
   // stopTime.serviceDay already corresponds to midnight in the agency's home timezone so no extra conversion is needed.
-  const startOfDate = new Date(stopTime.serviceDay * 1000)
+  const startOfDate = originDate || new Date(stopTime.serviceDay * 1000)
   const departureTimestamp = addSeconds(
     startOfDate,
     realTime ? stopTime.realtimeDeparture : stopTime.scheduledDeparture

--- a/lib/components/viewers/stop-schedule-table.tsx
+++ b/lib/components/viewers/stop-schedule-table.tsx
@@ -1,7 +1,5 @@
 import { connect } from 'react-redux'
-import { FormattedMessage, FormattedTime } from 'react-intl'
-import { zonedTimeToUtc } from 'date-fns-tz'
-import addSeconds from 'date-fns/addSeconds'
+import { FormattedMessage } from 'react-intl'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore TYPESCRIPT TODO: wait for typescripted core-utils
 import coreUtils from '@opentripplanner/core-utils'
@@ -15,6 +13,8 @@ import {
 } from '../../util/viewer'
 import Loading from '../narrative/loading'
 import type { StopData } from '../util/types'
+
+import DepartureTime from './departure-time'
 
 // Styles for the schedule table and its contents.
 const StyledTable = styled.table`
@@ -101,9 +101,6 @@ class StopScheduleTable extends Component<{
 
     const today = coreUtils.time.getCurrentDate(homeTimezone)
 
-    // Compute the UTC date that corresponds to midnight (00:00) of the given date in homeTimezone
-    const startOfDate = zonedTimeToUtc(date, homeTimezone)
-
     // Find the next stop time that is departing.
     // We will scroll to that stop time entry (if showing schedules for today).
     const shouldHighlightFirstDeparture =
@@ -148,10 +145,7 @@ class StopScheduleTable extends Component<{
               ? nextStopTime === highlightedStopTime
               : highlightRow
             const routeName = route.shortName ? route.shortName : route.longName
-            const departureTimestamp = addSeconds(
-              startOfDate,
-              stopTime.scheduledDeparture
-            )
+
             // Add ref to scroll to the first stop time departing from now.
             const refProp = scrollToRow ? this.targetDepartureRef : undefined
 
@@ -163,7 +157,7 @@ class StopScheduleTable extends Component<{
                 <RouteCell>{routeName}</RouteCell>
                 <td>{headsign}</td>
                 <TimeCell>
-                  <FormattedTime timeStyle="short" value={departureTimestamp} />
+                  <DepartureTime stopTime={stopTime} />
                 </TimeCell>
               </tr>
             )

--- a/lib/components/viewers/stop-schedule-table.tsx
+++ b/lib/components/viewers/stop-schedule-table.tsx
@@ -1,4 +1,3 @@
-import { connect } from 'react-redux'
 import { FormattedMessage } from 'react-intl'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore TYPESCRIPT TODO: wait for typescripted core-utils
@@ -168,8 +167,4 @@ class StopScheduleTable extends Component<{
   }
 }
 
-const mapStateToProps = (state: Record<string, any>) => ({
-  homeTimezone: state.otp.config.homeTimezone
-})
-
-export default connect(mapStateToProps)(StopScheduleTable)
+export default StopScheduleTable

--- a/lib/components/viewers/stop-time-cell.tsx
+++ b/lib/components/viewers/stop-time-cell.tsx
@@ -1,5 +1,5 @@
 import 'moment-timezone'
-import { FormattedMessage, FormattedTime } from 'react-intl'
+import { FormattedMessage } from 'react-intl'
 // TODO: typescript core-utils, add common types (pattern, stop, configs)
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -8,9 +8,12 @@ import moment from 'moment'
 import React from 'react'
 
 import { getSecondsUntilDeparture } from '../../util/viewer'
+import { Time } from '../util/types'
 import FormattedDayOfWeek from '../util/formatted-day-of-week'
 import FormattedDuration from '../util/formatted-duration'
 import Icon from '../util/icon'
+
+import DepartureTime from './departure-time'
 
 const { getUserTimezone } = coreUtils.time
 const ONE_HOUR_IN_SECONDS = 3600
@@ -20,8 +23,7 @@ type Props = {
   /** If configured, the timezone of the area */
   homeTimezone?: string
   /** A stopTime object as received from a transit index API */
-  // TODO: common shared types
-  stopTime: any
+  stopTime: Time
 }
 
 /**
@@ -50,18 +52,9 @@ const StopTimeCell = ({
       </div>
     )
   }
-  const userTimezone = getUserTimezone()
   const departureTime = stopTime.realtimeDeparture
   const now = moment().tz(homeTimezone)
   const serviceDay = moment(stopTime.serviceDay * 1000).tz(homeTimezone)
-
-  // Convert seconds after midnight to unix (milliseconds) for FormattedTime
-  // Convert to userTimezone rather than spying on startOf for tests
-  const departureMoment = moment(stopTime.serviceDay * 1000)
-    .tz(userTimezone)
-    .startOf('day')
-  departureMoment.add(departureTime, 's')
-  const departureTimestamp = departureMoment.valueOf()
 
   // Determine if arrival occurs on different day, making sure to account for
   // any extra days added to the service day if it arrives after midnight. Note:
@@ -119,12 +112,7 @@ const StopTimeCell = ({
               <FormattedDuration duration={secondsUntilDeparture} />
             )
           ) : (
-            // Show formatted time (with timezone if user is not in home timezone)
-            <FormattedTime
-              timeStyle="short"
-              timeZone={homeTimezone}
-              value={departureTimestamp}
-            />
+            <DepartureTime realTime stopTime={stopTime} />
           )}
         </div>
       </div>

--- a/lib/components/viewers/trip-viewer.js
+++ b/lib/components/viewers/trip-viewer.js
@@ -1,6 +1,4 @@
-// FIXME: Remove this eslint rule exception.
-/* eslint-disable jsx-a11y/label-has-for */
-import { Button, Label } from 'react-bootstrap'
+import { Label as BsLabel, Button } from 'react-bootstrap'
 import { connect } from 'react-redux'
 import { FormattedMessage } from 'react-intl'
 import { toDate } from 'date-fns-tz'
@@ -88,17 +86,17 @@ class TripViewer extends Component {
               {/* Wheelchair/bike accessibility badges, if applicable */}
               <h4>
                 {tripData.wheelchairAccessible === 1 && (
-                  <Label bsStyle="primary">
+                  <BsLabel bsStyle="primary">
                     <Icon type="wheelchair-alt" withSpace />
                     <FormattedMessage id="components.TripViewer.accessible" />
-                  </Label>
+                  </BsLabel>
                 )}
                 <SpanWithSpace margin={0.25} />
                 {tripData.bikesAllowed === 1 && (
-                  <Label bsStyle="success">
+                  <BsLabel bsStyle="success">
                     <Icon type="bicycle" withSpace />
                     <FormattedMessage id="components.TripViewer.bicyclesAllowed" />
-                  </Label>
+                  </BsLabel>
                 )}
               </h4>
             </div>

--- a/lib/components/viewers/trip-viewer.js
+++ b/lib/components/viewers/trip-viewer.js
@@ -2,9 +2,9 @@
 /* eslint-disable jsx-a11y/label-has-for */
 import { Button, Label } from 'react-bootstrap'
 import { connect } from 'react-redux'
-import { FormattedMessage, FormattedTime } from 'react-intl'
+import { FormattedMessage } from 'react-intl'
+import { toDate } from 'date-fns-tz'
 import coreUtils from '@opentripplanner/core-utils'
-import moment from 'moment'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
@@ -15,14 +15,16 @@ import Icon from '../util/icon'
 import SpanWithSpace from '../util/span-with-space'
 import Strong from '../util/strong-text'
 
+import DepartureTime from './departure-time'
 import ViewStopButton from './view-stop-button'
 
-const { getUserTimezone } = coreUtils.time
+const { getCurrentDate } = coreUtils.time
 
 class TripViewer extends Component {
   static propTypes = {
     findTrip: apiActions.findTrip.type,
     hideBackButton: PropTypes.bool,
+    homeTimezone: PropTypes.string,
     setViewedTrip: uiActions.setViewedTrip.type,
     tripData: PropTypes.object,
     viewedTrip: PropTypes.object
@@ -39,7 +41,10 @@ class TripViewer extends Component {
   }
 
   render() {
-    const { hideBackButton, tripData, viewedTrip } = this.props
+    const { hideBackButton, homeTimezone, tripData, viewedTrip } = this.props
+    const startOfDay = toDate(getCurrentDate(homeTimezone), {
+      timeZone: homeTimezone
+    })
 
     return (
       <div className="trip-viewer">
@@ -121,20 +126,13 @@ class TripViewer extends Component {
                 highlightClass = 'strip-map-highlight-last'
               }
 
-              // Convert to unix (millisceonds) for FormattedTime
-              // Use timezone to avoid spying on startOf in future tests
-              const userTimezone = getUserTimezone()
-              const departureMoment = moment().tz(userTimezone).startOf('day')
-              departureMoment.add(tripData.stopTimes[i].scheduledDeparture, 's')
-              const departureTimestamp = departureMoment.valueOf()
-
               return (
                 <div key={i}>
                   {/* the departure time */}
                   <div className="stop-time">
-                    <FormattedTime
-                      timeStyle="short"
-                      value={departureTimestamp}
+                    <DepartureTime
+                      originDate={startOfDay}
+                      stopTime={tripData.stopTimes[i]}
                     />
                   </div>
 
@@ -173,6 +171,7 @@ class TripViewer extends Component {
 const mapStateToProps = (state) => {
   const viewedTrip = state.otp.ui.viewedTrip
   return {
+    homeTimezone: state.otp.config.homeTimezone,
     tripData: state.otp.transitIndex.trips[viewedTrip.tripId],
     viewedTrip
   }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "currency-formatter": "^1.4.2",
     "d3-selection": "^1.3.0",
     "d3-zoom": "^1.7.1",
+    "date-fns": "^2.23.0",
+    "date-fns-tz": "^1.1.4",
     "deepmerge": "^4.2.2",
     "flat": "^5.0.2",
     "font-awesome": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@opentripplanner/transit-vehicle-overlay": "^2.3.1",
     "@opentripplanner/transitive-overlay": "^1.1.3",
     "@opentripplanner/trip-details": "^2.0.0",
-    "@opentripplanner/trip-form": "^1.11.3",
+    "@opentripplanner/trip-form": "^1.11.4",
     "@opentripplanner/trip-viewer-overlay": "^1.1.1",
     "@opentripplanner/vehicle-rental-overlay": "^1.4.2",
     "blob-stream": "^0.1.3",

--- a/percy/har-mock-config.yml
+++ b/percy/har-mock-config.yml
@@ -1,6 +1,6 @@
 branding: HAR test
 title: test environment
-homeTimezone: America/Chicago
+homeTimezone: America/New_York
 
 # Default OTP API
 api:

--- a/percy/percy.test.js
+++ b/percy/percy.test.js
@@ -85,7 +85,7 @@ beforeAll(async () => {
       const client = await targetPage.target().createCDPSession()
       await client.send('Runtime.evaluate', {
         expression:
-          'Date.now = function() { return 1646832142000; }; Date.getTime = function() { return 1646832142000; }'
+          'Date.now = function() { return 1646835742000; }; Date.getTime = function() { return 1646835742000; }'
       })
     })
   } catch (error) {
@@ -120,7 +120,7 @@ jest.setTimeout(600000)
 /*
 test('OTP-RR Fixed Routes', async () => {
   const transitive = await loadPath(
-    '/?ui_activeSearch=5rzujqghc&ui_activeItinerary=0&fromPlace=Opus Music Store%2C Decatur%2C GA%3A%3A33.77505%2C-84.300178&toPlace=Five Points Station (MARTA Stop ID 908981)%3A%3A33.753837%2C-84.391397&date=2022-03-09&time=08%3A58&arriveBy=false&mode=WALK%2CBUS%2CSUBWAY%2CTRAM%2CFLEX_EGRESS%2CFLEX_ACCESS%2CFLEX_DIRECT&showIntermediateStops=true&maxWalkDistance=1207&optimize=QUICK&walkSpeed=1.34&ignoreRealtimeUpdates=true&wheelchair=false&numItineraries=3&otherThanPreferredRoutesPenalty=900'
+    '/?ui_activeSearch=5rzujqghc&ui_activeItinerary=0&fromPlace=Opus Music Store%2C Decatur%2C GA%3A%3A33.77505%2C-84.300178&toPlace=Five Points Station (MARTA Stop ID 908981)%3A%3A33.753837%2C-84.391397&date=2022-03-09&time=09%3A58&arriveBy=false&mode=WALK%2CBUS%2CSUBWAY%2CTRAM%2CFLEX_EGRESS%2CFLEX_ACCESS%2CFLEX_DIRECT&showIntermediateStops=true&maxWalkDistance=1207&optimize=QUICK&walkSpeed=1.34&ignoreRealtimeUpdates=true&wheelchair=false&numItineraries=3&otherThanPreferredRoutesPenalty=900'
   )
   await percySnapshotWithWait(transitive, 'Itinerary (with transitive)', true)
 
@@ -142,7 +142,7 @@ test('OTP-RR', async () => {
 
   // Plan a trip
   await page.goto(
-    `http://localhost:${MOCK_SERVER_PORT}/#/?ui_activeSearch=5rzujqghc&ui_activeItinerary=0&fromPlace=Opus Music Store%2C Decatur%2C GA%3A%3A33.77505%2C-84.300178&toPlace=Five Points Station (MARTA Stop ID 908981)%3A%3A33.753837%2C-84.391397&date=2022-05-09&time=08%3A58&arriveBy=false&mode=WALK%2CBUS%2CSUBWAY%2CTRAM%2CFLEX_EGRESS%2CFLEX_ACCESS%2CFLEX_DIRECT&showIntermediateStops=true&maxWalkDistance=1207&optimize=QUICK&walkSpeed=1.34&ignoreRealtimeUpdates=true&wheelchair=false&numItineraries=3&otherThanPreferredRoutesPenalty=900`
+    `http://localhost:${MOCK_SERVER_PORT}/#/?ui_activeSearch=5rzujqghc&ui_activeItinerary=0&fromPlace=Opus Music Store%2C Decatur%2C GA%3A%3A33.77505%2C-84.300178&toPlace=Five Points Station (MARTA Stop ID 908981)%3A%3A33.753837%2C-84.391397&date=2022-05-09&time=09%3A58&arriveBy=false&mode=WALK%2CBUS%2CSUBWAY%2CTRAM%2CFLEX_EGRESS%2CFLEX_ACCESS%2CFLEX_DIRECT&showIntermediateStops=true&maxWalkDistance=1207&optimize=QUICK&walkSpeed=1.34&ignoreRealtimeUpdates=true&wheelchair=false&numItineraries=3&otherThanPreferredRoutesPenalty=900`
   )
   await page.waitForNavigation({ waitUntil: 'networkidle2' })
   await page.waitForSelector('.title')

--- a/percy/percy.test.js
+++ b/percy/percy.test.js
@@ -85,7 +85,7 @@ beforeAll(async () => {
       const client = await targetPage.target().createCDPSession()
       await client.send('Runtime.evaluate', {
         expression:
-          'Date.now = function() { return 1646835742000; }; Date.getTime = function() { return 1646835742000; }'
+          'Date.now = function() { return 1646832142000; }; Date.getTime = function() { return 1646832142000; }'
       })
     })
   } catch (error) {
@@ -120,7 +120,7 @@ jest.setTimeout(600000)
 /*
 test('OTP-RR Fixed Routes', async () => {
   const transitive = await loadPath(
-    '/?ui_activeSearch=5rzujqghc&ui_activeItinerary=0&fromPlace=Opus Music Store%2C Decatur%2C GA%3A%3A33.77505%2C-84.300178&toPlace=Five Points Station (MARTA Stop ID 908981)%3A%3A33.753837%2C-84.391397&date=2022-03-09&time=09%3A58&arriveBy=false&mode=WALK%2CBUS%2CSUBWAY%2CTRAM%2CFLEX_EGRESS%2CFLEX_ACCESS%2CFLEX_DIRECT&showIntermediateStops=true&maxWalkDistance=1207&optimize=QUICK&walkSpeed=1.34&ignoreRealtimeUpdates=true&wheelchair=false&numItineraries=3&otherThanPreferredRoutesPenalty=900'
+    '/?ui_activeSearch=5rzujqghc&ui_activeItinerary=0&fromPlace=Opus Music Store%2C Decatur%2C GA%3A%3A33.77505%2C-84.300178&toPlace=Five Points Station (MARTA Stop ID 908981)%3A%3A33.753837%2C-84.391397&date=2022-03-09&time=08%3A58&arriveBy=false&mode=WALK%2CBUS%2CSUBWAY%2CTRAM%2CFLEX_EGRESS%2CFLEX_ACCESS%2CFLEX_DIRECT&showIntermediateStops=true&maxWalkDistance=1207&optimize=QUICK&walkSpeed=1.34&ignoreRealtimeUpdates=true&wheelchair=false&numItineraries=3&otherThanPreferredRoutesPenalty=900'
   )
   await percySnapshotWithWait(transitive, 'Itinerary (with transitive)', true)
 
@@ -142,7 +142,7 @@ test('OTP-RR', async () => {
 
   // Plan a trip
   await page.goto(
-    `http://localhost:${MOCK_SERVER_PORT}/#/?ui_activeSearch=5rzujqghc&ui_activeItinerary=0&fromPlace=Opus Music Store%2C Decatur%2C GA%3A%3A33.77505%2C-84.300178&toPlace=Five Points Station (MARTA Stop ID 908981)%3A%3A33.753837%2C-84.391397&date=2022-05-09&time=09%3A58&arriveBy=false&mode=WALK%2CBUS%2CSUBWAY%2CTRAM%2CFLEX_EGRESS%2CFLEX_ACCESS%2CFLEX_DIRECT&showIntermediateStops=true&maxWalkDistance=1207&optimize=QUICK&walkSpeed=1.34&ignoreRealtimeUpdates=true&wheelchair=false&numItineraries=3&otherThanPreferredRoutesPenalty=900`
+    `http://localhost:${MOCK_SERVER_PORT}/#/?ui_activeSearch=5rzujqghc&ui_activeItinerary=0&fromPlace=Opus Music Store%2C Decatur%2C GA%3A%3A33.77505%2C-84.300178&toPlace=Five Points Station (MARTA Stop ID 908981)%3A%3A33.753837%2C-84.391397&date=2022-05-09&time=08%3A58&arriveBy=false&mode=WALK%2CBUS%2CSUBWAY%2CTRAM%2CFLEX_EGRESS%2CFLEX_ACCESS%2CFLEX_DIRECT&showIntermediateStops=true&maxWalkDistance=1207&optimize=QUICK&walkSpeed=1.34&ignoreRealtimeUpdates=true&wheelchair=false&numItineraries=3&otherThanPreferredRoutesPenalty=900`
   )
   await page.waitForNavigation({ waitUntil: 'networkidle2' })
   await page.waitForSelector('.title')

--- a/percy/percy.test.js
+++ b/percy/percy.test.js
@@ -79,13 +79,13 @@ beforeAll(async () => {
       // headless: false
     })
 
-    // Fix time
+    // Fix time to Monday, March 14, 2022 14:22:22 GMT (10:22:22 AM EDT).
     browser.on('targetchanged', async (target) => {
       const targetPage = await target.page()
       const client = await targetPage.target().createCDPSession()
       await client.send('Runtime.evaluate', {
         expression:
-          'Date.now = function() { return 1646835742000; }; Date.getTime = function() { return 1646835742000; }'
+          'Date.now = function() { return 1647267742000; }; Date.getTime = function() { return 1647267742000; }'
       })
     })
   } catch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2450,10 +2450,10 @@
     flat "^5.0.2"
     velocity-react "^1.4.3"
 
-"@opentripplanner/trip-form@^1.11.3":
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/trip-form/-/trip-form-1.11.3.tgz#a341f169102eacd32037e29d596adde3a14becd7"
-  integrity sha512-InP6VCRdeKFQ7AKyQEzW9cdNmO4hk+vGdKyY4hGscaUD+G4jY7DVCyFIejxz5olhBRiQWeA2cF5idWLxa1PyYg==
+"@opentripplanner/trip-form@^1.11.4":
+  version "1.11.4"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/trip-form/-/trip-form-1.11.4.tgz#6a9c672f6b4c6e28d5af3c212dadd7d657bcfe20"
+  integrity sha512-Ej/gYjJjqIUIxLvOECKjyUUY/FxDPy8D9hechA2mLBisZVQDfPPXOu5JThNuTkwMbtAGoTCPN3x3iIBrGAs7dw==
   dependencies:
     "@opentripplanner/core-utils" "^4.11.2"
     "@opentripplanner/icons" "^1.2.2"


### PR DESCRIPTION
Fix #625.

In the Stop Viewer we show an indication if the agency timezone is different than the user time zone. Should that be shown in itinerary results too?
