### PR TITLE
refactor(StopViewer): Remove unnecessary CSS className props.

### DIFF
--- a/lib/components/viewers/stop-schedule-table.tsx
+++ b/lib/components/viewers/stop-schedule-table.tsx
@@ -112,17 +112,17 @@ class StopScheduleTable extends Component<{
         <thead>
           <tr>
             {showBlockIds && (
-              <th className="base-color-bg">
+              <th>
                 <FormattedMessage id="components.StopScheduleTable.block" />
               </th>
             )}
-            <th className="base-color-bg">
+            <th>
               <FormattedMessage id="components.StopScheduleTable.route" />
             </th>
-            <th className="base-color-bg">
+            <th>
               <FormattedMessage id="components.StopScheduleTable.destination" />
             </th>
-            <th className="base-color-bg">
+            <th>
               <FormattedMessage id="components.StopScheduleTable.departure" />
             </th>
           </tr>

--- a/lib/components/viewers/stop-viewer.js
+++ b/lib/components/viewers/stop-viewer.js
@@ -173,7 +173,7 @@ class StopViewer extends Component {
     )
 
     return (
-      <div className="stop-viewer-header base-color-bg">
+      <div className="stop-viewer-header">
         {/* Back button */}
         {!hideBackButton && (
           <div className="back-button-container">
@@ -396,7 +396,7 @@ class StopViewer extends Component {
         {this._renderHeader(agencyCount)}
 
         {stopData && (
-          <div className="stop-viewer-body base-color-bg">
+          <div className="stop-viewer-body">
             {this._renderControls()}
             <Scrollable>{contents}</Scrollable>
             {/* Future: add stop details */}


### PR DESCRIPTION
This PR has suggestions to improve CSS for the stop viewer refresh.