### PR TITLE
Render itinerary bodies using ambient font

### DIFF
--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -37,6 +37,10 @@ const ItineraryBodyContainer = styled.div`
 `
 
 const StyledItineraryBody = styled(ItineraryBody)`
+  /* Render itineraries using the ambient font (not necessarily Hind). */
+  *:not(.fa) {
+    font-family: inherit;
+  }
   ${PlaceNameWrapper} {
     font-weight: inherit;
   }


### PR DESCRIPTION
This overrides the `ItineraryBody` component's internal font so that the ambient font is used throughout the UI. (This helps support fonts that support Vietnamese letters, among others).