### PR TITLE
Calltaker Support More Natural Time Input

### DIFF
--- a/__tests__/components/__snapshots__/date-time-options.js.snap
+++ b/__tests__/components/__snapshots__/date-time-options.js.snap
@@ -1,0 +1,1114 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components > form > call-taker > date time options should correctly handle "12a" 1`] = `
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en-US"
+  formats={Object {}}
+  locale="en-US"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <Provider
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+  >
+    <Connect(injectIntl(DateTimeOptions))
+      date="2022-11-17"
+      time="12a"
+    >
+      <injectIntl(DateTimeOptions)
+        date="2022-11-17"
+        dispatch={[Function]}
+        homeTimezone="America/Los_Angeles"
+        time="12a"
+        timeFormat="h:mm a"
+      >
+        <DateTimeOptions
+          date="2022-11-17"
+          dispatch={[Function]}
+          homeTimezone="America/Los_Angeles"
+          intl={
+            Object {
+              "defaultFormats": Object {},
+              "defaultLocale": "en-US",
+              "defaultRichTextElements": undefined,
+              "formatDate": [Function],
+              "formatDateTimeRange": [Function],
+              "formatDateToParts": [Function],
+              "formatDisplayName": [Function],
+              "formatList": [Function],
+              "formatListToParts": [Function],
+              "formatMessage": [Function],
+              "formatNumber": [Function],
+              "formatNumberToParts": [Function],
+              "formatPlural": [Function],
+              "formatRelativeTime": [Function],
+              "formatTime": [Function],
+              "formatTimeToParts": [Function],
+              "formats": Object {},
+              "formatters": Object {
+                "getDateTimeFormat": [Function],
+                "getDisplayNames": [Function],
+                "getListFormat": [Function],
+                "getMessageFormat": [Function],
+                "getNumberFormat": [Function],
+                "getPluralRules": [Function],
+                "getRelativeTimeFormat": [Function],
+              },
+              "locale": "en-US",
+              "messages": Object {},
+              "onError": [Function],
+              "textComponent": Symbol(react.fragment),
+              "timeZone": undefined,
+              "wrapRichTextChunksInFragment": undefined,
+            }
+          }
+          time="12a"
+          timeFormat="h:mm a"
+        >
+          <select
+            onBlur={[Function]}
+            onChange={[Function]}
+          >
+            <option
+              key="NOW"
+              value="NOW"
+            >
+              components.DateTimeOptions.now
+            </option>
+            <option
+              key="DEPART"
+              value="DEPART"
+            >
+              components.DateTimeOptions.departAt
+            </option>
+            <option
+              key="ARRIVE"
+              value="ARRIVE"
+            >
+              components.DateTimeOptions.arriveBy
+            </option>
+          </select>
+          <OverlayTrigger
+            defaultOverlayShown={false}
+            overlay={
+              <Tooltip
+                bsClass="tooltip"
+                id="time-tooltip"
+                placement="right"
+              >
+                12:00 AM
+              </Tooltip>
+            }
+            placement="bottom"
+            trigger={
+              Array [
+                "focus",
+                "hover",
+              ]
+            }
+          >
+            <input
+              className="datetime-slim"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onClick={null}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              style={
+                Object {
+                  "fontSize": "inherit",
+                  "lineHeight": ".8em",
+                  "marginLeft": "3px",
+                  "padding": "0px",
+                  "width": "50px",
+                }
+              }
+              value=""
+            />
+          </OverlayTrigger>
+          <input
+            className="datetime-slim"
+            onChange={[Function]}
+            style={
+              Object {
+                "fontSize": "14px",
+                "lineHeight": "1em",
+                "outline": "none",
+                "width": "109px",
+              }
+            }
+            type="date"
+            value="2022-11-17"
+          />
+        </DateTimeOptions>
+      </injectIntl(DateTimeOptions)>
+    </Connect(injectIntl(DateTimeOptions))>
+  </Provider>
+</IntlProvider>
+`;
+
+exports[`components > form > call-taker > date time options should correctly handle "12p" 1`] = `
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en-US"
+  formats={Object {}}
+  locale="en-US"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <Provider
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+  >
+    <Connect(injectIntl(DateTimeOptions))
+      date="2022-11-17"
+      time="12p"
+    >
+      <injectIntl(DateTimeOptions)
+        date="2022-11-17"
+        dispatch={[Function]}
+        homeTimezone="America/Los_Angeles"
+        time="12p"
+        timeFormat="h:mm a"
+      >
+        <DateTimeOptions
+          date="2022-11-17"
+          dispatch={[Function]}
+          homeTimezone="America/Los_Angeles"
+          intl={
+            Object {
+              "defaultFormats": Object {},
+              "defaultLocale": "en-US",
+              "defaultRichTextElements": undefined,
+              "formatDate": [Function],
+              "formatDateTimeRange": [Function],
+              "formatDateToParts": [Function],
+              "formatDisplayName": [Function],
+              "formatList": [Function],
+              "formatListToParts": [Function],
+              "formatMessage": [Function],
+              "formatNumber": [Function],
+              "formatNumberToParts": [Function],
+              "formatPlural": [Function],
+              "formatRelativeTime": [Function],
+              "formatTime": [Function],
+              "formatTimeToParts": [Function],
+              "formats": Object {},
+              "formatters": Object {
+                "getDateTimeFormat": [Function],
+                "getDisplayNames": [Function],
+                "getListFormat": [Function],
+                "getMessageFormat": [Function],
+                "getNumberFormat": [Function],
+                "getPluralRules": [Function],
+                "getRelativeTimeFormat": [Function],
+              },
+              "locale": "en-US",
+              "messages": Object {},
+              "onError": [Function],
+              "textComponent": Symbol(react.fragment),
+              "timeZone": undefined,
+              "wrapRichTextChunksInFragment": undefined,
+            }
+          }
+          time="12p"
+          timeFormat="h:mm a"
+        >
+          <select
+            onBlur={[Function]}
+            onChange={[Function]}
+          >
+            <option
+              key="NOW"
+              value="NOW"
+            >
+              components.DateTimeOptions.now
+            </option>
+            <option
+              key="DEPART"
+              value="DEPART"
+            >
+              components.DateTimeOptions.departAt
+            </option>
+            <option
+              key="ARRIVE"
+              value="ARRIVE"
+            >
+              components.DateTimeOptions.arriveBy
+            </option>
+          </select>
+          <OverlayTrigger
+            defaultOverlayShown={false}
+            overlay={
+              <Tooltip
+                bsClass="tooltip"
+                id="time-tooltip"
+                placement="right"
+              >
+                12:00 PM
+              </Tooltip>
+            }
+            placement="bottom"
+            trigger={
+              Array [
+                "focus",
+                "hover",
+              ]
+            }
+          >
+            <input
+              className="datetime-slim"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onClick={null}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              style={
+                Object {
+                  "fontSize": "inherit",
+                  "lineHeight": ".8em",
+                  "marginLeft": "3px",
+                  "padding": "0px",
+                  "width": "50px",
+                }
+              }
+              value=""
+            />
+          </OverlayTrigger>
+          <input
+            className="datetime-slim"
+            onChange={[Function]}
+            style={
+              Object {
+                "fontSize": "14px",
+                "lineHeight": "1em",
+                "outline": "none",
+                "width": "109px",
+              }
+            }
+            type="date"
+            value="2022-11-17"
+          />
+        </DateTimeOptions>
+      </injectIntl(DateTimeOptions)>
+    </Connect(injectIntl(DateTimeOptions))>
+  </Provider>
+</IntlProvider>
+`;
+
+exports[`components > form > call-taker > date time options should correctly handle "133" 1`] = `
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en-US"
+  formats={Object {}}
+  locale="en-US"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <Provider
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+  >
+    <Connect(injectIntl(DateTimeOptions))
+      date="2022-11-17"
+      time="133"
+    >
+      <injectIntl(DateTimeOptions)
+        date="2022-11-17"
+        dispatch={[Function]}
+        homeTimezone="America/Los_Angeles"
+        time="133"
+        timeFormat="h:mm a"
+      >
+        <DateTimeOptions
+          date="2022-11-17"
+          dispatch={[Function]}
+          homeTimezone="America/Los_Angeles"
+          intl={
+            Object {
+              "defaultFormats": Object {},
+              "defaultLocale": "en-US",
+              "defaultRichTextElements": undefined,
+              "formatDate": [Function],
+              "formatDateTimeRange": [Function],
+              "formatDateToParts": [Function],
+              "formatDisplayName": [Function],
+              "formatList": [Function],
+              "formatListToParts": [Function],
+              "formatMessage": [Function],
+              "formatNumber": [Function],
+              "formatNumberToParts": [Function],
+              "formatPlural": [Function],
+              "formatRelativeTime": [Function],
+              "formatTime": [Function],
+              "formatTimeToParts": [Function],
+              "formats": Object {},
+              "formatters": Object {
+                "getDateTimeFormat": [Function],
+                "getDisplayNames": [Function],
+                "getListFormat": [Function],
+                "getMessageFormat": [Function],
+                "getNumberFormat": [Function],
+                "getPluralRules": [Function],
+                "getRelativeTimeFormat": [Function],
+              },
+              "locale": "en-US",
+              "messages": Object {},
+              "onError": [Function],
+              "textComponent": Symbol(react.fragment),
+              "timeZone": undefined,
+              "wrapRichTextChunksInFragment": undefined,
+            }
+          }
+          time="133"
+          timeFormat="h:mm a"
+        >
+          <select
+            onBlur={[Function]}
+            onChange={[Function]}
+          >
+            <option
+              key="NOW"
+              value="NOW"
+            >
+              components.DateTimeOptions.now
+            </option>
+            <option
+              key="DEPART"
+              value="DEPART"
+            >
+              components.DateTimeOptions.departAt
+            </option>
+            <option
+              key="ARRIVE"
+              value="ARRIVE"
+            >
+              components.DateTimeOptions.arriveBy
+            </option>
+          </select>
+          <OverlayTrigger
+            defaultOverlayShown={false}
+            overlay={
+              <Tooltip
+                bsClass="tooltip"
+                id="time-tooltip"
+                placement="right"
+              >
+                1:03 PM
+              </Tooltip>
+            }
+            placement="bottom"
+            trigger={
+              Array [
+                "focus",
+                "hover",
+              ]
+            }
+          >
+            <input
+              className="datetime-slim"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onClick={null}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              style={
+                Object {
+                  "fontSize": "inherit",
+                  "lineHeight": ".8em",
+                  "marginLeft": "3px",
+                  "padding": "0px",
+                  "width": "50px",
+                }
+              }
+              value=""
+            />
+          </OverlayTrigger>
+          <input
+            className="datetime-slim"
+            onChange={[Function]}
+            style={
+              Object {
+                "fontSize": "14px",
+                "lineHeight": "1em",
+                "outline": "none",
+                "width": "109px",
+              }
+            }
+            type="date"
+            value="2022-11-17"
+          />
+        </DateTimeOptions>
+      </injectIntl(DateTimeOptions)>
+    </Connect(injectIntl(DateTimeOptions))>
+  </Provider>
+</IntlProvider>
+`;
+
+exports[`components > form > call-taker > date time options should correctly handle "133p" 1`] = `
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en-US"
+  formats={Object {}}
+  locale="en-US"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <Provider
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+  >
+    <Connect(injectIntl(DateTimeOptions))
+      date="2022-11-17"
+      time="133p"
+    >
+      <injectIntl(DateTimeOptions)
+        date="2022-11-17"
+        dispatch={[Function]}
+        homeTimezone="America/Los_Angeles"
+        time="133p"
+        timeFormat="h:mm a"
+      >
+        <DateTimeOptions
+          date="2022-11-17"
+          dispatch={[Function]}
+          homeTimezone="America/Los_Angeles"
+          intl={
+            Object {
+              "defaultFormats": Object {},
+              "defaultLocale": "en-US",
+              "defaultRichTextElements": undefined,
+              "formatDate": [Function],
+              "formatDateTimeRange": [Function],
+              "formatDateToParts": [Function],
+              "formatDisplayName": [Function],
+              "formatList": [Function],
+              "formatListToParts": [Function],
+              "formatMessage": [Function],
+              "formatNumber": [Function],
+              "formatNumberToParts": [Function],
+              "formatPlural": [Function],
+              "formatRelativeTime": [Function],
+              "formatTime": [Function],
+              "formatTimeToParts": [Function],
+              "formats": Object {},
+              "formatters": Object {
+                "getDateTimeFormat": [Function],
+                "getDisplayNames": [Function],
+                "getListFormat": [Function],
+                "getMessageFormat": [Function],
+                "getNumberFormat": [Function],
+                "getPluralRules": [Function],
+                "getRelativeTimeFormat": [Function],
+              },
+              "locale": "en-US",
+              "messages": Object {},
+              "onError": [Function],
+              "textComponent": Symbol(react.fragment),
+              "timeZone": undefined,
+              "wrapRichTextChunksInFragment": undefined,
+            }
+          }
+          time="133p"
+          timeFormat="h:mm a"
+        >
+          <select
+            onBlur={[Function]}
+            onChange={[Function]}
+          >
+            <option
+              key="NOW"
+              value="NOW"
+            >
+              components.DateTimeOptions.now
+            </option>
+            <option
+              key="DEPART"
+              value="DEPART"
+            >
+              components.DateTimeOptions.departAt
+            </option>
+            <option
+              key="ARRIVE"
+              value="ARRIVE"
+            >
+              components.DateTimeOptions.arriveBy
+            </option>
+          </select>
+          <OverlayTrigger
+            defaultOverlayShown={false}
+            overlay={
+              <Tooltip
+                bsClass="tooltip"
+                id="time-tooltip"
+                placement="right"
+              >
+                1:33 PM
+              </Tooltip>
+            }
+            placement="bottom"
+            trigger={
+              Array [
+                "focus",
+                "hover",
+              ]
+            }
+          >
+            <input
+              className="datetime-slim"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onClick={null}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              style={
+                Object {
+                  "fontSize": "inherit",
+                  "lineHeight": ".8em",
+                  "marginLeft": "3px",
+                  "padding": "0px",
+                  "width": "50px",
+                }
+              }
+              value=""
+            />
+          </OverlayTrigger>
+          <input
+            className="datetime-slim"
+            onChange={[Function]}
+            style={
+              Object {
+                "fontSize": "14px",
+                "lineHeight": "1em",
+                "outline": "none",
+                "width": "109px",
+              }
+            }
+            type="date"
+            value="2022-11-17"
+          />
+        </DateTimeOptions>
+      </injectIntl(DateTimeOptions)>
+    </Connect(injectIntl(DateTimeOptions))>
+  </Provider>
+</IntlProvider>
+`;
+
+exports[`components > form > call-taker > date time options should correctly handle "135p" 1`] = `
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en-US"
+  formats={Object {}}
+  locale="en-US"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <Provider
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+  >
+    <Connect(injectIntl(DateTimeOptions))
+      date="2022-11-17"
+      time="135p"
+    >
+      <injectIntl(DateTimeOptions)
+        date="2022-11-17"
+        dispatch={[Function]}
+        homeTimezone="America/Los_Angeles"
+        time="135p"
+        timeFormat="h:mm a"
+      >
+        <DateTimeOptions
+          date="2022-11-17"
+          dispatch={[Function]}
+          homeTimezone="America/Los_Angeles"
+          intl={
+            Object {
+              "defaultFormats": Object {},
+              "defaultLocale": "en-US",
+              "defaultRichTextElements": undefined,
+              "formatDate": [Function],
+              "formatDateTimeRange": [Function],
+              "formatDateToParts": [Function],
+              "formatDisplayName": [Function],
+              "formatList": [Function],
+              "formatListToParts": [Function],
+              "formatMessage": [Function],
+              "formatNumber": [Function],
+              "formatNumberToParts": [Function],
+              "formatPlural": [Function],
+              "formatRelativeTime": [Function],
+              "formatTime": [Function],
+              "formatTimeToParts": [Function],
+              "formats": Object {},
+              "formatters": Object {
+                "getDateTimeFormat": [Function],
+                "getDisplayNames": [Function],
+                "getListFormat": [Function],
+                "getMessageFormat": [Function],
+                "getNumberFormat": [Function],
+                "getPluralRules": [Function],
+                "getRelativeTimeFormat": [Function],
+              },
+              "locale": "en-US",
+              "messages": Object {},
+              "onError": [Function],
+              "textComponent": Symbol(react.fragment),
+              "timeZone": undefined,
+              "wrapRichTextChunksInFragment": undefined,
+            }
+          }
+          time="135p"
+          timeFormat="h:mm a"
+        >
+          <select
+            onBlur={[Function]}
+            onChange={[Function]}
+          >
+            <option
+              key="NOW"
+              value="NOW"
+            >
+              components.DateTimeOptions.now
+            </option>
+            <option
+              key="DEPART"
+              value="DEPART"
+            >
+              components.DateTimeOptions.departAt
+            </option>
+            <option
+              key="ARRIVE"
+              value="ARRIVE"
+            >
+              components.DateTimeOptions.arriveBy
+            </option>
+          </select>
+          <OverlayTrigger
+            defaultOverlayShown={false}
+            overlay={
+              <Tooltip
+                bsClass="tooltip"
+                id="time-tooltip"
+                placement="right"
+              >
+                1:35 PM
+              </Tooltip>
+            }
+            placement="bottom"
+            trigger={
+              Array [
+                "focus",
+                "hover",
+              ]
+            }
+          >
+            <input
+              className="datetime-slim"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onClick={null}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              style={
+                Object {
+                  "fontSize": "inherit",
+                  "lineHeight": ".8em",
+                  "marginLeft": "3px",
+                  "padding": "0px",
+                  "width": "50px",
+                }
+              }
+              value=""
+            />
+          </OverlayTrigger>
+          <input
+            className="datetime-slim"
+            onChange={[Function]}
+            style={
+              Object {
+                "fontSize": "14px",
+                "lineHeight": "1em",
+                "outline": "none",
+                "width": "109px",
+              }
+            }
+            type="date"
+            value="2022-11-17"
+          />
+        </DateTimeOptions>
+      </injectIntl(DateTimeOptions)>
+    </Connect(injectIntl(DateTimeOptions))>
+  </Provider>
+</IntlProvider>
+`;
+
+exports[`components > form > call-taker > date time options should correctly handle "1335" 1`] = `
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en-US"
+  formats={Object {}}
+  locale="en-US"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <Provider
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+  >
+    <Connect(injectIntl(DateTimeOptions))
+      date="2022-11-17"
+      time="1335"
+    >
+      <injectIntl(DateTimeOptions)
+        date="2022-11-17"
+        dispatch={[Function]}
+        homeTimezone="America/Los_Angeles"
+        time="1335"
+        timeFormat="h:mm a"
+      >
+        <DateTimeOptions
+          date="2022-11-17"
+          dispatch={[Function]}
+          homeTimezone="America/Los_Angeles"
+          intl={
+            Object {
+              "defaultFormats": Object {},
+              "defaultLocale": "en-US",
+              "defaultRichTextElements": undefined,
+              "formatDate": [Function],
+              "formatDateTimeRange": [Function],
+              "formatDateToParts": [Function],
+              "formatDisplayName": [Function],
+              "formatList": [Function],
+              "formatListToParts": [Function],
+              "formatMessage": [Function],
+              "formatNumber": [Function],
+              "formatNumberToParts": [Function],
+              "formatPlural": [Function],
+              "formatRelativeTime": [Function],
+              "formatTime": [Function],
+              "formatTimeToParts": [Function],
+              "formats": Object {},
+              "formatters": Object {
+                "getDateTimeFormat": [Function],
+                "getDisplayNames": [Function],
+                "getListFormat": [Function],
+                "getMessageFormat": [Function],
+                "getNumberFormat": [Function],
+                "getPluralRules": [Function],
+                "getRelativeTimeFormat": [Function],
+              },
+              "locale": "en-US",
+              "messages": Object {},
+              "onError": [Function],
+              "textComponent": Symbol(react.fragment),
+              "timeZone": undefined,
+              "wrapRichTextChunksInFragment": undefined,
+            }
+          }
+          time="1335"
+          timeFormat="h:mm a"
+        >
+          <select
+            onBlur={[Function]}
+            onChange={[Function]}
+          >
+            <option
+              key="NOW"
+              value="NOW"
+            >
+              components.DateTimeOptions.now
+            </option>
+            <option
+              key="DEPART"
+              value="DEPART"
+            >
+              components.DateTimeOptions.departAt
+            </option>
+            <option
+              key="ARRIVE"
+              value="ARRIVE"
+            >
+              components.DateTimeOptions.arriveBy
+            </option>
+          </select>
+          <OverlayTrigger
+            defaultOverlayShown={false}
+            overlay={
+              <Tooltip
+                bsClass="tooltip"
+                id="time-tooltip"
+                placement="right"
+              >
+                1:35 PM
+              </Tooltip>
+            }
+            placement="bottom"
+            trigger={
+              Array [
+                "focus",
+                "hover",
+              ]
+            }
+          >
+            <input
+              className="datetime-slim"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onClick={null}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              style={
+                Object {
+                  "fontSize": "inherit",
+                  "lineHeight": ".8em",
+                  "marginLeft": "3px",
+                  "padding": "0px",
+                  "width": "50px",
+                }
+              }
+              value=""
+            />
+          </OverlayTrigger>
+          <input
+            className="datetime-slim"
+            onChange={[Function]}
+            style={
+              Object {
+                "fontSize": "14px",
+                "lineHeight": "1em",
+                "outline": "none",
+                "width": "109px",
+              }
+            }
+            type="date"
+            value="2022-11-17"
+          />
+        </DateTimeOptions>
+      </injectIntl(DateTimeOptions)>
+    </Connect(injectIntl(DateTimeOptions))>
+  </Provider>
+</IntlProvider>
+`;
+
+exports[`components > form > call-taker > date time options should render 1`] = `
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en-US"
+  formats={Object {}}
+  locale="en-US"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <Provider
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+  >
+    <Connect(injectIntl(DateTimeOptions))
+      date="2022-11-17"
+      time="12:34"
+    >
+      <injectIntl(DateTimeOptions)
+        date="2022-11-17"
+        dispatch={[Function]}
+        homeTimezone="America/Los_Angeles"
+        time="12:34"
+        timeFormat="h:mm a"
+      >
+        <DateTimeOptions
+          date="2022-11-17"
+          dispatch={[Function]}
+          homeTimezone="America/Los_Angeles"
+          intl={
+            Object {
+              "defaultFormats": Object {},
+              "defaultLocale": "en-US",
+              "defaultRichTextElements": undefined,
+              "formatDate": [Function],
+              "formatDateTimeRange": [Function],
+              "formatDateToParts": [Function],
+              "formatDisplayName": [Function],
+              "formatList": [Function],
+              "formatListToParts": [Function],
+              "formatMessage": [Function],
+              "formatNumber": [Function],
+              "formatNumberToParts": [Function],
+              "formatPlural": [Function],
+              "formatRelativeTime": [Function],
+              "formatTime": [Function],
+              "formatTimeToParts": [Function],
+              "formats": Object {},
+              "formatters": Object {
+                "getDateTimeFormat": [Function],
+                "getDisplayNames": [Function],
+                "getListFormat": [Function],
+                "getMessageFormat": [Function],
+                "getNumberFormat": [Function],
+                "getPluralRules": [Function],
+                "getRelativeTimeFormat": [Function],
+              },
+              "locale": "en-US",
+              "messages": Object {},
+              "onError": [Function],
+              "textComponent": Symbol(react.fragment),
+              "timeZone": undefined,
+              "wrapRichTextChunksInFragment": undefined,
+            }
+          }
+          time="12:34"
+          timeFormat="h:mm a"
+        >
+          <select
+            onBlur={[Function]}
+            onChange={[Function]}
+          >
+            <option
+              key="NOW"
+              value="NOW"
+            >
+              components.DateTimeOptions.now
+            </option>
+            <option
+              key="DEPART"
+              value="DEPART"
+            >
+              components.DateTimeOptions.departAt
+            </option>
+            <option
+              key="ARRIVE"
+              value="ARRIVE"
+            >
+              components.DateTimeOptions.arriveBy
+            </option>
+          </select>
+          <OverlayTrigger
+            defaultOverlayShown={false}
+            overlay={
+              <Tooltip
+                bsClass="tooltip"
+                id="time-tooltip"
+                placement="right"
+              >
+                12:34 PM
+              </Tooltip>
+            }
+            placement="bottom"
+            trigger={
+              Array [
+                "focus",
+                "hover",
+              ]
+            }
+          >
+            <input
+              className="datetime-slim"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onClick={null}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              style={
+                Object {
+                  "fontSize": "inherit",
+                  "lineHeight": ".8em",
+                  "marginLeft": "3px",
+                  "padding": "0px",
+                  "width": "50px",
+                }
+              }
+              value=""
+            />
+          </OverlayTrigger>
+          <input
+            className="datetime-slim"
+            onChange={[Function]}
+            style={
+              Object {
+                "fontSize": "14px",
+                "lineHeight": "1em",
+                "outline": "none",
+                "width": "109px",
+              }
+            }
+            type="date"
+            value="2022-11-17"
+          />
+        </DateTimeOptions>
+      </injectIntl(DateTimeOptions)>
+    </Connect(injectIntl(DateTimeOptions))>
+  </Provider>
+</IntlProvider>
+`;

--- a/__tests__/components/date-time-options.js
+++ b/__tests__/components/date-time-options.js
@@ -1,0 +1,89 @@
+import {
+  getMockInitialState,
+  mockWithProvider
+} from '../test-utils/mock-data/store'
+import { setDefaultTestTime } from '../test-utils'
+import DateTimeOptions from '../../lib/components/form/call-taker/date-time-options'
+
+describe('components > form > call-taker > date time options', () => {
+  beforeEach(setDefaultTestTime)
+
+  // TODO: generate each of these with a method?
+  it('should render', () => {
+    const mockState = getMockInitialState()
+
+    expect(
+      mockWithProvider(
+        DateTimeOptions,
+        { date: '2022-11-17', time: '12:34' },
+        mockState
+      ).snapshot()
+    ).toMatchSnapshot()
+  })
+  it('should correctly handle "12p"', () => {
+    const mockState = getMockInitialState()
+
+    expect(
+      mockWithProvider(
+        DateTimeOptions,
+        { date: '2022-11-17', time: '12p' },
+        mockState
+      ).snapshot()
+    ).toMatchSnapshot()
+  })
+  it('should correctly handle "12a"', () => {
+    const mockState = getMockInitialState()
+
+    expect(
+      mockWithProvider(
+        DateTimeOptions,
+        { date: '2022-11-17', time: '12a' },
+        mockState
+      ).snapshot()
+    ).toMatchSnapshot()
+  })
+  it('should correctly handle "1335"', () => {
+    const mockState = getMockInitialState()
+
+    expect(
+      mockWithProvider(
+        DateTimeOptions,
+        { date: '2022-11-17', time: '1335' },
+        mockState
+      ).snapshot()
+    ).toMatchSnapshot()
+  })
+  it('should correctly handle "135p"', () => {
+    const mockState = getMockInitialState()
+
+    expect(
+      mockWithProvider(
+        DateTimeOptions,
+        { date: '2022-11-17', time: '135p' },
+        mockState
+      ).snapshot()
+    ).toMatchSnapshot()
+  })
+  it('should correctly handle "133"', () => {
+    const mockState = getMockInitialState()
+
+    expect(
+      mockWithProvider(
+        DateTimeOptions,
+        { date: '2022-11-17', time: '133' },
+        mockState
+      ).snapshot()
+    ).toMatchSnapshot()
+  })
+  it('should correctly handle "133p"', () => {
+    const mockState = getMockInitialState()
+
+    expect(
+      mockWithProvider(
+        DateTimeOptions,
+        { date: '2022-11-17', time: '133p' },
+        mockState
+      ).snapshot()
+    ).toMatchSnapshot()
+  })
+})

--- a/__tests__/test-utils/mock-data/store.js
+++ b/__tests__/test-utils/mock-data/store.js
@@ -26,6 +26,7 @@ const storeMiddleWare = [
  */
 export function getMockInitialState() {
   const mockConfig = {
+    dateTime: { timeFormat: 'h:mm a' },
     initialQuery: {}
   }
   return clone({

--- a/lib/components/form/call-taker/date-time-options.js
+++ b/lib/components/form/call-taker/date-time-options.js
@@ -32,16 +32,14 @@ function getDepartureOptions(intl) {
  * Time formats passed to date-fns to parse the user's time input.
  */
 const SUPPORTED_TIME_FORMATS = [
-  'HH:mm:ss',
-  'h:mm:ss a',
-  'h:mm:ssa',
-  'h:mm a',
-  'h:mma',
-  'h:mm',
-  'HHmm',
-  'hmm',
-  'ha',
-  'h',
+  'h:mmaaaaa',
+  'hmmaaaaa',
+  'haaaaa',
+  'Hmm',
+  'Hm',
+  'H:mm',
+  'H:m',
+  'H',
   'HH:mm'
 ]
 
@@ -121,6 +119,8 @@ class DateTimeOptions extends Component {
     if (timer) window.clearInterval(timer)
     const newTimer = window.setInterval(this._refreshDateTime, 1000)
     this.setState({ timer: newTimer })
+    // Immediately start
+    this._refreshDateTime(true)
   }
 
   _stopAutoRefresh = () => {
@@ -128,11 +128,11 @@ class DateTimeOptions extends Component {
     this.setState({ timer: null })
   }
 
-  _refreshDateTime = () => {
+  _refreshDateTime = (initial = false) => {
     const now = new Date()
     const dateTimeParams = dateToQueryParams(now, this.props.homeTimezone)
     // Update query param if the current time has changed (i.e., on minute ticks).
-    if (dateTimeParams.time !== this.props.time) {
+    if (initial || dateTimeParams.time !== this.props.time) {
       this.props.setQueryParam(dateTimeParams)
     }
   }


### PR DESCRIPTION
Crucially, "12p" is now supported as an input. The repair was to modify the list of accepted time formats, and their order.

This PR also adds some unit tests to verify that behavior remains consistent into the future.