### PR TITLE
Remove eslint disable

### DIFF
--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -566,13 +566,13 @@ exports[`components > viewers > stop viewer should render countdown times after 
                         name="calendar"
                       >
                         <FontAwesome
-                          className="sc-bdfBQB decmux"
+                          className="sc-gInthZ fFpLwO"
                           fixedWidth={true}
                           name="calendar"
                         >
                           <span
                             aria-hidden={true}
-                            className="fa fa-calendar fa-fw sc-bdfBQB decmux"
+                            className="fa fa-calendar fa-fw sc-gInthZ fFpLwO"
                           />
                         </FontAwesome>
                       </Styled(FontAwesome)>
@@ -779,7 +779,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
               </div>
               <styled.div>
                 <div
-                  className="sc-cxFLGX lkVcpP"
+                  className="sc-fHYyUA dsBqmr"
                 >
                   <LiveStopTimes
                     findStopTimesForStop={[Function]}
@@ -1317,7 +1317,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                       color="333333"
                                     >
                                       <section
-                                        className="sc-fFucqa kUqmgT"
+                                        className="sc-eFuaqX gcNSTz"
                                         color="333333"
                                       >
                                         20
@@ -1514,7 +1514,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                           margin={0.25}
                         >
                           <span
-                            className="sc-hBEYId kYwHch"
+                            className="sc-FyeoB fqliIl"
                           >
                             <input
                               name="autoUpdate"
@@ -1549,13 +1549,13 @@ exports[`components > viewers > stop viewer should render countdown times after 
                             name="refresh"
                           >
                             <FontAwesome
-                              className="sc-bdfBQB decmux fa-spin"
+                              className="sc-gInthZ fFpLwO fa-spin"
                               fixedWidth={true}
                               name="refresh"
                             >
                               <span
                                 aria-hidden={true}
-                                className="fa fa-refresh fa-fw sc-bdfBQB decmux fa-spin"
+                                className="fa fa-refresh fa-fw sc-gInthZ fFpLwO fa-spin"
                               />
                             </FontAwesome>
                           </Styled(FontAwesome)>
@@ -2369,7 +2369,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                     >
                                       <styled.div>
                                         <div
-                                          className="sc-fodVek klHrRi"
+                                          className="sc-jXktde kmcqbz"
                                         >
                                           P
                                         </div>
@@ -2768,13 +2768,13 @@ exports[`components > viewers > stop viewer should render countdown times for st
                         name="calendar"
                       >
                         <FontAwesome
-                          className="sc-bdfBQB decmux"
+                          className="sc-gInthZ fFpLwO"
                           fixedWidth={true}
                           name="calendar"
                         >
                           <span
                             aria-hidden={true}
-                            className="fa fa-calendar fa-fw sc-bdfBQB decmux"
+                            className="fa fa-calendar fa-fw sc-gInthZ fFpLwO"
                           />
                         </FontAwesome>
                       </Styled(FontAwesome)>
@@ -2981,7 +2981,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
               </div>
               <styled.div>
                 <div
-                  className="sc-cxFLGX lkVcpP"
+                  className="sc-fHYyUA dsBqmr"
                 >
                   <LiveStopTimes
                     findStopTimesForStop={[Function]}
@@ -3240,7 +3240,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                       color="333333"
                                     >
                                       <section
-                                        className="sc-fFucqa kUqmgT"
+                                        className="sc-eFuaqX gcNSTz"
                                         color="333333"
                                       >
                                         20
@@ -3437,7 +3437,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                           margin={0.25}
                         >
                           <span
-                            className="sc-hBEYId kYwHch"
+                            className="sc-FyeoB fqliIl"
                           >
                             <input
                               name="autoUpdate"
@@ -3472,13 +3472,13 @@ exports[`components > viewers > stop viewer should render countdown times for st
                             name="refresh"
                           >
                             <FontAwesome
-                              className="sc-bdfBQB decmux fa-spin"
+                              className="sc-gInthZ fFpLwO fa-spin"
                               fixedWidth={true}
                               name="refresh"
                             >
                               <span
                                 aria-hidden={true}
-                                className="fa fa-refresh fa-fw sc-bdfBQB decmux fa-spin"
+                                className="fa fa-refresh fa-fw sc-gInthZ fFpLwO fa-spin"
                               />
                             </FontAwesome>
                           </Styled(FontAwesome)>
@@ -3896,7 +3896,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                     >
                                       <styled.div>
                                         <div
-                                          className="sc-fodVek klHrRi"
+                                          className="sc-jXktde kmcqbz"
                                         >
                                           P
                                         </div>
@@ -4493,13 +4493,13 @@ exports[`components > viewers > stop viewer should render times after midnight w
                         name="calendar"
                       >
                         <FontAwesome
-                          className="sc-bdfBQB decmux"
+                          className="sc-gInthZ fFpLwO"
                           fixedWidth={true}
                           name="calendar"
                         >
                           <span
                             aria-hidden={true}
-                            className="fa fa-calendar fa-fw sc-bdfBQB decmux"
+                            className="fa fa-calendar fa-fw sc-gInthZ fFpLwO"
                           />
                         </FontAwesome>
                       </Styled(FontAwesome)>
@@ -4706,7 +4706,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
               </div>
               <styled.div>
                 <div
-                  className="sc-cxFLGX lkVcpP"
+                  className="sc-fHYyUA dsBqmr"
                 >
                   <LiveStopTimes
                     findStopTimesForStop={[Function]}
@@ -5244,7 +5244,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                       color="333333"
                                     >
                                       <section
-                                        className="sc-fFucqa kUqmgT"
+                                        className="sc-eFuaqX gcNSTz"
                                         color="333333"
                                       >
                                         20
@@ -5474,7 +5474,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                           margin={0.25}
                         >
                           <span
-                            className="sc-hBEYId kYwHch"
+                            className="sc-FyeoB fqliIl"
                           >
                             <input
                               name="autoUpdate"
@@ -5509,13 +5509,13 @@ exports[`components > viewers > stop viewer should render times after midnight w
                             name="refresh"
                           >
                             <FontAwesome
-                              className="sc-bdfBQB decmux fa-spin"
+                              className="sc-gInthZ fFpLwO fa-spin"
                               fixedWidth={true}
                               name="refresh"
                             >
                               <span
                                 aria-hidden={true}
-                                className="fa fa-refresh fa-fw sc-bdfBQB decmux fa-spin"
+                                className="fa fa-refresh fa-fw sc-gInthZ fFpLwO fa-spin"
                               />
                             </FontAwesome>
                           </Styled(FontAwesome)>
@@ -6329,7 +6329,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                     >
                                       <styled.div>
                                         <div
-                                          className="sc-fodVek klHrRi"
+                                          className="sc-jXktde kmcqbz"
                                         >
                                           P
                                         </div>
@@ -7442,13 +7442,13 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                         name="calendar"
                       >
                         <FontAwesome
-                          className="sc-bdfBQB decmux"
+                          className="sc-gInthZ fFpLwO"
                           fixedWidth={true}
                           name="calendar"
                         >
                           <span
                             aria-hidden={true}
-                            className="fa fa-calendar fa-fw sc-bdfBQB decmux"
+                            className="fa fa-calendar fa-fw sc-gInthZ fFpLwO"
                           />
                         </FontAwesome>
                       </Styled(FontAwesome)>
@@ -7655,7 +7655,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
               </div>
               <styled.div>
                 <div
-                  className="sc-cxFLGX lkVcpP"
+                  className="sc-fHYyUA dsBqmr"
                 >
                   <LiveStopTimes
                     findStopTimesForStop={[Function]}
@@ -8447,7 +8447,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                       color="333333"
                                     >
                                       <section
-                                        className="sc-fFucqa kUqmgT"
+                                        className="sc-eFuaqX gcNSTz"
                                         color="333333"
                                       >
                                         20
@@ -8894,7 +8894,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                       color="333333"
                                     >
                                       <section
-                                        className="sc-fFucqa kUqmgT"
+                                        className="sc-eFuaqX gcNSTz"
                                         color="333333"
                                       >
                                         36
@@ -9341,7 +9341,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                       color="333333"
                                     >
                                       <section
-                                        className="sc-fFucqa kUqmgT"
+                                        className="sc-eFuaqX gcNSTz"
                                         color="333333"
                                       >
                                         94
@@ -9896,7 +9896,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                       color="333333"
                                     >
                                       <section
-                                        className="sc-fFucqa kUqmgT"
+                                        className="sc-eFuaqX gcNSTz"
                                         color="333333"
                                       >
                                         94
@@ -10126,7 +10126,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                           margin={0.25}
                         >
                           <span
-                            className="sc-hBEYId kYwHch"
+                            className="sc-FyeoB fqliIl"
                           >
                             <input
                               name="autoUpdate"
@@ -10161,13 +10161,13 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                             name="refresh"
                           >
                             <FontAwesome
-                              className="sc-bdfBQB decmux fa-spin"
+                              className="sc-gInthZ fFpLwO fa-spin"
                               fixedWidth={true}
                               name="refresh"
                             >
                               <span
                                 aria-hidden={true}
-                                className="fa fa-refresh fa-fw sc-bdfBQB decmux fa-spin"
+                                className="fa fa-refresh fa-fw sc-gInthZ fFpLwO fa-spin"
                               />
                             </FontAwesome>
                           </Styled(FontAwesome)>
@@ -12013,7 +12013,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     >
                                       <styled.div>
                                         <div
-                                          className="sc-fodVek klHrRi"
+                                          className="sc-jXktde kmcqbz"
                                         >
                                           P
                                         </div>
@@ -13116,13 +13116,13 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                         name="calendar"
                       >
                         <FontAwesome
-                          className="sc-bdfBQB decmux"
+                          className="sc-gInthZ fFpLwO"
                           fixedWidth={true}
                           name="calendar"
                         >
                           <span
                             aria-hidden={true}
-                            className="fa fa-calendar fa-fw sc-bdfBQB decmux"
+                            className="fa fa-calendar fa-fw sc-gInthZ fFpLwO"
                           />
                         </FontAwesome>
                       </Styled(FontAwesome)>
@@ -13329,7 +13329,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
               </div>
               <styled.div>
                 <div
-                  className="sc-cxFLGX lkVcpP"
+                  className="sc-fHYyUA dsBqmr"
                 >
                   <LiveStopTimes
                     findStopTimesForStop={[Function]}
@@ -14120,7 +14120,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                       color="333333"
                                     >
                                       <section
-                                        className="sc-fFucqa kUqmgT"
+                                        className="sc-eFuaqX gcNSTz"
                                         color="333333"
                                       >
                                         20
@@ -14350,7 +14350,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                           margin={0.25}
                         >
                           <span
-                            className="sc-hBEYId kYwHch"
+                            className="sc-FyeoB fqliIl"
                           >
                             <input
                               name="autoUpdate"
@@ -14385,13 +14385,13 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                             name="refresh"
                           >
                             <FontAwesome
-                              className="sc-bdfBQB decmux fa-spin"
+                              className="sc-gInthZ fFpLwO fa-spin"
                               fixedWidth={true}
                               name="refresh"
                             >
                               <span
                                 aria-hidden={true}
-                                className="fa fa-refresh fa-fw sc-bdfBQB decmux fa-spin"
+                                className="fa fa-refresh fa-fw sc-gInthZ fFpLwO fa-spin"
                               />
                             </FontAwesome>
                           </Styled(FontAwesome)>
@@ -16217,7 +16217,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                     >
                                       <styled.div>
                                         <div
-                                          className="sc-fodVek klHrRi"
+                                          className="sc-jXktde kmcqbz"
                                         >
                                           P
                                         </div>

--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
-// FIXME: This file has many methods and variables used before they are defined.
-
 /* globals fetch */
 import { push, replace } from 'connected-react-router'
 import hash from 'object-hash'
@@ -103,6 +100,115 @@ function executeOTPAction(methodName, ...params) {
         ? v2Actions[methodName](...params)
         : v1Actions[methodName](...params)
     )
+  }
+}
+
+function constructRoutingQuery(
+  state,
+  ignoreRealtimeUpdates,
+  injectedParams = {}
+) {
+  const { config, currentQuery } = state.otp
+  const routingType = currentQuery.routingType
+  // Check for routingType-specific API config; if none, use default API
+  const rt =
+    config.routingTypes &&
+    config.routingTypes.find((rt) => rt.key === routingType)
+  const api = (rt && rt.api) || config.api
+  const planEndpoint = `${api.host}${api.port ? ':' + api.port : ''}${
+    api.path
+  }/plan`
+  const params = {
+    ...getRoutingParams(config, currentQuery, ignoreRealtimeUpdates),
+    // Apply mode override, if specified (for batch routing).
+    ...injectedParams
+  }
+  return `${planEndpoint}?${qs.stringify(params, { arrayFormat: 'repeat' })}`
+}
+
+/**
+ * This method determines the fetch options (including API key and Authorization headers) for the OTP API.
+ * - If the OTP server is not the middleware server (standalone OTP server),
+ *   an empty object is returned.
+ * - If the OTP server is the same as the middleware server,
+ *   then an object is returned with the following:
+ *   - A middleware API key, if it has been set in the configuration (it is most likely required),
+ *   - An Auth0 accessToken, when includeToken is true and a user is logged in (userState.loggedInUser is not null).
+ * This method assumes JSON request bodies.)
+ */
+function getOtpFetchOptions(state, includeToken = false) {
+  let apiBaseUrl, apiKey, token
+
+  const { api, persistence } = state.otp.config
+  if (persistence && persistence.otp_middleware) {
+    // Prettier does not understand the syntax on this line
+    // eslint-disable-next-line prettier/prettier
+    ({ apiBaseUrl, apiKey } = persistence.otp_middleware)
+  }
+
+  const isOtpServerSameAsMiddleware = apiBaseUrl === api.host
+  if (isOtpServerSameAsMiddleware) {
+    if (includeToken && state.user) {
+      const { accessToken, loggedInUser } = state.user
+      if (accessToken && loggedInUser) {
+        token = accessToken
+      }
+    }
+
+    return getSecureFetchOptions(token, apiKey)
+  } else {
+    return {}
+  }
+}
+
+function getJsonAndCheckResponse(res) {
+  if (res.status >= 400) {
+    const error = new Error('Received error from server')
+    error.response = res
+    throw error
+  }
+  return res.json()
+}
+
+/**
+ * Update the browser/URL history with new parameters
+ * NOTE: This has not been tested for profile-based journeys.
+ */
+export function setUrlSearch(params, replaceCurrent = false) {
+  return function (dispatch, getState) {
+    const base = getState().router.location.pathname
+    const path = `${base}?${qs.stringify(params, { arrayFormat: 'repeat' })}`
+    if (replaceCurrent) dispatch(replace(path))
+    else dispatch(push(path))
+  }
+}
+
+/**
+ * Update the OTP Query parameters in the URL and ensure that the active search
+ * is set correctly. Leaves any other existing URL parameters (e.g., UI) unchanged.
+ */
+export function updateOtpUrlParams(state, searchId) {
+  const { config, currentQuery } = state.otp
+  // Get updated OTP params from current query.
+  const otpParams = getRoutingParams(config, currentQuery, true)
+  return function (dispatch, getState) {
+    const params = {}
+    // Get all URL params and ensure non-routing params (UI, sessionId) remain
+    // unchanged.
+    const urlParams = getUrlParams()
+    Object.keys(urlParams)
+      // If param is non-routing, add to params to keep the same after update.
+      .filter((key) => key.indexOf('_') !== -1 || key === 'sessionId')
+      .forEach((key) => {
+        params[key] = urlParams[key]
+      })
+    params.ui_activeSearch = searchId
+    // Assumes this is a new search and the active itinerary should be reset.
+    params.ui_activeItinerary = config.itinerary?.showFirstResultByDefault
+      ? 0
+      : -1
+    // Merge in the provided OTP params and update the URL.
+    dispatch(setUrlSearch(Object.assign(params, otpParams)))
   }
 }
 
@@ -240,71 +346,145 @@ export function routingQuery(searchId = null, updateSearchInReducer = false) {
   }
 }
 
