### PR TITLE
Map Popup Usability Improvements

### DIFF
--- a/lib/components/map/point-popup.tsx
+++ b/lib/components/map/point-popup.tsx
@@ -55,7 +55,7 @@ function MapPopup({
       <div>
         <FromToLocationPicker
           label
-          location={mapPopupLocation}
+          location={{ ...mapPopupLocation, name: popupName }}
           setLocation={onSetLocationFromPopup}
         />
       </div>

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -573,6 +573,20 @@ function createOtpReducer(config) {
           }
         })
       case 'SET_MAP_POPUP_LOCATION':
+        // If we are trying to add the name to a location, and the
+        // popup is closed or has been moved somewhere else,
+        // don't update!
+        if (
+          action.payload &&
+          action.payload.location &&
+          action.payload.location.name &&
+          (state.ui?.mapPopupLocation === null ||
+            state.ui.mapPopupLocation.lat !== action.payload.location.lat ||
+            state.ui.mapPopupLocation.lon !== action.payload.location.lon)
+        ) {
+          return state
+        }
+
         return update(state, {
           ui: {
             mapPopupLocation: { $set: action.payload.location }

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -577,9 +577,7 @@ function createOtpReducer(config) {
         // popup is closed or has been moved somewhere else,
         // don't update!
         if (
-          action.payload &&
-          action.payload.location &&
-          action.payload.location.name &&
+          action?.payload?.location?.name &&
           (state.ui?.mapPopupLocation === null ||
             state.ui.mapPopupLocation.lat !== action.payload.location.lat ||
             state.ui.mapPopupLocation.lon !== action.payload.location.lon)

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -579,8 +579,10 @@ function createOtpReducer(config) {
         if (
           action?.payload?.location?.name &&
           (state.ui?.mapPopupLocation === null ||
-            state.ui.mapPopupLocation.lat !== action.payload.location.lat ||
-            state.ui.mapPopupLocation.lon !== action.payload.location.lon)
+            !coreUtils.map.matchLatLon(
+              state.ui.mapPopupLocation,
+              action.payload.location
+            ))
         ) {
           return state
         }


### PR DESCRIPTION
There were a few bugs surrounding the map popup.

If clicking around the map rapidly, the popup would move without user consent as reverse geocoding results came in delayed. This has now been fixed.

There was a second bug where the from-to-picker would sometimes not supply a name to the location field when the reverse geocoding result hadn't arrived yet.

This PR resolves both of these small bugs!

This PR is BLOCKED by any other PR that resolves the `falsy` code spell issue.