### PR TITLE
Fix regression with field trip date display

### DIFF
--- a/lib/components/admin/field-trip-details.js
+++ b/lib/components/admin/field-trip-details.js
@@ -166,11 +166,8 @@ class FieldTripDetails extends Component {
               }}
               type="date"
             />
-            {travelDateValue && (
-              <span>
-                ({formatDistanceToNow(travelDate, { addSuffix: true })})
-              </span>
-            )}
+            {travelDateValue &&
+              formatDistanceToNow(travelDate, { addSuffix: true })}
           </small>
         </div>
       </WindowHeader>

--- a/lib/components/admin/field-trip-details.js
+++ b/lib/components/admin/field-trip-details.js
@@ -8,6 +8,7 @@ import { format, formatDistanceToNow, parse } from 'date-fns'
 import {
   getDateFormat,
   // yyyy-MM-dd, which is same format required for date input controls.
+  OTP_API_DATE_FORMAT,
   OTP_API_DATE_FORMAT_DATE_FNS
 } from '@opentripplanner/core-utils/lib/time'
 import { GraduationCap } from '@styled-icons/fa-solid/GraduationCap'
@@ -87,11 +88,7 @@ class FieldTripDetails extends Component {
     // Only persist the date if it is valid (not an empty string)
     if (newDateValue !== '') {
       const { dateFormat, intl, request, setRequestDate } = this.props
-      const newDate = parse(
-        newDateValue,
-        OTP_API_DATE_FORMAT_DATE_FNS,
-        new Date()
-      )
+      const newDate = parse(newDateValue, OTP_API_DATE_FORMAT, new Date())
       const convertedRequestDate = format(newDate, dateFormat)
       setRequestDate(request, convertedRequestDate, intl)
     }
@@ -139,7 +136,9 @@ class FieldTripDetails extends Component {
     const { request } = this.props
     const { id, schoolName, travelDate: travelDateValue } = request
     const travelDate = parseDate(travelDateValue)
-    const travelDateFormatted = format(travelDate, OTP_API_DATE_FORMAT_DATE_FNS)
+    const travelDateFormatted = travelDateValue
+      ? format(travelDate, OTP_API_DATE_FORMAT)
+      : null
     return (
       <WindowHeader>
         <IconWithText Icon={GraduationCap}>
@@ -167,7 +166,11 @@ class FieldTripDetails extends Component {
               }}
               type="date"
             />
-            ({formatDistanceToNow(travelDate, { addSuffix: true })})
+            {travelDateValue && (
+              <span>
+                ({formatDistanceToNow(travelDate, { addSuffix: true })})
+              </span>
+            )}
           </small>
         </div>
       </WindowHeader>


### PR DESCRIPTION
Fixes bug where clicking on a field trip entry in the FT request list (see screenshot) caused browser crash due to date library issue. Should now work when selecting requests both with date set (e.g. requests 35-37) and not set (e.g. request 34).

<img width="481" alt="image" src="https://user-images.githubusercontent.com/653100/197563579-c1648b7c-d9fa-4adb-a724-2c0367f6e497.png">
