### PR TITLE
Reduce API calls from Route Viewer.

### DIFF
--- a/__tests__/reducers/__snapshots__/create-otp-reducer.js.snap
+++ b/__tests__/reducers/__snapshots__/create-otp-reducer.js.snap
@@ -97,6 +97,7 @@ Object {
   },
   "transitIndex": Object {
     "routes": Object {},
+    "routesFetchStatus": 0,
     "stops": Object {},
     "trips": Object {},
   },

--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -738,7 +738,7 @@ export function findRouteIfNeeded(params) {
     if (!routeId) return
 
     // If route details were already requested or fetched, don't fetch them again.
-    const route = (getState().otp.transitIndex.routes || {})[routeId]
+    const route = getState().otp.transitIndex.routes?.[routeId]
     if (route?.patterns || route?.pending) return
 
     dispatch(findingRoute(routeId))

--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -8,6 +8,7 @@ import coreUtils from '@opentripplanner/core-utils'
 import qs from 'qs'
 
 import { convertToPlace, getPersistenceMode } from '../util/user'
+import { FETCH_STATUS } from '../util/constants'
 import { getSecureFetchOptions } from '../util/middleware'
 import { getStopViewerConfig, queryIsValid } from '../util/state'
 
@@ -701,11 +702,19 @@ export function findStopTimesForStop(params) {
 
 // Routes lookup query
 
+export const findingRoutes = createAction('FINDING_ROUTES')
 export const findRoutesResponse = createAction('FIND_ROUTES_RESPONSE')
 export const findRoutesError = createAction('FIND_ROUTES_ERROR')
 
-export function findRoutes(params) {
-  return executeOTPAction('findRoutes', params)
+export function findRoutesIfNeeded(params) {
+  return function (dispatch, getState) {
+    if (
+      getState().otp.transitIndex.routesFetchStatus === FETCH_STATUS.UNFETCHED
+    ) {
+      dispatch(findingRoutes())
+      dispatch(executeOTPAction('findRoutes', params))
+    }
+  }
 }
 
 // Patterns for Route lookup query

--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -738,7 +738,7 @@ export function findRouteIfNeeded(params) {
     if (!routeId) return
 
     // If route details were already requested or fetched, don't fetch them again.
-    const route = getState().otp.transitIndex.routes?.[routeId]
+    const route = getState().otp.transitIndex.routes[routeId]
     if (route?.patterns || route?.pending) return
 
     dispatch(findingRoute(routeId))

--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -719,11 +719,22 @@ export const findPatternsForRouteError = createAction(
 
 // Single Route lookup query
 
+export const findingRoute = createAction('FINDING_ROUTE')
 export const findRouteResponse = createAction('FIND_ROUTE_RESPONSE')
 export const findRouteError = createAction('FIND_ROUTE_ERROR')
 
-export function findRoute(params) {
-  return executeOTPAction('findRoute', params)
+export function findRouteIfNeeded(params) {
+  return function (dispatch, getState) {
+    const { routeId } = params
+    if (!routeId) return
+
+    // If route details were already requested or fetched, don't fetch them again.
+    const route = (getState().otp.transitIndex.routes || {})[routeId]
+    if (route?.patterns || route?.pending) return
+
+    dispatch(findingRoute(routeId))
+    dispatch(executeOTPAction('findRoute', params))
+  }
 }
 
 export function findPatternsForRoute(params) {

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -14,7 +14,7 @@ import { getPathFromParts } from '../util/ui'
 
 import { clearActiveSearch, parseUrlQueryString, setActiveSearch } from './form'
 import { clearLocation, setMapCenter } from './map'
-import { findRouteIfNeeded, setUrlSearch } from './api'
+import { findRouteIfNeeded, findRoutesIfNeeded, setUrlSearch } from './api'
 import { setActiveItinerary } from './narrative'
 import { setRouterId } from './config'
 
@@ -178,8 +178,7 @@ function idToParams(id, delimiter = ',') {
  */
 export function matchContentToUrl(map, location) {
   // eslint-disable-next-line complexity
-  return function (dispatch, getState) {
-    const state = getState()
+  return async function (dispatch, getState) {
     // This is a bit of a hack to make up for the fact that react-router does
     // not always provide the match params as expected.
     // https://github.com/ReactTraining/react-router/issues/5870#issuecomment-394194338
@@ -193,6 +192,7 @@ export function matchContentToUrl(map, location) {
     switch (root) {
       case 'route':
         if (id) {
+          await dispatch(findRoutesIfNeeded())
           dispatch(findRouteIfNeeded({ routeId: id }))
 
           // Check for pattern "submatch"

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -14,7 +14,7 @@ import { getPathFromParts } from '../util/ui'
 
 import { clearActiveSearch, parseUrlQueryString, setActiveSearch } from './form'
 import { clearLocation, setMapCenter } from './map'
-import { findRoute, setUrlSearch } from './api'
+import { findRouteIfNeeded, setUrlSearch } from './api'
 import { setActiveItinerary } from './narrative'
 import { setRouterId } from './config'
 
@@ -193,12 +193,8 @@ export function matchContentToUrl(map, location) {
     switch (root) {
       case 'route':
         if (id) {
-          // This is a bit of a hack to check if the route details have been grabbed
-          // bikesAllowed will only be populated if route details are present
-          // Moving away from manual requests should help resolve this
-          if (!state.otp.transitIndex?.routes?.[id]?.bikesAllowed) {
-            dispatch(findRoute({ routeId: id }))
-          }
+          dispatch(findRouteIfNeeded({ routeId: id }))
+
           // Check for pattern "submatch"
           const subMatch = matchPath(location.pathname, {
             exact: true,

--- a/lib/components/app/call-taker-panel.js
+++ b/lib/components/app/call-taker-panel.js
@@ -275,7 +275,7 @@ class CallTakerPanel extends Component {
             >
               <AdvancedOptions
                 currentQuery={currentQuery}
-                findRoutes={this.props.findRoutes}
+                findRoutesIfNeeded={this.props.findRoutesIfNeeded}
                 modes={modes}
                 onKeyDown={this._handleFormKeyDown}
                 routes={routes}
@@ -321,7 +321,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = {
   beginCallIfNeeded: callTakerActions.beginCallIfNeeded,
-  findRoutes: apiActions.findRoutes,
+  findRoutesIfNeeded: apiActions.findRoutesIfNeeded,
   routingQuery: apiActions.routingQuery,
   setGroupSize: fieldTripActions.setGroupSize,
   setQueryParam: formActions.setQueryParam

--- a/lib/components/form/call-taker/advanced-options.js
+++ b/lib/components/form/call-taker/advanced-options.js
@@ -55,7 +55,7 @@ class AdvancedOptions extends Component {
 
   componentDidMount() {
     // Fetch routes for banned/preferred routes selectors.
-    this.props.findRoutes()
+    this.props.findRoutesIfNeeded()
   }
 
   componentDidUpdate(prevProps) {

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -118,9 +118,13 @@ export class RouteRow extends PureComponent {
     }
   }
 
-  _onClick = () => {
-    const { findRouteIfNeeded, isActive, route, setViewedRoute } = this.props
+  _onFocusOrMouseEnter = () => {
+    const { findRouteIfNeeded, route } = this.props
     findRouteIfNeeded({ routeId: route.id })
+  }
+
+  _onClick = () => {
+    const { isActive, route, setViewedRoute } = this.props
     if (isActive) {
       // Deselect current route if active.
       setViewedRoute({ patternId: null, routeId: null })
@@ -146,6 +150,8 @@ export class RouteRow extends PureComponent {
           className="clear-button-formatting"
           isActive={isActive}
           onClick={this._onClick}
+          onFocus={this._onFocusOrMouseEnter}
+          onMouseEnter={this._onFocusOrMouseEnter}
         >
           <RouteRowElement>
             {operator && operator.logo && (

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -118,7 +118,7 @@ export class RouteRow extends PureComponent {
     }
   }
 
-  _onFocusOrMouseEnter = () => {
+  _onFocusOrEnter = () => {
     const { findRouteIfNeeded, route } = this.props
     findRouteIfNeeded({ routeId: route.id })
   }
@@ -150,9 +150,9 @@ export class RouteRow extends PureComponent {
           className="clear-button-formatting"
           isActive={isActive}
           onClick={this._onClick}
-          onFocus={this._onFocusOrMouseEnter}
-          onMouseEnter={this._onFocusOrMouseEnter}
-          onTouchStart={this._onFocusOrMouseEnter}
+          onFocus={this._onFocusOrEnter}
+          onMouseEnter={this._onFocusOrEnter}
+          onTouchStart={this._onFocusOrEnter}
         >
           <RouteRowElement>
             {operator && operator.logo && (

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -130,12 +130,8 @@ export class RouteRow extends PureComponent {
   }
 
   _onMouseEnter = () => {
-    const { findRoute, route } = this.props
-    // Fetch route details (patterns) only if they have not been obtained before.
-    if (!route.patterns) {
-      // TODO: limit the calls to findRoute if another one is already pending.
-      findRoute({ routeId: route.id })
-    }
+    const { findRouteIfNeeded, route } = this.props
+    findRouteIfNeeded({ routeId: route.id })
   }
 
   // Used to ensure details are visible until animation completes

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -119,7 +119,8 @@ export class RouteRow extends PureComponent {
   }
 
   _onClick = () => {
-    const { isActive, route, setViewedRoute } = this.props
+    const { findRouteIfNeeded, isActive, route, setViewedRoute } = this.props
+    findRouteIfNeeded({ routeId: route.id })
     if (isActive) {
       // Deselect current route if active.
       setViewedRoute({ patternId: null, routeId: null })
@@ -127,11 +128,6 @@ export class RouteRow extends PureComponent {
       // Otherwise, set active and fetch route patterns.
       setViewedRoute({ routeId: route.id })
     }
-  }
-
-  _onMouseEnter = () => {
-    const { findRouteIfNeeded, route } = this.props
-    findRouteIfNeeded({ routeId: route.id })
   }
 
   // Used to ensure details are visible until animation completes
@@ -150,7 +146,6 @@ export class RouteRow extends PureComponent {
           className="clear-button-formatting"
           isActive={isActive}
           onClick={this._onClick}
-          onMouseEnter={this._onMouseEnter}
         >
           <RouteRowElement>
             {operator && operator.logo && (

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -152,6 +152,7 @@ export class RouteRow extends PureComponent {
           onClick={this._onClick}
           onFocus={this._onFocusOrMouseEnter}
           onMouseEnter={this._onFocusOrMouseEnter}
+          onTouchStart={this._onFocusOrMouseEnter}
         >
           <RouteRowElement>
             {operator && operator.logo && (

--- a/lib/components/viewers/route-viewer.js
+++ b/lib/components/viewers/route-viewer.js
@@ -11,7 +11,7 @@ import React, { Component } from 'react'
 
 import { ComponentContext } from '../../util/contexts'
 import {
-  findRoute,
+  findRouteIfNeeded,
   findRoutes,
   getVehiclePositionsForRoute
 } from '../../actions/api'
@@ -44,7 +44,7 @@ class RouteViewer extends Component {
       mode: PropTypes.string,
       search: PropTypes.string
     }),
-    findRoute: findRoute.type,
+    findRouteIfNeeded: findRouteIfNeeded.type,
     getVehiclePositionsForRoute: getVehiclePositionsForRoute.type,
     hideBackButton: PropTypes.bool,
     modes: PropTypes.array,
@@ -130,7 +130,7 @@ class RouteViewer extends Component {
     const {
       agencies,
       filter,
-      findRoute,
+      findRouteIfNeeded,
       getVehiclePositionsForRoute,
       hideBackButton,
       intl,
@@ -308,7 +308,7 @@ class RouteViewer extends Component {
               ) || {}
             return (
               <RouteRow
-                findRoute={findRoute}
+                findRouteIfNeeded={findRouteIfNeeded}
                 getVehiclePositionsForRoute={getVehiclePositionsForRoute}
                 initialRender={initialRender}
                 intl={intl}
@@ -334,7 +334,7 @@ class RouteViewer extends Component {
 
 // connect to redux store
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   return {
     agencies: getAgenciesFromRoutes(state),
     filter: state.otp.ui.routeViewer.filter,
@@ -348,7 +348,7 @@ const mapStateToProps = (state, ownProps) => {
 }
 
 const mapDispatchToProps = {
-  findRoute,
+  findRouteIfNeeded,
   findRoutes,
   getVehiclePositionsForRoute,
   setMainPanelContent,

--- a/lib/components/viewers/route-viewer.js
+++ b/lib/components/viewers/route-viewer.js
@@ -177,7 +177,7 @@ class RouteViewer extends Component {
             </div>
 
             <div className="header-text route-expanded">
-              {route && ModeIcon && (
+              {route && !route.pending && ModeIcon && (
                 <ModeIcon
                   aria-label={getFormattedMode(
                     getModeFromRoute(route).toLowerCase(),

--- a/lib/components/viewers/route-viewer.js
+++ b/lib/components/viewers/route-viewer.js
@@ -9,12 +9,9 @@ import coreUtils from '@opentripplanner/core-utils'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
+import * as apiActions from '../../actions/api'
+import * as uiActions from '../../actions/ui'
 import { ComponentContext } from '../../util/contexts'
-import {
-  findRouteIfNeeded,
-  findRoutes,
-  getVehiclePositionsForRoute
-} from '../../actions/api'
 import {
   getAgenciesFromRoutes,
   getModesForActiveAgencyFilter,
@@ -26,11 +23,6 @@ import {
   getModeFromRoute
 } from '../../util/viewer'
 import { getFormattedMode } from '../../util/i18n'
-import {
-  setMainPanelContent,
-  setRouteViewerFilter,
-  setViewedRoute
-} from '../../actions/ui'
 import { StyledIconWrapper } from '../util/styledIcon'
 
 import { RouteName, RouteRow } from './RouteRow'
@@ -44,12 +36,12 @@ class RouteViewer extends Component {
       mode: PropTypes.string,
       search: PropTypes.string
     }),
-    findRouteIfNeeded: findRouteIfNeeded.type,
-    getVehiclePositionsForRoute: getVehiclePositionsForRoute.type,
+    findRouteIfNeeded: PropTypes.func,
+    getVehiclePositionsForRoute: PropTypes.func,
     hideBackButton: PropTypes.bool,
     modes: PropTypes.array,
     routes: PropTypes.array,
-    setViewedRoute: setViewedRoute.type,
+    setViewedRoute: PropTypes.func,
     transitOperators: PropTypes.array,
     viewedRoute: PropTypes.shape({
       patternId: PropTypes.string,
@@ -79,8 +71,7 @@ class RouteViewer extends Component {
         })
 
   componentDidMount() {
-    const { findRoutes, routes } = this.props
-    if (!routes || routes.length <= 1) findRoutes()
+    this.props.findRoutesIfNeeded()
   }
 
   /** Used to scroll to actively viewed route on load */
@@ -348,12 +339,12 @@ const mapStateToProps = (state) => {
 }
 
 const mapDispatchToProps = {
-  findRouteIfNeeded,
-  findRoutes,
-  getVehiclePositionsForRoute,
-  setMainPanelContent,
-  setRouteViewerFilter,
-  setViewedRoute
+  findRouteIfNeeded: apiActions.findRouteIfNeeded,
+  findRoutesIfNeeded: apiActions.findRoutesIfNeeded,
+  getVehiclePositionsForRoute: apiActions.getVehiclePositionsForRoute,
+  setMainPanelContent: uiActions.setMainPanelContent,
+  setRouteViewerFilter: uiActions.setRouteViewerFilter,
+  setViewedRoute: uiActions.setViewedRoute
 }
 
 export default connect(

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -211,6 +211,7 @@ export function getInitialState(userDefinedConfig) {
     },
     transitIndex: {
       routes: {},
+      routesFetchStatus: FETCH_STATUS.UNFETCHED,
       stops: {},
       trips: {}
     },
@@ -816,11 +817,18 @@ function createOtpReducer(config) {
           }
         })
 
+      case 'FINDING_ROUTES':
+        return update(state, {
+          transitIndex: { routesFetchStatus: { $set: FETCH_STATUS.FETCHING } }
+        })
       case 'FIND_ROUTES_RESPONSE':
         // If routes is undefined, initialize it w/ the full payload
         if (!state.transitIndex.routes) {
           return update(state, {
-            transitIndex: { routes: { $set: action.payload } }
+            transitIndex: {
+              routes: { $set: action.payload },
+              routesFetchStatus: { $set: FETCH_STATUS.FETCHED }
+            }
           })
         }
         // otherwise, merge new data into what's already defined

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -827,6 +827,29 @@ function createOtpReducer(config) {
         return update(state, {
           transitIndex: { routes: { $merge: action.payload } }
         })
+      case 'FINDING_ROUTE':
+        // If routes is undefined, initialize it w/ this route only
+        if (!state.transitIndex.routes) {
+          return update(state, {
+            transitIndex: {
+              routes: { $set: { [action.payload]: { pending: true } } }
+            }
+          })
+        }
+        // Otherwise, overwrite only this route
+        if (!state.transitIndex.routes[action.payload]) {
+          return update(state, {
+            transitIndex: {
+              // If it is a new route, set rather than merge with an empty object
+              routes: { [action.payload]: { $set: { pending: true } } }
+            }
+          })
+        }
+        return update(state, {
+          transitIndex: {
+            routes: { [action.payload]: { $merge: { pending: true } } }
+          }
+        })
       case 'FIND_ROUTE_RESPONSE':
         // If routes is undefined, initialize it w/ this route only
         if (!state.transitIndex.routes) {
@@ -847,7 +870,11 @@ function createOtpReducer(config) {
         }
         return update(state, {
           transitIndex: {
-            routes: { [action.payload.id]: { $merge: action.payload } }
+            routes: {
+              [action.payload.id]: {
+                $merge: { ...action.payload, pending: false }
+              }
+            }
           }
         })
       case 'FIND_PATTERNS_FOR_ROUTE_RESPONSE':


### PR DESCRIPTION
Requires #671.

This PR changes the route viewer and the api plumbing, so that only one request to fetch all routes is sent and only one request to fetch route details is sent per route. Route details are now fetched on clicking a route in the viewer instead of on mouse over.

Bugs/inefficiencies are addressed when opening route viewer in the following scenarios:
- from the initial view
- from the `/route` url, no route selected
- from the `/route/1:1234` urls to show details expanded (url, patterns) and its shape on the map
- from the `/route/1:1234/pattern/1:1234:0:01` urls to show a route pattern.