### PR TITLE
Route viewer visual tweaks

### DIFF
--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -1331,7 +1331,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY btlMPV"
+                                          className="sc-fmlJrY bUSHCh"
                                           color="333333"
                                         >
                                           20
@@ -4145,7 +4145,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY btlMPV"
+                                          className="sc-fmlJrY bUSHCh"
                                           color="333333"
                                         >
                                           20
@@ -6479,7 +6479,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY btlMPV"
+                                          className="sc-fmlJrY bUSHCh"
                                           color="333333"
                                         >
                                           20
@@ -10249,7 +10249,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY btlMPV"
+                                          className="sc-fmlJrY bUSHCh"
                                           color="333333"
                                         >
                                           20
@@ -11473,7 +11473,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY btlMPV"
+                                          className="sc-fmlJrY bUSHCh"
                                           color="333333"
                                         >
                                           36
@@ -12697,7 +12697,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY btlMPV"
+                                          className="sc-fmlJrY bUSHCh"
                                           color="333333"
                                         >
                                           94
@@ -14029,7 +14029,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY btlMPV"
+                                          className="sc-fmlJrY bUSHCh"
                                           color="333333"
                                         >
                                           94
@@ -18825,7 +18825,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY btlMPV"
+                                          className="sc-fmlJrY bUSHCh"
                                           color="333333"
                                         >
                                           20

--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -1331,7 +1331,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY kzIrEg"
+                                          className="sc-fmlJrY btlMPV"
                                           color="333333"
                                         >
                                           20
@@ -4145,7 +4145,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY kzIrEg"
+                                          className="sc-fmlJrY btlMPV"
                                           color="333333"
                                         >
                                           20
@@ -6479,7 +6479,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY kzIrEg"
+                                          className="sc-fmlJrY btlMPV"
                                           color="333333"
                                         >
                                           20
@@ -10249,7 +10249,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY kzIrEg"
+                                          className="sc-fmlJrY btlMPV"
                                           color="333333"
                                         >
                                           20
@@ -11473,7 +11473,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY kzIrEg"
+                                          className="sc-fmlJrY btlMPV"
                                           color="333333"
                                         >
                                           36
@@ -12697,7 +12697,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY kzIrEg"
+                                          className="sc-fmlJrY btlMPV"
                                           color="333333"
                                         >
                                           94
@@ -14029,7 +14029,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY kzIrEg"
+                                          className="sc-fmlJrY btlMPV"
                                           color="333333"
                                         >
                                           94
@@ -18825,7 +18825,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY kzIrEg"
+                                          className="sc-fmlJrY btlMPV"
                                           color="333333"
                                         >
                                           20

--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -1331,7 +1331,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY guloJk"
+                                          className="sc-fmlJrY kzIrEg"
                                           color="333333"
                                         >
                                           20
@@ -4145,7 +4145,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY guloJk"
+                                          className="sc-fmlJrY kzIrEg"
                                           color="333333"
                                         >
                                           20
@@ -6479,7 +6479,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY guloJk"
+                                          className="sc-fmlJrY kzIrEg"
                                           color="333333"
                                         >
                                           20
@@ -10249,7 +10249,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY guloJk"
+                                          className="sc-fmlJrY kzIrEg"
                                           color="333333"
                                         >
                                           20
@@ -11473,7 +11473,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY guloJk"
+                                          className="sc-fmlJrY kzIrEg"
                                           color="333333"
                                         >
                                           36
@@ -12697,7 +12697,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY guloJk"
+                                          className="sc-fmlJrY kzIrEg"
                                           color="333333"
                                         >
                                           94
@@ -14029,7 +14029,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY guloJk"
+                                          className="sc-fmlJrY kzIrEg"
                                           color="333333"
                                         >
                                           94
@@ -18825,7 +18825,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                         color="333333"
                                       >
                                         <span
-                                          className="sc-fmlJrY guloJk"
+                                          className="sc-fmlJrY kzIrEg"
                                           color="333333"
                                         >
                                           20

--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -1327,16 +1327,16 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                         }
                                       }
                                     >
-                                      <styled.section
+                                      <styled.span
                                         color="333333"
                                       >
