### PR TITLE
Do not reset UI upon acquiring location if viewer is active

### DIFF
--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -206,9 +206,6 @@ export function formChanged(oldQuery, newQuery) {
         if (ui.mobileScreen !== MobileScreens.WELCOME_SCREEN) {
           dispatch(setMobileScreen(MobileScreens.SEARCH_FORM))
         }
-        if (ui.mainPanelContent > 0) {
-          dispatch(setMainPanelContent(null))
-        }
       }
     } else if (queryIsValid(state)) {
       // If replanning trip and query is valid,


### PR DESCRIPTION
Fix #702.

This PR removes the resetting of the UI after device location is acquired.
Test using for instance http://localhost:9966/#/route, http://localhost:9966/#/route/<route_id>, http://localhost:9966/#/stop/<stop_id> where the viewed route or stop should remain on screen after device location is acquired.
