### PR TITLE
fix(actions/apiV2): Add stop code field to stops graphql query.

### DIFF
--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -198,6 +198,7 @@ stopTimes: stoptimesForPatterns(numberOfDepartures: 3) {
 
 const stopGraphQLQuery = `
 id: gtfsId
+code
 lat
 lon
 locationType


### PR DESCRIPTION
This PR adds the stop code field to stops graphql queries, so the stop code is shown instead of the GTFS stop id in the stop viewer and related stops.