-function getJsonAndCheckResponse(res) {
-  if (res.status >= 400) {
-    const error = new Error('Received error from server')
-    error.response = res
-    throw error
+/**
+ * Creates the URL to use for making an API request.
+ *
+ * @param  {Object} config   The app-wide config
+ * @param  {string} endpoint The API endpoint path
+ * @param  {Object} options  The options object for the API request
+ * @return {string}          The URL to use for making the http request
+ */
+function makeApiUrl(config, endpoint, options) {
+  let url
+  if (
+    options.serviceId &&
+    config.alternateTransitIndex &&
+    config.alternateTransitIndex.services.includes(options.serviceId)
+  ) {
+    console.log('Using alt service for ' + options.serviceId)
+    url = config.alternateTransitIndex.apiRoot + endpoint
+  } else {
+    const api = config.api
+
+    // Don't crash if no api is defined (such as in the unit test env)
+    if (!api?.host) return null
+
+    url = `${api.host}${api.port ? ':' + api.port : ''}${api.path}/${endpoint}`
   }
-  return res.json()
+  return url
+}
+
+const throttledUrls = {}
+
+function now() {
+  return new Date().getTime()
+}
+
+const TEN_SECONDS = 10000
+
+// automatically clear throttled urls older than 10 seconds
+window.setInterval(() => {
+  Object.keys(throttledUrls).forEach((key) => {
+    if (throttledUrls[key] < now() - TEN_SECONDS) {
+      delete throttledUrls[key]
+    }
+  })
+}, 1000)
+
+/**
+ * Handle throttling URL.
+ * @param  {[type]} url - API endpoint path
+ * @param  {FetchOptions} fetchOptions - fetch options (e.g., method, body, headers).
+ * @return {?number} - null if the URL has already been requested in the last
+ *   ten seconds, otherwise the UNIX epoch millis of the request time
+ */
+function handleThrottlingUrl(url, fetchOptions) {
+  const throttleKey = fetchOptions ? `${url}-${hash(fetchOptions)}` : url
+  if (
+    throttledUrls[throttleKey] &&
+    throttledUrls[throttleKey] > now() - TEN_SECONDS
+  ) {
+    // URL already had a request within last 10 seconds, warn and exit
+    console.warn(`Request throttled for url: ${url}`)
+    return null
+  }
+  throttledUrls[throttleKey] = now()
+  return throttledUrls[throttleKey]
 }
 
 /**
- * This method determines the fetch options (including API key and Authorization headers) for the OTP API.
- * - If the OTP server is not the middleware server (standalone OTP server),
- *   an empty object is returned.
- * - If the OTP server is the same as the middleware server,
- *   then an object is returned with the following:
- *   - A middleware API key, if it has been set in the configuration (it is most likely required),
- *   - An Auth0 accessToken, when includeToken is true and a user is logged in (userState.loggedInUser is not null).
- * This method assumes JSON request bodies.)
+ * Generic helper for constructing API queries. Automatically throttles queries
+ * to url to no more than once per 10 seconds.
+ *
+ * @param {string} endpoint - The API endpoint path (does not include
+ *   '../otp/routers/router_id/')
+ * @param {Function} responseAction - Action to dispatch on a successful API
+ *   response. Accepts payload object parameter.
+ * @param {Function} errorAction - Function to invoke on API error response.
+ *   Accepts error object parameter.
+ * @param {Options} options - Any of the following optional settings:
+ *   - rewritePayload: Function to be invoked to modify payload before being
+ *       passed to responseAction. Accepts and returns payload object.
+ *   - postprocess: Function to be invoked after responseAction is invoked.
+ *       Accepts payload, dispatch, getState parameters.
+ *   - serviceId: identifier for TransitIndex service used in
+ *       alternateTransitIndex configuration.
+ *   - fetchOptions: fetch options (e.g., method, body, headers).
  */
-function getOtpFetchOptions(state, includeToken = false) {
-  let apiBaseUrl, apiKey, token
+export function createQueryAction(
+  endpoint,
+  responseAction,
+  errorAction,
+  options = {}
+) {
+  /* eslint-disable-next-line complexity */
+  return async function (dispatch, getState) {
+    const state = getState()
+    const { config } = state.otp
+    const url = makeApiUrl(config, endpoint, options)
 
-  const { api, persistence } = state.otp.config
-  if (persistence && persistence.otp_middleware) {
-    // Prettier does not understand the syntax on this line
-    // eslint-disable-next-line prettier/prettier
-    ({ apiBaseUrl, apiKey } = persistence.otp_middleware)
-  }
-
-  const isOtpServerSameAsMiddleware = apiBaseUrl === api.host
-  if (isOtpServerSameAsMiddleware) {
-    if (includeToken && state.user) {
-      const { accessToken, loggedInUser } = state.user
-      if (accessToken && loggedInUser) {
-        token = accessToken
-      }
+    if (!options.noThrottle) {
+      // Don't make a request to a URL that has already seen the same request
+      // within the last 10 seconds
+      if (!handleThrottlingUrl(url, options.fetchOptions)) return
     }
 
-    return getSecureFetchOptions(token, apiKey)
-  } else {
-    return {}
-  }
-}
+    let payload
+    try {
+      // Need to merge headers to support graphQL POST request with an api key
+      const mergedHeaders = {
+        ...getOtpFetchOptions(state)?.headers,
+        ...options.fetchOptions?.headers
+      }
 
-function constructRoutingQuery(
-  state,
-  ignoreRealtimeUpdates,
-  injectedParams = {}
-) {
-  const { config, currentQuery } = state.otp
-  const routingType = currentQuery.routingType
-  // Check for routingType-specific API config; if none, use default API
-  const rt =
-    config.routingTypes &&
-    config.routingTypes.find((rt) => rt.key === routingType)
-  const api = (rt && rt.api) || config.api
-  const planEndpoint = `${api.host}${api.port ? ':' + api.port : ''}${
-    api.path
-  }/plan`
-  const params = {
-    ...getRoutingParams(config, currentQuery, ignoreRealtimeUpdates),
-    // Apply mode override, if specified (for batch routing).
-    ...injectedParams
+      const response = await fetch(url, {
+        ...getOtpFetchOptions(state),
+        ...options.fetchOptions,
+        headers: mergedHeaders
+      })
+
+      if (response.status >= 400) {
+        const error = new Error('Received error from server')
+        error.response = response
+        throw error
+      }
+      payload = await response.json()
+    } catch (err) {
+      return dispatch(errorAction(err))
+    }
+
+    if (typeof options.rewritePayload === 'function') {
+      dispatch(
+        responseAction(options.rewritePayload(payload, dispatch, getState))
+      )
+    } else {
+      dispatch(responseAction(payload))
+    }
+
+    if (typeof options.postprocess === 'function') {
+      options.postprocess(payload, dispatch, getState)
+    }
   }
-  return `${planEndpoint}?${qs.stringify(params, { arrayFormat: 'repeat' })}`
 }
 
 // Park and Ride location query
@@ -775,187 +955,4 @@ export const receivedVehiclePositionsError = createAction(
 
 export function getVehiclePositionsForRoute(routeId) {
   return executeOTPAction('getVehiclePositionsForRoute', routeId)
-}
-
-const throttledUrls = {}
-
-function now() {
-  return new Date().getTime()
-}
-
-const TEN_SECONDS = 10000
-
-// automatically clear throttled urls older than 10 seconds
-window.setInterval(() => {
-  Object.keys(throttledUrls).forEach((key) => {
-    if (throttledUrls[key] < now() - TEN_SECONDS) {
-      delete throttledUrls[key]
-    }
-  })
-}, 1000)
-
-/**
- * Handle throttling URL.
- * @param  {[type]} url - API endpoint path
- * @param  {FetchOptions} fetchOptions - fetch options (e.g., method, body, headers).
- * @return {?number} - null if the URL has already been requested in the last
- *   ten seconds, otherwise the UNIX epoch millis of the request time
- */
-function handleThrottlingUrl(url, fetchOptions) {
-  const throttleKey = fetchOptions ? `${url}-${hash(fetchOptions)}` : url
-  if (
-    throttledUrls[throttleKey] &&
-    throttledUrls[throttleKey] > now() - TEN_SECONDS
-  ) {
-    // URL already had a request within last 10 seconds, warn and exit
-    console.warn(`Request throttled for url: ${url}`)
-    return null
-  }
-  throttledUrls[throttleKey] = now()
-  return throttledUrls[throttleKey]
-}
-
-/**
- * Generic helper for constructing API queries. Automatically throttles queries
- * to url to no more than once per 10 seconds.
- *
- * @param {string} endpoint - The API endpoint path (does not include
- *   '../otp/routers/router_id/')
- * @param {Function} responseAction - Action to dispatch on a successful API
- *   response. Accepts payload object parameter.
- * @param {Function} errorAction - Function to invoke on API error response.
- *   Accepts error object parameter.
- * @param {Options} options - Any of the following optional settings:
- *   - rewritePayload: Function to be invoked to modify payload before being
- *       passed to responseAction. Accepts and returns payload object.
- *   - postprocess: Function to be invoked after responseAction is invoked.
- *       Accepts payload, dispatch, getState parameters.
- *   - serviceId: identifier for TransitIndex service used in
- *       alternateTransitIndex configuration.
- *   - fetchOptions: fetch options (e.g., method, body, headers).
- */
-export function createQueryAction(
-  endpoint,
-  responseAction,
-  errorAction,
-  options = {}
-) {
-  /* eslint-disable-next-line complexity */
-  return async function (dispatch, getState) {
-    const state = getState()
-    const { config } = state.otp
-    const url = makeApiUrl(config, endpoint, options)
-
-    if (!options.noThrottle) {
-      // Don't make a request to a URL that has already seen the same request
-      // within the last 10 seconds
-      if (!handleThrottlingUrl(url, options.fetchOptions)) return
-    }
-
-    let payload
-    try {
-      // Need to merge headers to support graphQL POST request with an api key
-      const mergedHeaders = {
-        ...getOtpFetchOptions(state)?.headers,
-        ...options.fetchOptions?.headers
-      }
-
-      const response = await fetch(url, {
-        ...getOtpFetchOptions(state),
-        ...options.fetchOptions,
-        headers: mergedHeaders
-      })
-
-      if (response.status >= 400) {
-        const error = new Error('Received error from server')
-        error.response = response
-        throw error
-      }
-      payload = await response.json()
-    } catch (err) {
-      return dispatch(errorAction(err))
-    }
-
-    if (typeof options.rewritePayload === 'function') {
-      dispatch(
-        responseAction(options.rewritePayload(payload, dispatch, getState))
-      )
-    } else {
-      dispatch(responseAction(payload))
-    }
-
-    if (typeof options.postprocess === 'function') {
-      options.postprocess(payload, dispatch, getState)
-    }
-  }
-}
-
-/**
- * Creates the URL to use for making an API request.
- *
- * @param  {Object} config   The app-wide config
- * @param  {string} endpoint The API endpoint path
- * @param  {Object} options  The options object for the API request
- * @return {string}          The URL to use for making the http request
- */
-function makeApiUrl(config, endpoint, options) {
-  let url
-  if (
-    options.serviceId &&
-    config.alternateTransitIndex &&
-    config.alternateTransitIndex.services.includes(options.serviceId)
-  ) {
-    console.log('Using alt service for ' + options.serviceId)
-    url = config.alternateTransitIndex.apiRoot + endpoint
-  } else {
-    const api = config.api
-
-    // Don't crash if no api is defined (such as in the unit test env)
-    if (!api?.host) return null
-
-    url = `${api.host}${api.port ? ':' + api.port : ''}${api.path}/${endpoint}`
-  }
-  return url
-}
-
-/**
- * Update the browser/URL history with new parameters
- * NOTE: This has not been tested for profile-based journeys.
- */
-export function setUrlSearch(params, replaceCurrent = false) {
-  return function (dispatch, getState) {
-    const base = getState().router.location.pathname
-    const path = `${base}?${qs.stringify(params, { arrayFormat: 'repeat' })}`
-    if (replaceCurrent) dispatch(replace(path))
-    else dispatch(push(path))
-  }
-}
-
-/**
- * Update the OTP Query parameters in the URL and ensure that the active search
- * is set correctly. Leaves any other existing URL parameters (e.g., UI) unchanged.
- */
-export function updateOtpUrlParams(state, searchId) {
-  const { config, currentQuery } = state.otp
-  // Get updated OTP params from current query.
-  const otpParams = getRoutingParams(config, currentQuery, true)
-  return function (dispatch, getState) {
-    const params = {}
-    // Get all URL params and ensure non-routing params (UI, sessionId) remain
-    // unchanged.
-    const urlParams = getUrlParams()
-    Object.keys(urlParams)
-      // If param is non-routing, add to params to keep the same after update.
-      .filter((key) => key.indexOf('_') !== -1 || key === 'sessionId')
-      .forEach((key) => {
-        params[key] = urlParams[key]
-      })
-    params.ui_activeSearch = searchId
-    // Assumes this is a new search and the active itinerary should be reset.
-    params.ui_activeItinerary = config.itinerary?.showFirstResultByDefault
-      ? 0
-      : -1
-    // Merge in the provided OTP params and update the URL.
-    dispatch(setUrlSearch(Object.assign(params, otpParams)))
-  }
 }

--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -1,3 +1,4 @@
+// TODO: Typescript
 import { createAction } from 'redux-actions'
 import coreUtils from '@opentripplanner/core-utils'
 import debounce from 'lodash.debounce'

--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -1,5 +1,3 @@
-// TODO: Typescript
-/* eslint-disable @typescript-eslint/no-use-before-define */
 import { createAction } from 'redux-actions'
 import coreUtils from '@opentripplanner/core-utils'
 import debounce from 'lodash.debounce'
@@ -118,6 +116,60 @@ let debouncedPlanTrip // store as variable here, so it can be reused.
 let lastDebouncePlanTimeMs
 
 /**
+ * Shorthand method to evaluate auto plan strategy. It is assumed that this is
+ * being called within the context of the `formChanged` action, so presumably
+ * some query param has already changed. If further checking of query params is
+ * needed, additional strategies should be added.
+ */
+const evaluateAutoPlanStrategy = (
+  strategy,
+  fromChanged,
+  toChanged,
+  oneLocationChanged
+) => {
+  switch (strategy) {
+    case 'ONE_LOCATION_CHANGED':
+      if (oneLocationChanged) return true
+      break
+    case 'BOTH_LOCATIONS_CHANGED':
+      if (fromChanged && toChanged) return true
+      break
+    case 'ANY':
+      return true
+    default:
+      return false
+  }
+}
+
+/**
+ * Check if the trip should be replanned based on the auto plan strategy,
+ * whether the mobile view is active, and the old/new queries. Response type is
+ * an object containing various booleans.
+ */
+export function checkShouldReplanTrip(autoPlan, isMobile, oldQuery, newQuery) {
+  // Determine if either from/to location has changed
+  const fromChanged = !isEqual(oldQuery.from, newQuery.from)
+  const toChanged = !isEqual(oldQuery.to, newQuery.to)
+  const oneLocationChanged =
+    (fromChanged && !toChanged) || (!fromChanged && toChanged)
+  // Check whether a trip should be auto-replanned
+  const strategy =
+    isMobile && autoPlan?.mobile ? autoPlan?.mobile : autoPlan?.default
+  const shouldReplanTrip = evaluateAutoPlanStrategy(
+    strategy,
+    fromChanged,
+    toChanged,
+    oneLocationChanged
+  )
+  return {
+    fromChanged,
+    oneLocationChanged,
+    shouldReplanTrip,
+    toChanged
+  }
+}
+
+/**
  * This action is dispatched when a change between the old query and new query
  * is detected. It handles checks for whether the trip should be replanned
  * (based on autoPlan strategies) as well as updating the UI state (esp. for
@@ -166,59 +218,5 @@ export function formChanged(oldQuery, newQuery) {
       }
       debouncedPlanTrip()
     }
-  }
-}
-
-/**
- * Check if the trip should be replanned based on the auto plan strategy,
- * whether the mobile view is active, and the old/new queries. Response type is
- * an object containing various booleans.
- */
-export function checkShouldReplanTrip(autoPlan, isMobile, oldQuery, newQuery) {
-  // Determine if either from/to location has changed
-  const fromChanged = !isEqual(oldQuery.from, newQuery.from)
-  const toChanged = !isEqual(oldQuery.to, newQuery.to)
-  const oneLocationChanged =
-    (fromChanged && !toChanged) || (!fromChanged && toChanged)
-  // Check whether a trip should be auto-replanned
-  const strategy =
-    isMobile && autoPlan?.mobile ? autoPlan?.mobile : autoPlan?.default
-  const shouldReplanTrip = evaluateAutoPlanStrategy(
-    strategy,
-    fromChanged,
-    toChanged,
-    oneLocationChanged
-  )
-  return {
-    fromChanged,
-    oneLocationChanged,
-    shouldReplanTrip,
-    toChanged
-  }
-}
-
-/**
- * Shorthand method to evaluate auto plan strategy. It is assumed that this is
- * being called within the context of the `formChanged` action, so presumably
- * some query param has already changed. If further checking of query params is
- * needed, additional strategies should be added.
- */
-const evaluateAutoPlanStrategy = (
-  strategy,
-  fromChanged,
-  toChanged,
-  oneLocationChanged
-) => {
-  switch (strategy) {
-    case 'ONE_LOCATION_CHANGED':
-      if (oneLocationChanged) return true
-      break
-    case 'BOTH_LOCATIONS_CHANGED':
-      if (fromChanged && toChanged) return true
-      break
-    case 'ANY':
-      return true
-    default:
-      return false
   }
 }

--- a/lib/actions/narrative.js
+++ b/lib/actions/narrative.js
@@ -1,8 +1,9 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
 import { createAction } from 'redux-actions'
 import coreUtils from '@opentripplanner/core-utils'
 
 import { setUrlSearch } from './api'
+
+const settingActiveitinerary = createAction('SET_ACTIVE_ITINERARY')
 
 export function setActiveItinerary(payload) {
   return function (dispatch, getState) {
@@ -14,7 +15,7 @@ export function setActiveItinerary(payload) {
     dispatch(setUrlSearch(urlParams))
   }
 }
-const settingActiveitinerary = createAction('SET_ACTIVE_ITINERARY')
+
 export const setActiveLeg = createAction('SET_ACTIVE_LEG')
 export const setActiveStep = createAction('SET_ACTIVE_STEP')
 // Set itinerary visible on map. This is used for mouse over effects with

--- a/lib/components/admin/field-trip-details.js
+++ b/lib/components/admin/field-trip-details.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-handler-names */
 /* eslint-disable react/prop-types */
 import { connect } from 'react-redux'
 import { DropdownButton, MenuItem } from 'react-bootstrap'

--- a/lib/components/app/app-menu.tsx
+++ b/lib/components/app/app-menu.tsx
@@ -1,18 +1,13 @@
-/* eslint-disable react/jsx-handler-names */
 import { connect } from 'react-redux'
 import { FormattedMessage, injectIntl, useIntl } from 'react-intl'
-import React, { Component, Fragment } from 'react'
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import { MenuItem } from 'react-bootstrap'
 import { withRouter } from 'react-router'
 import qs from 'qs'
+import React, { Component, Fragment } from 'react'
 import SlidingPane from 'react-sliding-pane'
 import type { RouteComponentProps } from 'react-router'
 import type { WrappedComponentProps } from 'react-intl'
-// No types available, old package
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
+// @ts-expect-error Velocity-React not typescripted
 import VelocityTransitionGroup from 'velocity-react/velocity-transition-group'
 
 import * as callTakerActions from '../../actions/call-taker'

--- a/lib/components/form/mode-buttons.tsx
+++ b/lib/components/form/mode-buttons.tsx
@@ -38,9 +38,8 @@ const ModeButton = ({
   onClick: (mode: string) => void
   selected: boolean
 }): JSX.Element => {
-  // FIXME: type context
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // FIXME: add types to context
+  // @ts-expect-error No type on ComponentContext
   const { ModeIcon } = useContext(ComponentContext)
   const { icon, label, mode } = item
   const overlayTooltip = (

--- a/lib/components/map/connected-transitive-overlay.tsx
+++ b/lib/components/map/connected-transitive-overlay.tsx
@@ -2,6 +2,7 @@ import { Company, Itinerary, Leg } from '@opentripplanner/types'
 import { connect } from 'react-redux'
 import { injectIntl, IntlShape, useIntl } from 'react-intl'
 import React from 'react'
+// @ts-expect-error transitive-overlay not typescripted
 import TransitiveCanvasOverlay from '@opentripplanner/transitive-overlay'
 
 import { getTransitiveData } from '../../util/state'

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -1,4 +1,3 @@
-// REMOVE THIS LINE BEFORE EDITING THIS FILE
 import { createSelector } from 'reselect'
 import { FormattedList, FormattedMessage } from 'react-intl'
 import { isTransit } from '@opentripplanner/core-utils/lib/itinerary'
@@ -75,7 +74,7 @@ export function getFeedWideRentalErrors(response) {
  * Generates a list of issues/errors from a list of OTP responses.
  *
  * @param {Object} state the redux state object
- * @return {Array} An array of objects describing the errors seen. These could also
+ * @return {Array} An array of objects describing errors seen. These could also
  *   include an `id` and `modes` key for trip planning errors or `network` for
  *   errors with vehicle rentals.
  */

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -1,5 +1,4 @@
 // REMOVE THIS LINE BEFORE EDITING THIS FILE
-/* eslint-disable  */
 import { createSelector } from 'reselect'
 import { FormattedList, FormattedMessage } from 'react-intl'
 import { isTransit } from '@opentripplanner/core-utils/lib/itinerary'
@@ -274,157 +273,6 @@ const hashItinerary = memoize((itinerary) =>
 )
 
 /**
- * Get the active itineraries for the active search, which is dependent on
- * whether realtime or non-realtime results should be displayed
- * @param {Object} state the redux state object
- * @return {Array}      array of itinerary objects from the OTP plan response,
- *                      or null if there is no active search
- */
-export const getActiveItineraries = createSelector(
-  (state) => state.otp.config,
-  getActiveSearchNonRealtimeResponse,
-  (state) => state.otp.filter,
-  getActiveSearchRealtimeResponse,
-  getActiveFieldTripRequest,
-  (
-    config,
-    nonRealtimeResponse,
-    itinerarySortSettings,
-    realtimeResponse,
-    activeFieldTripRequest
-  ) => {
-    const response = realtimeResponse || nonRealtimeResponse
-    const itineraries = []
-    // keep track of itinerary hashes in order to not include duplicate
-    // itineraries. Duplicate itineraries can occur in batch routing where a walk
-    // to transit trip can sometimes still be the most optimal trip even when
-    // additional modes such as bike rental were also requested
-    const seenItineraryHashes = {}
-    if (response) {
-      response.forEach((res) => {
-        if (res && res.plan) {
-          res.plan.itineraries.forEach((itinerary) => {
-            // hashing takes a while on itineraries
-            const itineraryHash = hashItinerary(itinerary)
-            if (!seenItineraryHashes[itineraryHash]) {
-              itineraries.push(itinerary)
-              seenItineraryHashes[itineraryHash] = true
-            }
-          })
-        }
-      })
-    }
-    const { sort } = itinerarySortSettings
-    const { direction, type } = sort
-    // If no sort type is provided (e.g., because batch routing is not enabled),
-    // do not sort itineraries (default sort from API response is used).
-    // Also, do not sort itineraries if a field trip request is active
-    return !type || Boolean(activeFieldTripRequest)
-      ? itineraries
-      : itineraries.sort((a, b) =>
-          sortItineraries(type, direction, a, b, config)
-        )
-  }
-)
-
-/**
- * Array sort function for itineraries (in batch routing context) that attempts
- * to sort based on the type/direction specified.
- */
-/* eslint-disable-next-line complexity */
-function sortItineraries(type, direction, a, b, config) {
-  switch (type) {
-    case 'WALKTIME':
-      if (direction === 'ASC') return a.walkTime - b.walkTime
-      else return b.walkTime - a.walkTime
-    case 'ARRIVALTIME':
-      if (direction === 'ASC') return a.endTime - b.endTime
-      else return b.endTime - a.endTime
-    case 'DEPARTURETIME':
-      if (direction === 'ASC') return a.startTime - b.startTime
-      else return b.startTime - a.startTime
-    case 'DURATION':
-      if (direction === 'ASC') return a.duration - b.duration
-      else return b.duration - a.duration
-    case 'COST':
-      const configCosts = config.itinerary?.costs
-      // Sort an itinerary without fare information last
-      const aTotal =
-        getTotalFare(a, configCosts) === null
-          ? Number.MAX_VALUE
-          : getTotalFare(a, configCosts)
-      const bTotal =
-        getTotalFare(b, configCosts) === null
-          ? Number.MAX_VALUE
-          : getTotalFare(b, configCosts)
-      if (direction === 'ASC') return aTotal - bTotal
-      else return bTotal - aTotal
-    default:
-      if (type !== 'BEST')
-        console.warn(`Sort (${type}) not supported. Defaulting to BEST.`)
-      // FIXME: Fully implement default sort algorithm.
-      const aCost = calculateItineraryCost(a, config)
-      const bCost = calculateItineraryCost(b, config)
-      if (direction === 'ASC') return aCost - bCost
-      else return bCost - aCost
-  }
-}
-
-/**
- * Default constants for calculating itinerary "cost", i.e., how preferential a
- * particular itinerary is based on factors like wait time, total fare, drive
- * time, etc.
- */
-const DEFAULT_WEIGHTS = {
-  driveReluctance: 2,
-  durationFactor: 0.25,
-  fareFactor: 0.5,
-  transferReluctance: 0.9,
-  waitReluctance: 0.1,
-  walkReluctance: 0.1
-}
-
-/**
- * This calculates the "cost" (not the monetary cost, but the cost according to
- * multiple factors like duration, total fare, and walking distance) for a
- * particular itinerary, for use in sorting itineraries.
- * FIXME: Do major testing to get this right.
- */
-function calculateItineraryCost(itinerary, config = {}) {
-  // Initialize weights to default values.
-  const weights = DEFAULT_WEIGHTS
-  // If config contains values to override defaults, apply those.
-  const configWeights = config.itinerary && config.itinerary.weights
-  if (configWeights) Object.assign(weights, configWeights)
-  return (
-    getTotalFare(
-      itinerary,
-      config.itinerary?.costs,
-      config.itinerary?.defaultFareKey
-    ) *
-      weights.fareFactor +
-    itinerary.duration * weights.durationFactor +
-    itinerary.walkDistance * weights.walkReluctance +
-    getDriveTime(itinerary) * weights.driveReluctance +
-    itinerary.waitingTime * weights.waitReluctance +
-    itinerary.transfers * weights.transferReluctance
-  )
-}
-
-/**
- * Get total drive time (i.e., total duration for legs with mode=CAR) for an
- * itinerary.
- */
-function getDriveTime(itinerary) {
-  if (!itinerary) return 0
-  let driveTime = 0
-  itinerary.legs.forEach((leg) => {
-    if (leg.mode === 'CAR') driveTime += leg.duration
-  })
-  return driveTime
-}
-
-/**
  * Default costs for modes that currently have no costs evaluated in
  * OpenTripPlanner.
  */
@@ -497,6 +345,162 @@ export function getTotalFare(
   if (drivingCost > 0) drivingCost += costs.carParkingCostCents
   return bikeshareCost + drivingCost + transitFare + maxTNCFare * 100
 }
+
+/**
+ * Get total drive time (i.e., total duration for legs with mode=CAR) for an
+ * itinerary.
+ */
+function getDriveTime(itinerary) {
+  if (!itinerary) return 0
+  let driveTime = 0
+  itinerary.legs.forEach((leg) => {
+    if (leg.mode === 'CAR') driveTime += leg.duration
+  })
+  return driveTime
+}
+
+/**
+ * Default constants for calculating itinerary "cost", i.e., how preferential a
+ * particular itinerary is based on factors like wait time, total fare, drive
+ * time, etc.
+ */
+const DEFAULT_WEIGHTS = {
+  driveReluctance: 2,
+  durationFactor: 0.25,
+  fareFactor: 0.5,
+  transferReluctance: 0.9,
+  waitReluctance: 0.1,
+  walkReluctance: 0.1
+}
+
+/**
+ * This calculates the "cost" (not the monetary cost, but the cost according to
+ * multiple factors like duration, total fare, and walking distance) for a
+ * particular itinerary, for use in sorting itineraries.
+ * FIXME: Do major testing to get this right.
+ */
+function calculateItineraryCost(itinerary, config = {}) {
+  // Initialize weights to default values.
+  const weights = DEFAULT_WEIGHTS
+  // If config contains values to override defaults, apply those.
+  const configWeights = config.itinerary && config.itinerary.weights
+  if (configWeights) Object.assign(weights, configWeights)
+  return (
+    getTotalFare(
+      itinerary,
+      config.itinerary?.costs,
+      config.itinerary?.defaultFareKey
+    ) *
+      weights.fareFactor +
+    itinerary.duration * weights.durationFactor +
+    itinerary.walkDistance * weights.walkReluctance +
+    getDriveTime(itinerary) * weights.driveReluctance +
+    itinerary.waitingTime * weights.waitReluctance +
+    itinerary.transfers * weights.transferReluctance
+  )
+}
+
+/**
+ * Array sort function for itineraries (in batch routing context) that attempts
+ * to sort based on the type/direction specified.
+ */
+/* eslint-disable-next-line complexity */
+function sortItineraries(type, direction, a, b, config) {
+  switch (type) {
+    case 'WALKTIME':
+      if (direction === 'ASC') return a.walkTime - b.walkTime
+      else return b.walkTime - a.walkTime
+    case 'ARRIVALTIME':
+      if (direction === 'ASC') return a.endTime - b.endTime
+      else return b.endTime - a.endTime
+    case 'DEPARTURETIME':
+      if (direction === 'ASC') return a.startTime - b.startTime
+      else return b.startTime - a.startTime
+    case 'DURATION':
+      if (direction === 'ASC') return a.duration - b.duration
+      else return b.duration - a.duration
+    case 'COST':
+      // eslint-disable-next-line no-case-declarations
+      const configCosts = config.itinerary?.costs
+      // Sort an itinerary without fare information last
+      // eslint-disable-next-line no-case-declarations
+      const aTotal =
+        getTotalFare(a, configCosts) === null
+          ? Number.MAX_VALUE
+          : getTotalFare(a, configCosts)
+      // eslint-disable-next-line no-case-declarations
+      const bTotal =
+        getTotalFare(b, configCosts) === null
+          ? Number.MAX_VALUE
+          : getTotalFare(b, configCosts)
+      if (direction === 'ASC') return aTotal - bTotal
+      else return bTotal - aTotal
+    default:
+      if (type !== 'BEST')
+        console.warn(`Sort (${type}) not supported. Defaulting to BEST.`)
+      // FIXME: Fully implement default sort algorithm.
+      // eslint-disable-next-line no-case-declarations
+      const aCost = calculateItineraryCost(a, config)
+      // eslint-disable-next-line no-case-declarations
+      const bCost = calculateItineraryCost(b, config)
+      if (direction === 'ASC') return aCost - bCost
+      else return bCost - aCost
+  }
+}
+
+/**
+ * Get the active itineraries for the active search, which is dependent on
+ * whether realtime or non-realtime results should be displayed
+ * @param {Object} state the redux state object
+ * @return {Array}      array of itinerary objects from the OTP plan response,
+ *                      or null if there is no active search
+ */
+export const getActiveItineraries = createSelector(
+  (state) => state.otp.config,
+  getActiveSearchNonRealtimeResponse,
+  (state) => state.otp.filter,
+  getActiveSearchRealtimeResponse,
+  getActiveFieldTripRequest,
+  (
+    config,
+    nonRealtimeResponse,
+    itinerarySortSettings,
+    realtimeResponse,
+    activeFieldTripRequest
+  ) => {
+    const response = realtimeResponse || nonRealtimeResponse
+    const itineraries = []
+    // keep track of itinerary hashes in order to not include duplicate
+    // itineraries. Duplicate itineraries can occur in batch routing where a walk
+    // to transit trip can sometimes still be the most optimal trip even when
+    // additional modes such as bike rental were also requested
+    const seenItineraryHashes = {}
+    if (response) {
+      response.forEach((res) => {
+        if (res && res.plan) {
+          res.plan.itineraries.forEach((itinerary) => {
+            // hashing takes a while on itineraries
+            const itineraryHash = hashItinerary(itinerary)
+            if (!seenItineraryHashes[itineraryHash]) {
+              itineraries.push(itinerary)
+              seenItineraryHashes[itineraryHash] = true
+            }
+          })
+        }
+      })
+    }
+    const { sort } = itinerarySortSettings
+    const { direction, type } = sort
+    // If no sort type is provided (e.g., because batch routing is not enabled),
+    // do not sort itineraries (default sort from API response is used).
+    // Also, do not sort itineraries if a field trip request is active
+    return !type || Boolean(activeFieldTripRequest)
+      ? itineraries
+      : itineraries.sort((a, b) =>
+          sortItineraries(type, direction, a, b, config)
+        )
+  }
+)
 
 /**
  * Get the active itinerary/profile for the active search object
@@ -660,8 +664,8 @@ export const getTransitiveData = createSelector(
       if (hasItineraryResponse) {
         return itineraryToRender
           ? itineraryToTransitive(itineraryToRender, {
-      companies,
-      disableFlexArc,
+              companies,
+              disableFlexArc,
               getTransitiveRouteLabel,
               intl
             })
@@ -821,6 +825,7 @@ export function getTitle(state, intl) {
       )
       break
     default:
+      // eslint-disable-next-line no-case-declarations
       const activeSearch = getActiveSearch(state)
       if (activeSearch) {
         status = summarizeQuery(activeSearch.query, intl, user.savedLocations)


### PR DESCRIPTION
This is mostly just reordering a few huge files so that functions aren't used before they're defined, and also removed eslint-disable comments from them. I also replaced `ts-disable` with `ts-expect-error`, which doesn't require an eslint override and also will throw an error if, in the future, it is no longer needed. (Redundant `ts-expect-error` statements generate an error if there is no error)