### PR TITLE
Remove thin font weights

### DIFF
--- a/__tests__/components/date-time-options.js
+++ b/__tests__/components/date-time-options.js
@@ -1,3 +1,4 @@
+import '../test-utils/mock-window-url'
 import {
   getMockInitialState,
   mockWithProvider

--- a/lib/components/form/batch-styled.ts
+++ b/lib/components/form/batch-styled.ts
@@ -101,6 +101,7 @@ export const StyledBatchPreferences = styled(SettingsSelectorPanel)`
   ${TripFormClasses.SettingLabel} {
     color: #686868;
     font-size: 14px;
+    /* Override bootstrap's font-weight on labels so they don't appear bold in batch settings. */
     font-weight: inherit;
     letter-spacing: 1px;
     padding-top: 8px;

--- a/lib/components/form/batch-styled.ts
+++ b/lib/components/form/batch-styled.ts
@@ -101,7 +101,7 @@ export const StyledBatchPreferences = styled(SettingsSelectorPanel)`
   ${TripFormClasses.SettingLabel} {
     color: #686868;
     font-size: 14px;
-    font-weight: 100;
+    font-weight: inherit;
     letter-spacing: 1px;
     padding-top: 8px;
     text-transform: uppercase;

--- a/lib/components/form/styled.js
+++ b/lib/components/form/styled.js
@@ -62,7 +62,7 @@ export const StyledSettingsSelectorPanel = styled(SettingsSelectorPanel)`
   ${TripFormClasses.SettingLabel} {
     color: #686868;
     font-size: 14px;
-    font-weight: 100;
+    font-weight: inherit;
     letter-spacing: 1px;
     padding-top: 8px;
     text-transform: uppercase;

--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -1,11 +1,13 @@
 /* eslint-disable react/prop-types */
 // TODO: Typescript (otp-rr config object)
 import { connect } from 'react-redux'
-import { PlaceName } from '@opentripplanner/itinerary-body/lib/otp-react-redux'
 import {
+  LegDescriptionHeadsignPrefix,
   PlaceName as PlaceNameWrapper,
-  PlaceRowWrapper
+  PlaceRowWrapper,
+  PlaceSubheader
 } from '@opentripplanner/itinerary-body/lib/styled'
+import { PlaceName } from '@opentripplanner/itinerary-body/lib/otp-react-redux'
 import clone from 'clone'
 import isEqual from 'lodash.isequal'
 import ItineraryBody from '@opentripplanner/itinerary-body/lib/otp-react-redux/itinerary-body'
@@ -41,7 +43,9 @@ const StyledItineraryBody = styled(ItineraryBody)`
   *:not(.fa) {
     font-family: inherit;
   }
-  ${PlaceNameWrapper} {
+  ${PlaceNameWrapper},
+  ${PlaceSubheader},
+  ${LegDescriptionHeadsignPrefix} {
     font-weight: inherit;
   }
   ${PlaceRowWrapper} {


### PR DESCRIPTION
This makes fonts such as the default MacOS system font more legible in:
- Narrative headers (where result status, "View all options", "Save Trip" and sort options are shown
- Travel preferences (submodes, speeds, ...)
- Itinerary body: stop number/stop viewer link, "to" between route long name and final destination.