### PR TITLE
fix(default-map): more lenient gbfs bike station parsing

### DIFF
--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -250,7 +250,8 @@ class DefaultMap extends Component {
 
     const bikeStations = [
       ...bikeRentalStations.filter(
-        (station) => station.isFloatingVehicle === false
+        (station) =>
+          !station.isFloatingVehicle || station.isFloatingVehicle === false
       ),
       ...vehicleRentalStations.filter(
         (station) => station.isFloatingBike === true


### PR DESCRIPTION
Previous bike station parsing would sometimes ignore non-floating bikes if bike-floating was not specified. This PR fixes this.

I've done some regression testing, but would appreciate a second set of eyes to make sure this doesn't break GBFS feeds unexpectedly.