-                                        <section
-                                          className="sc-fmlJrY fflxRz"
+                                        <span
+                                          className="sc-fmlJrY guloJk"
                                           color="333333"
                                         >
                                           20
-                                        </section>
-                                      </styled.section>
+                                        </span>
+                                      </styled.span>
                                     </DefaultRouteRenderer>
                                   </strong>
                                   <FormattedMessage
@@ -4141,16 +4141,16 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                         }
                                       }
                                     >
-                                      <styled.section
+                                      <styled.span
                                         color="333333"
                                       >
-                                        <section
-                                          className="sc-fmlJrY fflxRz"
+                                        <span
+                                          className="sc-fmlJrY guloJk"
                                           color="333333"
                                         >
                                           20
-                                        </section>
-                                      </styled.section>
+                                        </span>
+                                      </styled.span>
                                     </DefaultRouteRenderer>
                                   </strong>
                                   <FormattedMessage
@@ -6475,16 +6475,16 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                         }
                                       }
                                     >
-                                      <styled.section
+                                      <styled.span
                                         color="333333"
                                       >
-                                        <section
-                                          className="sc-fmlJrY fflxRz"
+                                        <span
+                                          className="sc-fmlJrY guloJk"
                                           color="333333"
                                         >
                                           20
-                                        </section>
-                                      </styled.section>
+                                        </span>
+                                      </styled.span>
                                     </DefaultRouteRenderer>
                                   </strong>
                                   <FormattedMessage
@@ -10245,16 +10245,16 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         }
                                       }
                                     >
-                                      <styled.section
+                                      <styled.span
                                         color="333333"
                                       >
-                                        <section
-                                          className="sc-fmlJrY fflxRz"
+                                        <span
+                                          className="sc-fmlJrY guloJk"
                                           color="333333"
                                         >
                                           20
-                                        </section>
-                                      </styled.section>
+                                        </span>
+                                      </styled.span>
                                     </DefaultRouteRenderer>
                                   </strong>
                                   <FormattedMessage
@@ -11469,16 +11469,16 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         }
                                       }
                                     >
-                                      <styled.section
+                                      <styled.span
                                         color="333333"
                                       >
-                                        <section
-                                          className="sc-fmlJrY fflxRz"
+                                        <span
+                                          className="sc-fmlJrY guloJk"
                                           color="333333"
                                         >
                                           36
-                                        </section>
-                                      </styled.section>
+                                        </span>
+                                      </styled.span>
                                     </DefaultRouteRenderer>
                                   </strong>
                                   <FormattedMessage
@@ -12693,16 +12693,16 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         }
                                       }
                                     >
-                                      <styled.section
+                                      <styled.span
                                         color="333333"
                                       >
-                                        <section
-                                          className="sc-fmlJrY fflxRz"
+                                        <span
+                                          className="sc-fmlJrY guloJk"
                                           color="333333"
                                         >
                                           94
-                                        </section>
-                                      </styled.section>
+                                        </span>
+                                      </styled.span>
                                     </DefaultRouteRenderer>
                                   </strong>
                                   <FormattedMessage
@@ -14025,16 +14025,16 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         }
                                       }
                                     >
-                                      <styled.section
+                                      <styled.span
                                         color="333333"
                                       >
-                                        <section
-                                          className="sc-fmlJrY fflxRz"
+                                        <span
+                                          className="sc-fmlJrY guloJk"
                                           color="333333"
                                         >
                                           94
-                                        </section>
-                                      </styled.section>
+                                        </span>
+                                      </styled.span>
                                     </DefaultRouteRenderer>
                                   </strong>
                                   <FormattedMessage
@@ -18821,16 +18821,16 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                         }
                                       }
                                     >
-                                      <styled.section
+                                      <styled.span
                                         color="333333"
                                       >
-                                        <section
-                                          className="sc-fmlJrY fflxRz"
+                                        <span
+                                          className="sc-fmlJrY guloJk"
                                           color="333333"
                                         >
                                           20
-                                        </section>
-                                      </styled.section>
+                                        </span>
+                                      </styled.span>
                                     </DefaultRouteRenderer>
                                   </strong>
                                   <FormattedMessage

