### PR TITLE
fix(components/narriative/utils): resolve a11y routing fa regression

### DIFF
--- a/lib/components/narrative/utils.tsx
+++ b/lib/components/narrative/utils.tsx
@@ -19,7 +19,7 @@ export function localizeGradationMap(
   gradationMap?: Record<string, any>
 ): Record<string, any> {
   if (!gradationMap) return {}
-  const newGradationMap: Record<string, any> = {}
+  const newGradationMap: Record<string, any> = { ...gradationMap }
 
   Object.keys(newGradationMap).forEach((key) => {
     // As these localization keys are in the config, rather than


### PR DESCRIPTION
Everyone missed a pretty glaring error in #651! This prevented the accessibility routing from working correctly. This PR resolves this and fixes accessibility labels.