### PR TITLE
More lenient browser targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
     "globalSetup": "<rootDir>/__tests__/test-utils/global-setup.js"
   },
   "browserslist": [
-    ">0.2%",
+    ">20%",
     "not dead",
     "not op_mini all"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6385,9 +6385,9 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   integrity sha512-+Vyv92BCj8QTH3pxlxmhXdwqAD+OngU5Ev7OiXG/cfNhJIP3lSE5wxIwW2TFpRj02PE/mAZF8po6/ZTYEa9/tg==
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001251:
-  version "1.0.30001310"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001310.tgz"
-  integrity sha512-cb9xTV8k9HTIUA3GnPUJCk0meUnrHL5gy5QePfDjxHyNBcnzPzrHFv5GqfP7ue5b1ZyzZL0RJboD6hQlPXjhjg==
+  version "1.0.30001393"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001393.tgz"
+  integrity sha512-N/od11RX+Gsk+1qY/jbPa0R6zJupEa0lxeBG598EbrtblxVCTJsQwbRBm6+V+rxpc5lHKdsXb9RY83cZIPLseA==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Many otp-rr users are using older computers/browsers. Targeting 0.2% latest is causing problems on some of these older browsers. Since the bundle size is massive anyway, we might as well support an extra few browsers.