### PR TITLE
Refactor Flex Reduction to be Optional

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -176,7 +176,7 @@ geocoder:
 modes:
   # This is the default behavior for flex merging.
   # If set to false, each FLEX mode (FLEX_EGRESS,FLEX_ACCESS,FLEX_DIRECT) will 
-  # be treated seperately. If set to true, a single FLEX mode will automatically 
+  # be treated separately. If set to true, a single FLEX mode will automatically 
   # be expanded and reduced to those three modes.
   mergeFlex: true 
   modeOptions:

--- a/example-config.yml
+++ b/example-config.yml
@@ -174,6 +174,11 @@ geocoder:
 
 # Use this mode config for the enhanced Transit+ config
 modes:
+  # This is the default behavior for flex merging.
+  # If set to false, each FLEX mode (FLEX_EGRESS,FLEX_ACCESS,FLEX_DIRECT) will 
+  # be treated seperately. If set to true, a single FLEX mode will automatically 
+  # be expanded and reduced to those three modes.
+  mergeFlex: true 
   modeOptions:
     - mode: TRANSIT
     - mode: WALK


### PR DESCRIPTION
Makes use of https://github.com/opentripplanner/otp-ui/pull/431 to enable the use of `FLEX_EGRESS,FLEX_ACCESS,FLEX_DIRECT` as distinct modes.