### PR TITLE
Avoid Webkit Geolocation Crash

### DIFF
--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -163,6 +163,9 @@ class ResponsiveWebapp extends Component {
       navigator.geolocation.watchPosition(
         // On success
         (position) => {
+          // This object cloning is required to be allowed to read the position info twice
+          // on webkit browsers.
+          // See https://github.com/opentripplanner/otp-react-redux/pull/697 for details
           receivedPositionResponse({ position: { ...position } })
         },
         // On error

--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -163,7 +163,7 @@ class ResponsiveWebapp extends Component {
       navigator.geolocation.watchPosition(
         // On success
         (position) => {
-          receivedPositionResponse({ position })
+          receivedPositionResponse({ position: { ...position } })
         },
         // On error
         (error) => {


### PR DESCRIPTION
Webkit has a strange requirement that geolocation information can only be read off of the object _once_. We were saving that position object, then reading it later. This is fine, but reading it a second time is the problem. This caused a weird javascript-ey version of an illegal access violation (that showed itself as a TypeError even though the "incorrect" and "correct" types were the same 😵‍💫)

Solution is to clone the position object so that when we access it a second time we aren't reading the problematic object but instead reading the cloned values. Since we only read the `watch` position twice, this fix only needs to be applied there.