### PR TITLE
chore(configs): Remove unused longDateFormat.

### DIFF
--- a/a11y/test-config.yml
+++ b/a11y/test-config.yml
@@ -113,4 +113,3 @@ modes:
 dateTime:
   timeFormat: h:mm a
   dateFormat: MM/dd/yyyy
-  longDateFormat: MMMM D, YYYY

--- a/example-config.yml
+++ b/example-config.yml
@@ -484,9 +484,6 @@ itinerary:
 # default is 60 seconds.
 # onTimeThresholdSeconds: 60
 
-# Format the date time format for display.
-dateTime:
-  longDateFormat: DD-MM-YYYY
 # stopViewer:
 #   # The radius (in meters) to use when searching for nearby stops and other
 #   # amenities (rental vehicles, park and rides) to show for the focused stop.

--- a/percy/har-mock-config.yml
+++ b/percy/har-mock-config.yml
@@ -113,4 +113,3 @@ modes:
 dateTime:
   timeFormat: h:mm a
   dateFormat: MM/dd/yyyy
-  longDateFormat: MMMM D, YYYY


### PR DESCRIPTION
This removes configuration entries for `longDateFormat` that are no longer used by UI components.