### PR TITLE
fix(metro ui): don't render e-scooter as bikeshare

### DIFF
--- a/lib/components/narrative/default/itinerary-description.tsx
+++ b/lib/components/narrative/default/itinerary-description.tsx
@@ -75,9 +75,9 @@ export function ItineraryDescription({ itinerary }: Props): JSX.Element {
     }
 
     if (isBicycle(mode)) accessModeId = 'bicycle'
+    if (rentedBike) accessModeId = 'bicycle_rent'
     if (isMicromobility(mode)) accessModeId = 'micromobility'
     if (rentedVehicle) accessModeId = 'micromobility_rent'
-    if (rentedBike) accessModeId = 'bicycle_rent'
     if (mode === 'CAR') accessModeId = 'drive'
   })
 


### PR DESCRIPTION
There was a small bug where e-scooters would be rendered as bikeshares when using OTP2 instances. This is corrected by changing the order in which we check for modes.