### PR TITLE
Exclude entire i18n folder from codespell

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true
-          # skip git, yarn, pixel test script, and i18n non-english resources.
+          # skip git, yarn, pixel test script, and all i18n resources.
           # Also, the a11y test file has a false positive and the ignore list does not work
           # see https://github.com/opentripplanner/otp-react-redux/pull/436/checks?check_run_id=3369380014
-          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n/[!en]*.yml
+          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./percy/percy.test.js,./i18n


### PR DESCRIPTION
#684 had the incorrect syntax (codespell only ignored files not starting with `e` or `n`!).
This PR now excludes the entire i18n folder from spellcheck. I tried multiple patterns to try to include the English-US file, but none seem to work (see #685).