### PR TITLE
Attempt again to exclude non-english i18n files.

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # This step will scan for the US english strings file.
+      - run: cp ./i18n/en-US.yml ./i18n/en-US.yaml
       - uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true
@@ -16,4 +18,4 @@ jobs:
           # and all i18n resources (negative globs to only scan the English file don't seem to work).
           # Also, the a11y test file has a false positive and the ignore list does not work
           # see https://github.com/opentripplanner/otp-react-redux/pull/436/checks?check_run_id=3369380014
-          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n/!(en-US).yml
+          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n/*.yml

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -15,4 +15,4 @@ jobs:
           # skip git, yarn, pixel test script, and i18n non-english resources.
           # Also, the a11y test file has a false positive and the ignore list does not work
           # see https://github.com/opentripplanner/otp-react-redux/pull/436/checks?check_run_id=3369380014
-          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n/[!en]*.yml
+          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n/!(en).yml

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,4 +16,4 @@ jobs:
           # and all i18n resources (negative globs to only scan the English file don't seem to work).
           # Also, the a11y test file has a false positive and the ignore list does not work
           # see https://github.com/opentripplanner/otp-react-redux/pull/436/checks?check_run_id=3369380014
-          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n
+          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n/!(en-US).yml

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -15,4 +15,4 @@ jobs:
           # skip git, yarn, pixel test script, and i18n non-english resources.
           # Also, the a11y test file has a false positive and the ignore list does not work
           # see https://github.com/opentripplanner/otp-react-redux/pull/436/checks?check_run_id=3369380014
-          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n/!(en).yml
+          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n/!(en)*.yml

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -12,7 +12,8 @@ jobs:
       - uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true
-          # skip git, yarn, pixel test script, and i18n non-english resources.
+          # skip git, yarn, pixel test script,
+          # and all i18n resources (negative globs to only scan the English file don't seem to work).
           # Also, the a11y test file has a false positive and the ignore list does not work
           # see https://github.com/opentripplanner/otp-react-redux/pull/436/checks?check_run_id=3369380014
-          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n/!(en)*.yml
+          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       # This step will scan for the US english strings file.
-      - run: cp ./i18n/en-US.yml ./i18n/en-US.yaml
+      - run: cp ./i18n/en-US.yml ./i18n/_en-US.yml
       - uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true
@@ -18,4 +18,4 @@ jobs:
           # and all i18n resources (negative globs to only scan the English file don't seem to work).
           # Also, the a11y test file has a false positive and the ignore list does not work
           # see https://github.com/opentripplanner/otp-react-redux/pull/436/checks?check_run_id=3369380014
-          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n/*.yml
+          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n/[!_]*.yml

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,4 +16,4 @@ jobs:
           # and all i18n resources (negative globs to only scan the English file don't seem to work).
           # Also, the a11y test file has a false positive and the ignore list does not work
           # see https://github.com/opentripplanner/otp-react-redux/pull/436/checks?check_run_id=3369380014
-          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n/!(en-US).yml
+          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n/!(en*.yml)

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,4 +16,4 @@ jobs:
           # and all i18n resources (negative globs to only scan the English file don't seem to work).
           # Also, the a11y test file has a false positive and the ignore list does not work
           # see https://github.com/opentripplanner/otp-react-redux/pull/436/checks?check_run_id=3369380014
-          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n/!(en*.yml)
+          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n/!(en-US).yml

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -56,7 +56,7 @@ actions:
     geolocationNotSupportedError: Geolocation not supported by your browser
     unknownPositionError: Unknown error getting position
   map:
-    currentLocation: (Current Location)
+    currentLocation: (Currenttt Location)
   user:
     accountDeleted: Your user account ({email}) has been deleted.
     authTokenError: Error obtaining an authorization token.

--- a/i18n/es.yml
+++ b/i18n/es.yml
@@ -23,3 +23,396 @@ _name: Spanish
 #     so it makes sense to group them by theme (e.g. accessModes) under the 'common' category.
 
 # Messages that are generated from actions
+actions:
+  fieldTrip:
+    setDateError: 'Error al establecer la fecha:'
+    itineraryCapacityError: 'No se puede guardar el plan: este plan no se pudo guardar
+      debido a la falta de capacidad en uno o más vehículos. Por favor, vuelva a planificar
+      su viaje.'
+    maxTripRequestsExceeded: Se superó el número máximo de solicitudes de viaje sin
+      resultados válidos.
+    saveItinerariesError: 'No se pudieron guardar los itinerarios: {err}'
+    fetchFieldTripError: 'Error al obtener el viaje: {err}'
+    fetchFieldTripsError: 'Error al obtener viajes: {err}'
+    fetchTripsForDateError: 'Error al obtener viajes para la fecha de viaje: {err}'
+    incompatibleTripDateError: La fecha de viaje planificada ({tripDate}) no es el
+      día de viaje solicitado ({requestDate})
+  user:
+    accountDeleted: El ({email}) de su cuenta de usuario ha sido eliminado.
+    authTokenError: Error al obtener un token de autorización.
+    genericError: 'Se ha encontrado un error: {err}'
+    confirmDeleteMonitoredTrip: ¿Desea eliminar este viaje?
+    confirmDeletePlace: ¿Quiere eliminar este lugar?
+    emailVerificationResent: El mensaje de verificación de correo electrónico ha sido
+      reenviado.
+    itineraryExistenceCheckFailed: Comprobación de errores para ver si el viaje seleccionado
+      es posible.
+    preferencesSaved: Tus preferencias se han guardado.
+    smsInvalidCode: El código introducido no es válido. Por favor, inténtelo de nuevo.
+    smsResendThrottled: Se ha enviado un SMS de verificación al número de teléfono
+      indicado hace menos de un minuto. Por favor, inténtelo de nuevo en unos momentos.
+    smsVerificationFailed: Su teléfono no ha podido ser verificado. Quizás el código
+      que has introducido ha caducado. Solicita un nuevo código e inténtalo de nuevo.
+  location:
+    geolocationNotSupportedError: Su navegador no admite la geolocalización
+    unknownPositionError: Error desconocido al obtener la posición
+  map:
+    currentLocation: (Ubicación actual)
+  callTaker:
+    callQuerySaveError: 'Error al almacenar consultas de llamadas: {err}'
+    callSaveError: 'No se pudo guardar la llamada: {err}'
+    checkSessionError: 'Error al establecer la sesión de autorización: {err}'
+    couldNotFindCallError: No se pudo encontrar la llamada. Estamos cancelando la
+      solicitud de guardar consultas.
+    fetchCallsError: 'Error al obtener llamadas: {err}'
+    queryFetchError: 'Error al obtener consultas: {err}'
+components:
+  BatchResultsScreen:
+    expandMap: Ampliar el mapa
+    showResults: Mostrar resultados
+  BatchRoutingPanel:
+    shortTitle: Planificar viaje
+  BatchSearchScreen:
+    header: Planifica tu viaje
+  BatchSettings:
+    planTripTooltip: Planificar viaje
+    validationMessage: 'Por favor, defina los siguientes campos para planificar un
+      viaje: {issues}'
+    destination: destino
+    origin: origen
+  BeforeSignInScreen:
+    mainTitle: Te iniciando sesión
+    message: "Para acceder a esta página deberá iniciar sesión. Por favor, espere\
+      \ mientras le redirigimos a la página de inicio de sesión…\n"
+  DateTimeOptions:
+    now: Ahora
+    arriveBy: Llegue a las
+    departAt: Salida a las
+  DateTimePreview:
+    leaveNow: Salir ahora
+    range: '{startTime, time, short} a {endTime, time, short}'
+    arriveAt: Llegar {arriveTime, time, short}
+    dayLastWeek: El {formattedDayOfWeek} pasado
+    departAt: Salida {departTime, time, short}
+    editDepartOrArrival: Editar la hora de salida o de llegada
+  ErrorMessage:
+    warning: Advertencia
+    header: No se pudo planificar el viaje
+  ExistingAccountDisplay:
+    a11y: Accesibilidad
+    notifications: Notificaciones
+    places: Lugares favoritos
+    mainTitle: Mis ajustes
+    terms: Términos
+  ItinerarySummary:
+    fareCost: "{useMaxFare, select,\n  true {{minTotalFare} - {maxTotalFare}}\n  other\
+      \ {{minTotalFare}}\n }\n"
+  MapLayers:
+    bike-rental: '{companies} Bicicleta Compartida'
+    car-rental: Ubicaciones de los coches de alquiler
+    micromobility-rental: '{companies} E-Scooters'
+    park-and-ride: Ubicaciones de Park & Ride
+    satellite: Satélite
+    stops: Paradas de tránsito
+    streets: Calles
+  ModeDropdown:
+    exclusiveMode: Solo {mode}
+  NarrativeItinerariesHeader:
+    itinerariesAndIssues: '{itinerariesFound} y {numIssues}'
+    searching: Encontrando tus opciones…
+    selectArrivalTime: Hora de llegada
+    selectBest: La mejor opción
+    selectCost: Costo
+    selectDepartureTime: Hora de salida
+    selectDuration: Duración
+    selectWalkTime: Tiempo de caminata
+    viewAll: Ver todas las opciones
+    itinerariesFound: '{itineraryNum, plural, one {# itinerario encontrado} other
+      {# itinerarios encontrados}}'
+    numIssues: '{issueNum, plural, one {# problema} other {# problemas}}'
+  NewAccountWizard:
+    terms: Crear una nueva cuenta
+    finish: ¡Configuración de la cuenta completa!
+    notifications: Preferencias de notificación
+    places: Añade tus ubicaciones
+    verify: Verifique su dirección de correo electrónico
+  NotFound:
+    description: El contenido que ha solicitado no está disponible.
+    header: Contenido no encontrado
+  NotificationPrefsPane:
+    noneSelect: No me avises
+    description: Puedes recibir notificaciones sobre los viajes que realizas con frecuencia.
+    notificationChannelPrompt: ¿Cómo desea recibir las notificaciones?
+    notificationEmailDetail: 'Los correos electrónicos de notificación se enviarán
+      a:'
+  PatternRow:
+    departure: Salida
+    routeName: <strong>{routeName}</strong> A {headsign}
+    routeShort: A {headsign}
+    status: Estado
+    collapseOrExpandDepartures: "{expanded, select, \n true {Desplegable}\n other\
+      \ {Ampliar}\n } para las salidas de Route {routeName}\n"
+  PhoneNumberEditor:
+    invalidPhone: Por favor, introduzca un número de teléfono válido.
+    requestNewCode: Solicitar un nuevo código
+    verify: Verificar
+    changeNumber: Cambiar número de teléfono
+    invalidCode: Introduzca 6 dígitos para el código de validación.
+    pending: Pendiente
+    placeholder: Introduzca su número de teléfono
+    prompt: 'Introduzca su número de teléfono para las notificaciones por SMS:'
+    sendVerificationText: Enviar texto de verificación
+    smsDetail: 'Las notificaciones por SMS se enviarán a:'
+    verificationCode: 'Código de verificación:'
+    verified: Verificado
+    verificationInstructions: "Por favor, compruebe en la aplicación de mensajería\
+      \ SMS de su teléfono móvil si hay un mensaje de texto con un código de verificación,\
+      \ e introduzca el código que aparece a continuación. El código caduca a los\
+      \ 10 minutos.\n"
+  Place:
+    viewStop: Ver parada
+    deleteThisPlace: Borrar este lugar
+    enterAlert: "Introduzca el origen/destino en el formulario (o establezca mediante\
+      \ un clic en el mapa) y haga clic en el marcador resultante para establecerlo\
+      \ como lugar de {placeType}.\n"
+  PlanFirstLastButtons:
+    first: Primero
+    previous: Anteriormente
+    last: Último
+    next: Próxima
+  PlanTripButton:
+    planTrip: Planificar viaje
+  PrintLayout:
+    itinerary: Itinerario
+    toggleMap: Alternar el mapa
+  RealtimeAnnotation:
+    serviceUpdate: Actualización del servicio
+    delaysShownInResults: "Los resultados de su viaje se han ajustado en base a información\
+      \ en tiempo real. En condiciones normales, este viaje duraría {normalDuration}\
+      \ utilizando las siguientes rutas: {routes}.\n"
+  RealtimeStatusLabel:
+    early: '{minutes} antes'
+    scheduled: programado
+    late: '{minutes} de retraso'
+    onTime: a tiempo
+  RelatedPanel:
+    hideExtraStops: Ocultar las paradas adicionales
+    showExtraStops: Mostrar {count} paradas adicionales
+  RelatedStopsPanel:
+    noArrivalFound: No se ha encontrado ninguna llegada
+    viewDetails: Ver detalles
+    relatedStops: Paradas relacionadas
+  RouteDetails:
+    moreDetails: Más detalles
+    operatedBy: Servicio operado por {agencyName}
+    selectADirection: Seleccione una dirección…
+    stopsTo: Hacia
+  RouteViewer:
+    agencyFilter: Filtro de agencia
+    findARoute: Buscar una ruta
+    modeFilter: Filtro de modo
+    shortTitle: Ver rutas
+    title: Visor de rutas
+    allAgencies: Todas las agencias
+    allModes: Todos los modos
+    header: Visor de rutas
+    noFilteredRoutesFound: ¡No hay rutas que coincidan con tu filtro!
+  SavedTripEditor:
+    editSavedTrip: Editar el viaje guardado
+    saveNewTrip: Guardar un nuevo viaje
+    tripNotifications: Notificaciones de viaje
+    tripInformation: Información sobre el viaje
+    tripNotFound: Viaje no encontrado
+    tripNotFoundDescription: Lo sentimos, no se ha encontrado el viaje solicitado.
+  SavedTripList:
+    myTrips: Mis viajes
+    noSavedTripsInstructions: Realice primero una búsqueda de viajes desde el mapa.
+    noSavedTrips: No tienes viajes guardados
+    pause: Pausa
+    resume: Reanudar
+  SavedTripScreen:
+    tooManyTrips: "Ya ha alcanzado el máximo de cinco viajes guardados. Por favor,\
+      \ elimine los viajes no utilizados de sus viajes guardados e inténtelo de nuevo.\n"
+    tripNameAlreadyUsed: Otro viaje guardado ya utiliza este nombre. Por favor, elija
+      un nombre diferente.
+    tripNameRequired: Por favor, introduzca el nombre del viaje.
+  SaveTripButton:
+    signInTooltip: Por favor, inicia sesión para guardar un viaje.
+    cantSaveText: No se puede guardar
+    cantSaveTooltip: Sólo se pueden controlar los itinerarios que incluyan ride hailing
+      y no los alquileres o los viajes en coche.
+    saveTripText: Salvar el viaje
+    signInText: Iniciar sesión para guardar el viaje
+  SearchScreen:
+    header: Planifica tu viaje
+  SettingsPreview:
+    defaultPreviewText: Opciones y preferencias de tránsito
+  StopViewer:
+    noStopsFound: No se han encontrado tiempos de parada para la fecha.
+    viewSchedule: Ver horario
+    displayStopId: '<strong>ID de Parada</strong>: {stopId}'
+    flexStop: Esta es una parada flexible. Los vehículos dejarán y recogerán a los
+      pasajeros en esta zona flexible previa solicitud. Es posible que tenga que llamar
+      con antelación para el servicio en esta zona.
+    header: Visor de paradas
+    loadingText: Cargando la parada...
+    timezoneWarning: Las horas de salida se indican en <strong>{timezoneCode}</strong>.
+    viewNextArrivals: Ver próximas llegadas
+    zoomToStop: Zoom a la parada
+  TabbedItineraries:
+    mustCallAhead: ¡Hay que llamar con antelación.
+    optionNumber: Opción {optionNum, number}
+  TransitVehicleOverlay:
+    vehicleName: 'Vehículo {vehicleNumber}: '
+    in_transit_to: Próxima parada {stop}
+    incoming_at: acercándose a {stop}
+    realtimeVehicleInfo: <strong>{vehicleNameOrBlank}</strong>{relativeTime}
+    stopped_at: puertas abiertas en la {stop}
+    travelingAt: Viajando a {milesPerHour}
+  TripBasicsPane:
+    selectAtLeastOneDay: Por favor, seleccione al menos un día para el seguimiento.
+    selectedItinerary: 'Itinerario seleccionado:'
+    tripDaysPrompt: ¿Qué días hace este viaje?
+    checkingItineraryExistence: Comprobación de la existencia de itinerarios para
+      cada día de la semana…
+    tripIsAvailableOnDaysIndicated: Su viaje está disponible en los días de la semana
+      indicados anteriormente.
+    tripNamePrompt: 'Por favor, indique un nombre para este viaje:'
+    tripNotAvailableOnDay: El viaje no está disponible el {repeatedDay}
+    unsavedChangesExistingTrip: Todavía no has guardado tu viaje. Si te vas, los cambios
+      se perderán.
+    unsavedChangesNewTrip: Todavía no has guardado tu nuevo viaje. Si lo dejas, se
+      perderá.
+  TripNotificationsPane:
+    oneHour: 1 hora
+    toggleAdvancedSettings: Activar la configuración avanzada
+    altRouteRecommended: Se recomienda una ruta alternativa o un punto de transferencia
+    delaysAboveThreshold: Hay retrasos o interrupciones de más de
+    monitorThisTrip: Supervise este viaje {minutes} antes de que comience hasta que
+      termine.
+    notificationsTurnedOff: Las notificaciones están desactivadas para su cuenta.
+    notifyViaChannelWhen: 'Notifíqueme por {channel} cuando:'
+    realtimeAlertFlagged: Hay una alerta en tiempo real marcada en mi viaje
+    howToReceiveAlerts: "Para recibir alertas de tus viajes guardados, activa las\
+      \ notificaciones en la configuración de tu cuenta e intenta guardar un viaje\
+      \ de nuevo.\n"
+    advancedSettings: Configuración avanzada
+  TripStatus:
+    planNewTrip: Planificar un nuevo viaje
+    alerts: '{alerts, plural, one {# alerta!} other {# alertas!}}'
+    deleteTrip: Borrar el viaje
+  TripStatusRenderers:
+    active:
+      description: El viaje debe comenzar a las {arrivalTime, time, short}.
+      onTimeHeading: El viaje está en curso y está más o menos a tiempo.
+      delayedHeading: La hora de inicio del viaje se retrasa {formattedDuration}!
+      earlyHeading: ¡El viaje está en marcha y llega {formattedDuration} antes de
+        lo previsto!
+      noDataHeading: El viaje está en curso (no hay actualizaciones disponibles en
+        tiempo real).
+    base:
+      togglePause: Pausa
+      lastCheckedDefaultText: Hora de la última comprobación desconocida
+      lastCheckedText: 'Últimos comprobados: Hace {formattedDuration}'
+      tripIsNotSnoozed: Snooze para el resto del día
+      tripIsSnoozed: Reactivar el análisis de los viajes
+      unknownState: Estado de viaje desconocido
+      untogglePause: Reanudar
+    nextTripNotPossible:
+      heading: El viaje no es posible hoy
+      description: "El planificador de viajes no ha podido encontrar su viaje hoy.\
+        \ Intente volver a planificar su itinerario para encontrar una ruta alternativa.\n"
+    snoozed:
+      heading: El seguimiento del viaje se ha suspendido por hoy
+      description: Reactivar la supervisión del viaje para ver el estado actualizado.
+    upcoming:
+      tripBegins: El viaje debe comenzar a las {tripStart, time, short}. (El seguimiento
+        en tiempo real comenzará a las {monitoringStart, time, short}.)
+      tripStartsSoonNoUpdates: El viaje comienza pronto (no hay actualizaciones disponibles
+        en tiempo real).
+      tripStartsSoonOnTime: El viaje comienza pronto y es más o menos puntual.
+      nextTripBegins: El próximo viaje comienza el {tripDatetime, date, ::eeeee yyyyMMdd}
+        a las {tripDatetime, time, short}.
+      tripStartIsDelayed: ¡La hora de inicio del viaje se retrasa ${duration}!
+      tripStartIsEarly: ¡La hora de inicio del viaje se produce ${duration} antes
+        de lo previsto!
+    inactive:
+      description: Reanudar la supervisión del viaje para ver el estado actualizado
+      heading: La supervisión del viaje está en pausa
+    notCalculated:
+      awaiting: A la espera del cálculo…
+      description: Por favor, espere un poco para calcular el viaje.
+      heading: Viaje aún no calculado
+    noLongerPossible:
+      description: "El planificador de viajes no pudo encontrar su viaje en ninguno\
+        \ de los días seleccionados de la semana. Intente volver a planificar su itinerario\
+        \ para encontrar una ruta alternativa.\n"
+      heading: El viaje ya no es posible
+  TripSummaryPane:
+    notifications: 'Notificaciones: <strong>{leadTimeInMinutes} minutos antes de la
+      salida programada</strong>'
+    happensOnDays: 'Ocurre en: <strong>{days}</strong>'
+    notificationsDisabled: 'Notificaciones: <strong>Discapacitados</strong>'
+  TripTools:
+    reportEmailSubject: Informar un problema con OpenTripPlanner
+    reportIssue: Informar problema
+    copyLink: Copiar link
+    linkCopied: Copiado
+    reportEmailTemplate: "***INSTRUCCIONES PARA EL USUARIO***\n Esta función le permite\
+      \ enviar por correo electrónico un informe a los administradores del sitio para\
+      \ que lo revisen. Por favor, rellene los campos que aparecen a continuación\
+      \ y envíelos utilizando su programa de correo electrónico habitual.\n \n ***POR\
+      \ FAVOR COMPLETE LO SIGUIENTE***\n\n Problema encontrado:\n \n Tipo de viaje\
+      \ que querías hacer:\n\n ***Detalles técnicos***\n"
+  TripViewer:
+    accessible: Accesible
+    bicyclesAllowed: Permitido
+    header: Visor de viajes
+    routeHeader: 'Ruta: <strong>{routeShortName}</strong> {routeLongName}'
+    viewStop: Vista
+  UserAccountScreen:
+    confirmDelete: ¿Está seguro de que desea eliminar su cuenta de usuario? Una vez
+      que lo hagas, no se podrá recuperar.
+  UserSettings:
+    favoriteStops: Paradas favoritas
+    mySavedPlaces: Mis lugares guardados (<manageLink>Administrar</manageLink>)
+    noFavoriteStops: No hay paradas favoritas
+    rememberSearches: ¿Recuerda las búsquedas/lugares recientes?
+    confirmDeletion: Tienes almacenadas búsquedas o lugares recientes. Si desactiva
+      el almacenamiento de lugares o búsquedas recientes, eliminará estos elementos.
+      ¿Continuar?
+    myPreferences: Mis preferencias
+    recentPlaces: Lugares recientes
+    recentSearchSummary: '{mode} de {from} al {to}'
+    recentSearches: Búsquedas recientes
+    stopId: 'ID de Parada: {stopId}'
+  UserTripSettings:
+    forgetOptions: Olvidar mis opciones
+    rememberOptions: Recuerde las opciones de viaje
+  VerifyEmailPane:
+    emailIsVerified: ¡Mi correo electrónico está verificado!
+    instructions1: "Por favor compruebe su buzón de correo electrónico y siga el enlace\
+      \ del mensaje para verificar su dirección de correo electrónico antes de finalizar\
+      \ la configuración de su cuenta.\n"
+    instructions2: Una vez verificado, haga clic en el botón de abajo para continuar.
+    resendVerification: Reenviar el correo electrónico de verificación
+  A11yPrefs:
+    accessibilityRoutingByDefault: Prefiera los viajes accesibles por defecto
+  AmenitiesPanel:
+    noNearbyScooters: No se encontraron alquileres de micromovilidad cerca.
+    noPRLotsFound: No hay Park-and-Ride cerca.
+    nearbyAmenities: Servicios cercanos
+    noNearbyBikes: No se ha encontrado ningún alquiler de bicicletas cercano.
+    bikesAtStation: "{companyLength, plural,\n =0 {Bicicletas en la {name}}\n other\
+      \ {Bicicletas de {company} en la{name}}\n }\n"
+    bikesAvailable: "{count, plural,\n =0 {No hay bicicletas disponibles}\n one {#\
+      \ bicicleta disponible}\n other {# bicicletas disponibles}\n }\n"
+    bikesNearby: "{count, plural,\n =0 {No hay bicicletas de {company} cerca}\n one\
+      \ {# bicicleta de {company} cerca}\n other {#bicicletas de {company} cerca}\n\
+      \ }\n"
+    scootersNearby: "{count, plural,\n =0 {No hay e-scooters de {company} cerca}\n\
+      \ one {# e-scooter de {company} cerca}\n other {# e-scooters de {company} cerca}\n\
+      \ }\n"
+    spacesAvailable: "{count, plural,\n =0 {No hay plazas de aparcamiento disponibles}\n\
+      \ one {# plaza de aparcamiento disponible}\n other {# plazas de aparcamiento\
+      \ disponibles}\n }\n"


### PR DESCRIPTION
#684 had the incorrect syntax (codespell only ignored files not starting with `e` or `n`!).
This PR ~tries to fix that~ now just excludes the `i18n` folder from spellcheck.