### PR TITLE
refactor(route-block): don't render multi-route view unless it will fit

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -232,6 +232,7 @@ components:
     fromStop: "from {stop}"
     orAlternatives: or other routes in the same direction
     itineraryDescription: "{time} itinerary using {routes}"
+    multipleOptions: Multiple Options
   MobileOptions:
     header: Set Search Options
   ModeDropdown:

--- a/lib/components/narrative/metro/route-block.tsx
+++ b/lib/components/narrative/metro/route-block.tsx
@@ -123,6 +123,8 @@ const RouteBlock = ({
     leg?.alternateRoutes &&
     Object.entries(leg.alternateRoutes || {}).every(
       (altRoute) =>
+        // This 7 does a good job at filtering out most problematic short names,
+        // but may be revistited in the future depending on what feeds cause issues
         altRoute[1].routeShortName && altRoute[1].routeShortName.length > 7
     )
 

--- a/lib/components/narrative/metro/route-block.tsx
+++ b/lib/components/narrative/metro/route-block.tsx
@@ -1,4 +1,4 @@
-import { FormattedMessage } from 'react-intl'
+import { FormattedMessage, useIntl } from 'react-intl'
 import { Leg } from '@opentripplanner/types'
 import { RouteLongName } from '@opentripplanner/itinerary-body/lib/defaults'
 import React, { useContext } from 'react'
@@ -37,13 +37,14 @@ const Wrapper = styled.span`
   }
 `
 
-const MultiWrapper = styled.span<{ multi?: boolean }>`
+const MultiWrapper = styled.span<{ italic?: boolean; multi?: boolean }>`
   display: flex;
   flex-direction: row;
   gap: 5px;
   grid-column: 2;
   grid-row: 1;
 
+  ${({ italic }) => italic && 'font-style: italic;'}
   ${({ multi }) =>
     multi
       ? `
@@ -101,17 +102,40 @@ const Divider = styled.span`
   opacity: 0.4;
 `
 
+// eslint-disable-next-line complexity
 const RouteBlock = ({
   footer,
   hideLongName,
-  leg,
+  leg: rawLeg,
   LegIcon,
   previousLegMode,
   showDivider
 }: Props): React.ReactElement | null => {
   // @ts-expect-error React context is populated dynamically
   const { RouteRenderer } = useContext(ComponentContext)
+  const intl = useIntl()
+
   const Route = RouteRenderer || DefaultRouteRenderer
+  const leg = { ...rawLeg }
+
+  // Determine if the routeShortName will fit!
+  const alternateRoutesAreTooLongToDisplay =
+    leg?.alternateRoutes &&
+    Object.entries(leg.alternateRoutes || {}).every(
+      (altRoute) =>
+        altRoute[1].routeShortName && altRoute[1].routeShortName.length > 7
+    )
+
+  // If there are too many characters, disable the multiple route display
+  if (alternateRoutesAreTooLongToDisplay) {
+    leg.alternateRoutes = undefined
+    // Only overwrite the name if we're NOT rendering the long name
+    if (hideLongName) {
+      leg.routeShortName = intl.formatMessage({
+        id: 'components.MetroUI.multipleOptions'
+      })
+    }
+  }
 
   return (
     <>
@@ -123,7 +147,10 @@ const RouteBlock = ({
           </LegIconWrapper>
         )}
         {(leg.routeShortName || leg.route || leg.routeLongName) && (
-          <MultiWrapper multi={!!leg.alternateRoutes}>
+          <MultiWrapper
+            italic={alternateRoutesAreTooLongToDisplay && hideLongName}
+            multi={!!leg.alternateRoutes}
+          >
             <Route leg={leg} />
             {Object.entries(leg?.alternateRoutes || {})?.map((altRoute) => {
               const route = altRoute[1]

--- a/lib/util/monitored-trip.js
+++ b/lib/util/monitored-trip.js
@@ -4,19 +4,19 @@ export const ALL_DAYS = [...WEEKDAYS, ...WEEKEND_DAYS]
 
 /**
  * Extracts the day of week fields of an object (e.g. a monitoredTrip) to an array.
- * Example: { monday: truthy, tuesday: falsy, wednesday: truthy ... } => ['monday', 'wednesday' ...]
+ * Example: { monday: truthy, tuesday: false-ey, wednesday: truthy ... } => ['monday', 'wednesday' ...]
  */
-export function dayFieldsToArray (monitoredTrip) {
-  return ALL_DAYS.filter(day => monitoredTrip[day])
+export function dayFieldsToArray(monitoredTrip) {
+  return ALL_DAYS.filter((day) => monitoredTrip[day])
 }
 
 /**
  * Converts an array of day of week values into an object with those fields.
  * Example: ['monday', 'wednesday' ...] => { monday: true, tuesday: false, wednesday: true ... }
  */
-export function arrayToDayFields (arrayOfDayTypes) {
+export function arrayToDayFields(arrayOfDayTypes) {
   const result = {}
-  ALL_DAYS.forEach(day => {
+  ALL_DAYS.forEach((day) => {
     result[day] = arrayOfDayTypes.includes(day)
   })
   return result
@@ -26,22 +26,22 @@ export function arrayToDayFields (arrayOfDayTypes) {
  * Returns a FormattedMessage string for the pluralised day of week via the react-intl imperative API
  * such that i18n IDs are hardcoded and can be kept track of by format.js tools
  */
-export function getFormattedDayOfWeekPlural (day, intl) {
+export function getFormattedDayOfWeekPlural(day, intl) {
   switch (day) {
     case 'monday':
-      return intl.formatMessage({id: 'common.daysOfWeekPlural.monday'})
+      return intl.formatMessage({ id: 'common.daysOfWeekPlural.monday' })
     case 'tuesday':
-      return intl.formatMessage({id: 'common.daysOfWeekPlural.tuesday'})
+      return intl.formatMessage({ id: 'common.daysOfWeekPlural.tuesday' })
     case 'wednesday':
-      return intl.formatMessage({id: 'common.daysOfWeekPlural.wednesday'})
+      return intl.formatMessage({ id: 'common.daysOfWeekPlural.wednesday' })
     case 'thursday':
-      return intl.formatMessage({id: 'common.daysOfWeekPlural.thursday'})
+      return intl.formatMessage({ id: 'common.daysOfWeekPlural.thursday' })
     case 'friday':
-      return intl.formatMessage({id: 'common.daysOfWeekPlural.friday'})
+      return intl.formatMessage({ id: 'common.daysOfWeekPlural.friday' })
     case 'saturday':
-      return intl.formatMessage({id: 'common.daysOfWeekPlural.saturday'})
+      return intl.formatMessage({ id: 'common.daysOfWeekPlural.saturday' })
     case 'sunday':
-      return intl.formatMessage({id: 'common.daysOfWeekPlural.sunday'})
+      return intl.formatMessage({ id: 'common.daysOfWeekPlural.sunday' })
     default:
       return null
   }


### PR DESCRIPTION
This PR addresses the issue of long `routeShortName`s. Really this should be handled with a GTFS fix, but until the world's GTFS follows best practices this PR avoids yucky text overflows!

This PR turns this:
<img width="448" alt="Screen Shot 2022-08-24 at 3 17 10 PM" src="https://user-images.githubusercontent.com/86619099/186428318-96ae6b5e-0d52-4808-bba8-050576f667df.png">

Into this:
<img width="446" alt="Screen Shot 2022-08-24 at 3 16 25 PM" src="https://user-images.githubusercontent.com/86619099/186428369-41e5e575-4c06-4b28-b35b-ae4aa420ba83.png">


