### PR TITLE
Don't show stops when all route patterns are previewed.

### DIFF
--- a/__tests__/components/date-time-options.js
+++ b/__tests__/components/date-time-options.js
@@ -1,3 +1,4 @@
+import '../test-utils/mock-window-url'
 import {
   getMockInitialState,
   mockWithProvider

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -100,8 +100,9 @@ export function setViewedRoute(payload) {
     const { viewedRoute } = otp.ui
     if (
       viewedRoute &&
-      payload?.viewedRoute?.routeId === viewedRoute.routeId &&
-      payload?.viewedRoute?.patternId === viewedRoute.patternId
+      payload?.routeId === viewedRoute.routeId &&
+      (payload?.patternId === viewedRoute.patternId ||
+        (!payload?.patternId && !viewedRoute.patternId))
     ) {
       return
     }

--- a/lib/components/map/connected-stops-overlay.js
+++ b/lib/components/map/connected-stops-overlay.js
@@ -21,25 +21,29 @@ const mapStateToProps = (state) => {
     patterns
   ) {
     // Display stops for a pattern or all patterns for a route.
-    let viewedPattern = patternId
 
-    // If a flex route is being shown but the pattern viewer is not active, then the
-    // stops of the first pattern of the route should be shown
-    // This will ensure that the flex zone stops are shown.
-
-    // Preferably, the flex stops would be rendered in a separate layer.
+    // Preferably, the flex zones would be rendered in a separate layer.
     // However, without changes to GraphQL, getting this data is very expensive
-    if (!viewedPattern && v2) {
-      viewedPattern = Object.keys(patterns)?.[0]
+    if (v2) {
+      // If a flex route is being shown, show flex zones from all patterns
+      // using the stops overlay, whether the pattern viewer is active or not.
+      Object.values(patterns).forEach((p) => {
+        stops = stops.concat(
+          p?.stops?.filter((s) => s.geometries?.geoJson?.type === 'Polygon')
+        )
+      })
     }
 
-    // Discard duplicates from pattern stops.
-    stops = (patterns?.[viewedPattern]?.stops || []).reduce((prev, cur) => {
-      if (!prev.find((stop) => stop.id === cur.id)) {
-        prev.push(cur)
-      }
-      return prev
-    }, [])
+    // Discard duplicates from pattern stops and flex zones.
+    stops = stops
+      .concat(patterns?.[patternId]?.stops || [])
+      .reduce((prev, cur) => {
+        if (!prev.find((stop) => stop.id === cur.id)) {
+          prev.push(cur)
+        }
+        return prev
+      }, [])
+
     // Override the minimum zoom so that the stops appear even if zoomed out
     minZoom = 2
   } else if (visible) {

--- a/lib/components/map/connected-stops-overlay.js
+++ b/lib/components/map/connected-stops-overlay.js
@@ -20,29 +20,25 @@ const mapStateToProps = (state) => {
     mainPanelContent === uiActions.MainPanelContent.ROUTE_VIEWER &&
     patterns
   ) {
-    // Display stops for a pattern or all patterns for a route.
-
-    // Preferably, the flex zones would be rendered in a separate layer.
-    // However, without changes to GraphQL, getting this data is very expensive
-    if (v2) {
+    // Avoid duplicates.
+    const stopsById = {}
+    // Display stops for the selected pattern for a route.
+    if (v2 && !patternId) {
       // If a flex route is being shown, show flex zones from all patterns
       // using the stops overlay, whether the pattern viewer is active or not.
+
+      // Preferably, the flex zones would be rendered in a separate layer.
+      // However, without changes to GraphQL, getting this data is very expensive
       Object.values(patterns).forEach((p) => {
-        stops = stops.concat(
-          p?.stops?.filter((s) => s.geometries?.geoJson?.type === 'Polygon')
-        )
+        p?.stops
+          ?.filter((s) => s.geometries?.geoJson?.type === 'Polygon')
+          ?.forEach((s) => (stopsById[s.id] = s))
       })
+    } else if (patternId) {
+      patterns?.[patternId]?.stops?.forEach((s) => (stopsById[s.id] = s))
     }
 
-    // Discard duplicates from pattern stops and flex zones.
-    stops = stops
-      .concat(patterns?.[patternId]?.stops || [])
-      .reduce((prev, cur) => {
-        if (!prev.find((stop) => stop.id === cur.id)) {
-          prev.push(cur)
-        }
-        return prev
-      }, [])
+    stops = Object.values(stopsById)
 
     // Override the minimum zoom so that the stops appear even if zoomed out
     minZoom = 2

--- a/lib/util/webapp-routes.js
+++ b/lib/util/webapp-routes.js
@@ -42,6 +42,7 @@ const routes = [
       // Route viewer (and route ID).
       '/route',
       '/route/:id',
+      '/route/:id/pattern/:patternId',
       // Stop viewer (and stop ID).
       '/stop',
       '/stop/:id'


### PR DESCRIPTION
This PR changes the route viewer so that, when a route is previewed (when the user clicks the route number) and all patterns are shown on the map, no stops are shown. Stops for a pattern continue to be displayed when the user selects a pattern from the destination drop-down selector.