--- a/lib/components/narrative/metro/default-route-renderer.tsx
+++ b/lib/components/narrative/metro/default-route-renderer.tsx
@@ -7,8 +7,13 @@ const Block = styled.span<{ color: string }>`
   border-radius: 5px;
   border-top: 5px solid #${(props) => props.color};
   display: inline-block;
-  max-width: 150px;
   padding: 3px 7px;
+
+  /* Below is for route names that are too long: cut-off and show ellipsis. */
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `
 
 type RouteRendererProps = {

--- a/lib/components/narrative/metro/default-route-renderer.tsx
+++ b/lib/components/narrative/metro/default-route-renderer.tsx
@@ -13,6 +13,8 @@ const Block = styled.span<{ color: string }>`
   max-width: 150px;
   overflow: hidden;
   text-overflow: ellipsis;
+  /* (Change the vertical alignment when changing the overflow attribute.) */
+  vertical-align: middle;
   white-space: nowrap;
 `
 

--- a/lib/components/narrative/metro/default-route-renderer.tsx
+++ b/lib/components/narrative/metro/default-route-renderer.tsx
@@ -2,16 +2,13 @@ import { Leg } from '@opentripplanner/types'
 import React from 'react'
 import styled from 'styled-components'
 
-// TODO: This should not be a section, but using div/span
-// doesn't allow us to style it from within the RouteBlock
-const Block = styled.section<{ color: string }>`
+const Block = styled.span<{ color: string }>`
   background: #${(props) => props.color}1A;
-  padding: 3px 7px;
-  border-top: 5px solid #${(props) => props.color};
   border-radius: 5px;
-  text-align: center;
+  border-top: 5px solid #${(props) => props.color};
   display: inline-block;
-  max-width: 12vw;
+  max-width: 150px;
+  padding: 3px 7px;
 `
 
 type RouteRendererProps = {

--- a/lib/components/narrative/metro/default-route-renderer.tsx
+++ b/lib/components/narrative/metro/default-route-renderer.tsx
@@ -7,6 +7,7 @@ const Block = styled.span<{ color: string }>`
   border-radius: 5px;
   border-top: 5px solid #${(props) => props.color};
   display: inline-block;
+  margin-top: -2px;
   padding: 3px 7px;
 
   /* Below is for route names that are too long: cut-off and show ellipsis. */

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -40,19 +40,18 @@ const RouteNameElement = styled.span`
   flex-shrink: 0;
   font-size: 16px;
   font-weight: 400;
-  /* HACK: Apply a negative bottom margin as a result of displaying an ellipsis,
-     even if white-space: nowrap is set. */
-  margin: 0 0 -7px 8px;
+  margin-left: 8px;
 `
 const RouteLongNameElement = styled.span`
   font-size: 16px;
   font-weight: 500;
-  /* Apply top margin so that the baseline of the default-rendered
-     route short name aligns with that of the route long name. */
-  margin: 4px 0 0 5px;
+  /* Top margin is same as border-top-width of the default route renderer,
+     so that the baseline of the route short name aligns with that
+     of the route long name. */
+  margin: 5px 0 0 5px;
 `
 
-const SimpleRouteRenderer = styled.h2`
+const SimpleRouteRenderer = styled.span`
   font-size: 18px;
   margin: 0;
   padding: 0;
@@ -63,7 +62,7 @@ export const RouteName = ({ basicRender, route, RouteRenderer }) => {
 
   return (
     <>
-      <RouteNameElement title={route.shortName}>
+      <RouteNameElement title={`${route.shortName}`}>
         {!basicRender ? (
           <Route leg={generateFakeLegForRouteRenderer(route)} />
         ) : (

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -40,15 +40,15 @@ const RouteNameElement = styled.span`
   flex-shrink: 0;
   font-size: 16px;
   font-weight: 400;
+  /* HACK: Apply a negative bottom margin as a result of displaying an ellipsis,
+     even if white-space: nowrap is set. */
   margin: 0 0 -7px 8px;
-  & span {
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
 `
 const RouteLongNameElement = styled.span`
   font-size: 16px;
   font-weight: 500;
+  /* Apply top margin so that the baseline of the default-rendered
+     route short name aligns with that of the route long name. */
   margin: 4px 0 0 5px;
 `
 

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -45,10 +45,10 @@ const RouteNameElement = styled.span`
 const RouteLongNameElement = styled.span`
   font-size: 16px;
   font-weight: 500;
-  /* Top margin is same as border-top-width of the default route renderer,
+  /* Top margin is same as border-top-width+margin-top of the default route renderer,
      so that the baseline of the route short name aligns with that
      of the route long name. */
-  margin: 5px 0 0 5px;
+  margin: 3px 0 0 5px;
 `
 
 const SimpleRouteRenderer = styled.span`

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -1,6 +1,6 @@
 // TODO: Typescript, which doesn't make sense to do in this file until common types are established
 /* eslint-disable react/prop-types */
-import { Button, Label } from 'react-bootstrap'
+import { Button } from 'react-bootstrap'
 import AnimateHeight from 'react-animate-height'
 import React, { PureComponent } from 'react'
 import styled from 'styled-components'
@@ -24,11 +24,8 @@ export const RouteRowButton = styled(Button)`
   align-items: center;
   display: flex;
   padding: 6px;
-  transition: all ease-in-out 0.1s;
   width: 100%;
 `
-
-export const RouteRowElement = styled.span``
 
 export const OperatorImg = styled.img`
   height: 25px;
@@ -36,26 +33,23 @@ export const OperatorImg = styled.img`
 `
 
 export const ModeIconElement = styled.span`
-  display: inline-block;
   height: 22px;
-  vertical-align: bottom;
 `
 
-const RouteNameElement = styled(Label)`
-  background-color: transparent;
-  color: inherit;
-  flex: 0 1 auto;
+const RouteNameElement = styled.span`
+  flex-shrink: 0;
   font-size: 16px;
   font-weight: 400;
-  margin-left: 8px;
-  margin-top: 2px;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  margin: 0 0 -7px 8px;
+  & span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 `
 const RouteLongNameElement = styled.span`
   font-size: 16px;
-  margin-left: 5px;
   font-weight: 500;
+  margin: 4px 0 0 5px;
 `
 
 const SimpleRouteRenderer = styled.h2`
@@ -69,7 +63,7 @@ export const RouteName = ({ basicRender, route, RouteRenderer }) => {
 
   return (
     <>
-      <RouteNameElement title={`${route.shortName}`}>
+      <RouteNameElement title={route.shortName}>
         {!basicRender ? (
           <Route leg={generateFakeLegForRouteRenderer(route)} />
         ) : (
@@ -154,19 +148,17 @@ export class RouteRow extends PureComponent {
           onMouseEnter={this._onFocusOrEnter}
           onTouchStart={this._onFocusOrEnter}
         >
-          <RouteRowElement>
-            {operator && operator.logo && (
-              <OperatorImg
-                alt={intl.formatMessage(
-                  {
-                    id: 'components.RouteRow.operatorLogoAltText'
-                  },
-                  { operatorName: operator.name }
-                )}
-                src={operator.logo}
-              />
-            )}
-          </RouteRowElement>
+          {operator && operator.logo && (
+            <OperatorImg
+              alt={intl.formatMessage(
+                {
+                  id: 'components.RouteRow.operatorLogoAltText'
+                },
+                { operatorName: operator.name }
+              )}
+              src={operator.logo}
+            />
+          )}
           {route.mode && (
             <ModeIconElement>
               <ModeIcon

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -45,10 +45,12 @@ const RouteNameElement = styled.span`
 const RouteLongNameElement = styled.span`
   font-size: 16px;
   font-weight: 500;
-  /* Top margin is same as border-top-width+margin-top of the default route renderer,
-     so that the baseline of the route short name aligns with that
-     of the route long name. */
-  margin: 3px 0 0 5px;
+  /*
+    Top margin is same as border-top-width+margin-top of the default route renderer,
+    so that the baseline of the route short name aligns with that
+    of the route long name.
+  */
+  margin: 2px 0 0 15px;
 `
 
 const SimpleRouteRenderer = styled.span`


### PR DESCRIPTION
This PR makes improves the route viewer layout, so route numbers are not shrunk on narrow screens and long route numbers are properly clipped.