### PR TITLE
Split findRoutes() into OTP1/2-specific implementations

### DIFF
--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -701,29 +701,8 @@ export function findStopTimesForStop(params) {
 
 // Routes lookup query
 
-const findRoutesResponse = createAction('FIND_ROUTES_RESPONSE')
-const findRoutesError = createAction('FIND_ROUTES_ERROR')
-
-export function findRoutes(params) {
-  return createQueryAction(
-    'index/routes',
-    findRoutesResponse,
-    findRoutesError,
-    {
-      postprocess: (payload, dispatch) => {
-        dispatch(setViewedStop(null))
-      },
-      rewritePayload: (payload) => {
-        const routes = {}
-        payload.forEach((rte) => {
-          routes[rte.id] = rte
-        })
-        return routes
-      },
-      serviceId: 'routes'
-    }
-  )
-}
+export const findRoutesResponse = createAction('FIND_ROUTES_RESPONSE')
+export const findRoutesError = createAction('FIND_ROUTES_ERROR')
 
 // Patterns for Route lookup query
 // TODO: replace with GraphQL query for route => patterns => geometry
@@ -741,6 +720,10 @@ export const findRouteError = createAction('FIND_ROUTE_ERROR')
 
 export function findRoute(params) {
   return executeOTPAction('findRoute', params)
+}
+
+export function findRoutes(params) {
+  return executeOTPAction('findRoutes', params)
 }
 
 export function findPatternsForRoute(params) {

--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -704,6 +704,10 @@ export function findStopTimesForStop(params) {
 export const findRoutesResponse = createAction('FIND_ROUTES_RESPONSE')
 export const findRoutesError = createAction('FIND_ROUTES_ERROR')
 
+export function findRoutes(params) {
+  return executeOTPAction('findRoutes', params)
+}
+
 // Patterns for Route lookup query
 // TODO: replace with GraphQL query for route => patterns => geometry
 export const findPatternsForRouteResponse = createAction(
@@ -720,10 +724,6 @@ export const findRouteError = createAction('FIND_ROUTE_ERROR')
 
 export function findRoute(params) {
   return executeOTPAction('findRoute', params)
-}
-
-export function findRoutes(params) {
-  return executeOTPAction('findRoutes', params)
 }
 
 export function findPatternsForRoute(params) {

--- a/lib/actions/apiV1.js
+++ b/lib/actions/apiV1.js
@@ -13,6 +13,8 @@ import {
   findRouteError,
   findRouteResponse,
   findRoutesAtStop,
+  findRoutesError,
+  findRoutesResponse,
   findStopError,
   findStopResponse,
   findStopsForPattern,
@@ -234,10 +236,32 @@ export const findRoute = (params) =>
     }
   )
 
+export function findRoutes() {
+  return createQueryAction(
+    'index/routes',
+    findRoutesResponse,
+    findRoutesError,
+    {
+      postprocess: (payload, dispatch) => {
+        dispatch(setViewedStop(null))
+      },
+      rewritePayload: (payload) => {
+        const routes = {}
+        payload.forEach((rte) => {
+          routes[rte.id] = rte
+        })
+        return routes
+      },
+      serviceId: 'routes'
+    }
+  )
+}
+
 export default {
   fetchStopInfo,
   findPatternsForRoute,
   findRoute,
+  findRoutes,
   findTrip,
   getVehiclePositionsForRoute,
   vehicleRentalQuery

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -521,9 +521,10 @@ const getVehiclePositionsForRoute = (routeId) =>
   }
 
 /**
- * Helper function to extract the agency id string from an OTP2-generated agency id.
+ * Helper function to extract the agency id string from an OTP2-generated agency id,
+ * so it matches the (simple) agency id defined in config.
  */
-function getAgencyId(agency /* Agency */) {
+function getAgencyIdMatchingConfig(agency /* Agency */) {
   const agencyParts = agency.id.split(':')
   // agencyId is the last portion of agencyParts (the first one is the feed id).
   return agencyParts[agencyParts.length - 1]
@@ -615,10 +616,7 @@ export const findRoute = (params) =>
             })
             newRoute.patterns = routePatterns
             // TODO: avoid explicit behavior shift like this
-            // The OTP2-generated agency id is in the form `feedId:agencyId`, so we need to extract the portion we want.
-            newRoute.agency.id = getAgencyId(newRoute.agency)
-            newRoute.sortOrder = -999
-            newRoute.sortOrderSet = false
+            newRoute.agency.id = getAgencyIdMatchingConfig(newRoute.agency)
             newRoute.v2 = true
 
             return newRoute
@@ -664,15 +662,13 @@ export function findRoutes() {
             return routes.reduce(
               (result, { agency, color, id, longName, mode, shortName }) => {
                 result[id] = {
-                  // The OTP2-generated agency id is in the form `feedId:agencyId`, so we need to extract the portion we want.
-                  agencyId: getAgencyId(agency),
+                  agencyId: getAgencyIdMatchingConfig(agency),
                   agencyName: agency.name,
                   color,
                   id,
                   longName,
                   mode,
                   shortName,
-                  sortOrder: -999,
                   v2: true
                 }
                 return result

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -7,6 +7,8 @@ import {
   findNearbyAmenitiesResponse,
   findRouteError,
   findRouteResponse,
+  findRoutesError,
+  findRoutesResponse,
   findStopError,
   findStopResponse,
   findStopTimesForTrip,
@@ -610,6 +612,68 @@ export const findRoute = (params) =>
     )
   }
 
+export function findRoutes() {
+  return function (dispatch) {
+    dispatch(
+      createGraphQLQueryAction(
+        `{
+          routes {
+            id: gtfsId
+            desc
+            agency {
+              id: gtfsId
+              name
+              url
+              timezone
+              lang
+              phone
+            }
+            longName
+            shortName
+            type
+            mode
+            color
+            textColor
+            bikesAllowed
+            routeBikesAllowed: bikesAllowed      
+          }
+        }
+      `,
+        {},
+        findRoutesResponse,
+        findRoutesError,
+        {
+          noThrottle: true,
+          // TODO: avoid re-writing OTP2 route object to match OTP1 style
+          rewritePayload: (payload) => {
+            if (payload.errors) {
+              return dispatch(findRoutesError(payload.errors))
+            }
+            const { routes } = payload?.data
+            if (!routes) return
+
+            return routes.map(
+              ({ agency, color, id, longName, mode, shortName }) => {
+                const agencyParts = agency.id.split(':')
+                return {
+                  agencyId: agencyParts[agencyParts.length === 2 ? 1 : 0],
+                  agencyName: agency.name,
+                  color,
+                  id,
+                  longName,
+                  mode,
+                  shortName,
+                  v2: true
+                }
+              }
+            )
+          }
+        }
+      )
+    )
+  }
+}
+
 export const findPatternsForRoute = (params) =>
   function (dispatch, getState) {
     const state = getState()
@@ -628,6 +692,7 @@ export default {
   fetchStopInfo,
   findPatternsForRoute,
   findRoute,
+  findRoutes,
   findTrip,
   getVehiclePositionsForRoute,
   vehicleRentalQuery

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -643,11 +643,14 @@ export function findRoutes() {
             const { routes } = payload?.data
             if (!routes) return
 
-            return routes.map(
-              ({ agency, color, id, longName, mode, shortName }) => {
+            // To initialize the route viewer,
+            // convert the routes array to a dictionary indexed by route ids.
+            return routes.reduce(
+              (result, { agency, color, id, longName, mode, shortName }) => {
                 const agencyParts = agency.id.split(':')
-                return {
-                  agencyId: agencyParts[agencyParts.length === 2 ? 1 : 0],
+                result[id] = {
+                  // agencyId is the last portion of agencyParts (the first one is the feed id)
+                  agencyId: agencyParts[agencyParts.length - 1],
                   agencyName: agency.name,
                   color,
                   id,
@@ -656,7 +659,9 @@ export function findRoutes() {
                   shortName,
                   v2: true
                 }
-              }
+                return result
+              },
+              {}
             )
           }
         }

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -619,23 +619,14 @@ export function findRoutes() {
         `{
           routes {
             id: gtfsId
-            desc
             agency {
               id: gtfsId
               name
-              url
-              timezone
-              lang
-              phone
             }
             longName
             shortName
-            type
             mode
             color
-            textColor
-            bikesAllowed
-            routeBikesAllowed: bikesAllowed      
           }
         }
       `,

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -520,6 +520,15 @@ const getVehiclePositionsForRoute = (routeId) =>
     )
   }
 
+/**
+ * Helper function to extract the agency id string from an OTP2-generated agency id.
+ */
+function getAgencyId(agency /* Agency */) {
+  const agencyParts = agency.id.split(':')
+  // agencyId is the last portion of agencyParts (the first one is the feed id).
+  return agencyParts[agencyParts.length - 1]
+}
+
 export const findRoute = (params) =>
   function (dispatch, getState) {
     const { routeId } = params
@@ -606,6 +615,8 @@ export const findRoute = (params) =>
             })
             newRoute.patterns = routePatterns
             // TODO: avoid explicit behavior shift like this
+            // The OTP2-generated agency id is in the form `feedId:agencyId`, so we need to extract the portion we want.
+            newRoute.agency.id = getAgencyId(newRoute.agency)
             newRoute.sortOrder = -999
             newRoute.sortOrderSet = false
             newRoute.v2 = true
@@ -652,10 +663,9 @@ export function findRoutes() {
             // convert the routes array to a dictionary indexed by route ids.
             return routes.reduce(
               (result, { agency, color, id, longName, mode, shortName }) => {
-                const agencyParts = agency.id.split(':')
                 result[id] = {
-                  // agencyId is the last portion of agencyParts (the first one is the feed id)
-                  agencyId: agencyParts[agencyParts.length - 1],
+                  // The OTP2-generated agency id is in the form `feedId:agencyId`, so we need to extract the portion we want.
+                  agencyId: getAgencyId(agency),
                   agencyName: agency.name,
                   color,
                   id,

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -520,16 +520,6 @@ const getVehiclePositionsForRoute = (routeId) =>
     )
   }
 
-/**
- * Helper function to extract the agency id string from an OTP2-generated agency id,
- * so it matches the (simple) agency id defined in config.
- */
-function getAgencyIdMatchingConfig(agency /* Agency */) {
-  const agencyParts = agency.id.split(':')
-  // agencyId is the last portion of agencyParts (the first one is the feed id).
-  return agencyParts[agencyParts.length - 1]
-}
-
 export const findRoute = (params) =>
   function (dispatch, getState) {
     const { routeId } = params
@@ -616,7 +606,6 @@ export const findRoute = (params) =>
             })
             newRoute.patterns = routePatterns
             // TODO: avoid explicit behavior shift like this
-            newRoute.agency.id = getAgencyIdMatchingConfig(newRoute.agency)
             newRoute.v2 = true
 
             return newRoute
@@ -662,7 +651,7 @@ export function findRoutes() {
             return routes.reduce(
               (result, { agency, color, id, longName, mode, shortName }) => {
                 result[id] = {
-                  agencyId: getAgencyIdMatchingConfig(agency),
+                  agencyId: agency.id,
                   agencyName: agency.name,
                   color,
                   id,

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -540,11 +540,14 @@ export const findRoute = (params) =>
             phone
           }
           longName
+          shortName
+          mode
           type
           color
           textColor
           bikesAllowed
           routeBikesAllowed: bikesAllowed
+          url
       
           patterns {
             id
@@ -603,6 +606,8 @@ export const findRoute = (params) =>
             })
             newRoute.patterns = routePatterns
             // TODO: avoid explicit behavior shift like this
+            newRoute.sortOrder = -999
+            newRoute.sortOrderSet = false
             newRoute.v2 = true
 
             return newRoute
@@ -657,6 +662,7 @@ export function findRoutes() {
                   longName,
                   mode,
                   shortName,
+                  sortOrder: -999,
                   v2: true
                 }
                 return result

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -131,7 +131,11 @@ export class RouteRow extends PureComponent {
 
   _onMouseEnter = () => {
     const { findRoute, route } = this.props
-    findRoute({ routeId: route.id })
+    // Fetch route details (patterns) only if they have not been obtained before.
+    if (!route.patterns) {
+      // TODO: limit the calls to findRoute if another one is already pending.
+      findRoute({ routeId: route.id })
+    }
   }
 
   // Used to ensure details are visible until animation completes


### PR DESCRIPTION
This (minimal) PR splits `findRoutes` from the API actions into OTP1 and OTP2 versions and fetch route and agency data while taking advantage of OTP2 graphql endpoint.