### PR TITLE
Make first itinerary leg clickable

### DIFF
--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -347,7 +347,8 @@ export function getActiveItinerary(state) {
  */
 export function getActiveLeg(state) {
   const { activeLeg } = getActiveSearch(state) || {}
-  if (!activeLeg) return undefined
+  // activeLeg is a number and can be zero, so check for null/undefined instead of truthy.
+  if (activeLeg === undefined || activeLeg === null) return undefined
 
   const activeItinerary = getActiveItinerary(state)
   return activeItinerary?.legs?.[activeLeg]


### PR DESCRIPTION
Fixes a bug that prevents fitting the shape of the first leg of an itinerary on the map when clicking that in the narrative.