### PR TITLE
co2 Tweaks

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -663,7 +663,7 @@ common:
       {isMore, select,
       true {more}
       other {less}
-      } CO<sub>2</sub> than driving alone.
+      } CO<sub>2</sub> than driving alone
 
   # Note to translator: the strings below are used in sentences such as:
   # "No trip found for bike, walk, and transit."

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -680,7 +680,7 @@ common:
       {isMore, select,
       true {plus}
       other {moins}
-      } qu'en voiture.
+      } qu'en voiture
 
   # Note to translator: some of the strings below are used in sentences such as:
   # "No trip found for bike, walk, and transit."

--- a/lib/components/narrative/metro/metro-itinerary.tsx
+++ b/lib/components/narrative/metro/metro-itinerary.tsx
@@ -199,8 +199,8 @@ const ItineraryGridSmall = styled.div`
 
 const BLUR_AMOUNT = 3
 const blurAnimation = keyframes`
- 0% { filter: blur(${BLUR_AMOUNT + 1}px); }
- 50% { filter: blur(${BLUR_AMOUNT}px) }
+ 0% { filter: blur(${BLUR_AMOUNT}px); }
+ 50% { filter: blur(${BLUR_AMOUNT + 1}px) }
 `
 
 const LoadingBlurred = styled.span<{ loading: boolean }>`
@@ -208,6 +208,7 @@ const LoadingBlurred = styled.span<{ loading: boolean }>`
   animation-name: ${(props) => (props.loading ? blurAnimation : '')};
   animation-duration: 1s;
   animation-iteration-count: infinite;
+  transition: all 0.2s ease-in-out;
 `
 
 type Props = {

--- a/lib/components/narrative/metro/metro-itinerary.tsx
+++ b/lib/components/narrative/metro/metro-itinerary.tsx
@@ -20,6 +20,7 @@ import {
   itineraryHasAccessibilityScores
 } from '../../../util/accessibility-routing'
 import { getActiveSearch, getFare } from '../../../util/state'
+import { IconWithText } from '../../util/styledIcon'
 import { ItineraryDescription } from '../default/itinerary-description'
 import { localizeGradationMap } from '../utils'
 import FormattedDuration, {
@@ -28,6 +29,7 @@ import FormattedDuration, {
 import ItineraryBody from '../line-itin/connected-itinerary-body'
 import NarrativeItinerary from '../narrative-itinerary'
 import SimpleRealtimeAnnotation from '../simple-realtime-annotation'
+import Sub from '../../util/sub-text'
 
 import { DepartureTimesList } from './departure-times-list'
 import {
@@ -36,10 +38,7 @@ import {
   getItineraryRoutes,
   removeInsignifigantWalkLegs
 } from './attribute-utils'
-import { IconWithText } from '../../util/styledIcon'
 import RouteBlock from './route-block'
-
-import Sub from '../../util/sub-text'
 
 const { ItineraryView } = uiActions
 
@@ -496,9 +495,6 @@ const mapStateToProps = (state: any, ownProps: Props) => {
     // @ts-expect-error state is not yet typed
     activeSearch && activeSearch.activeItineraryTimeIndex
 
-  // @ts-expect-error TODO: type activeSearch
-  const pending = activeSearch ? Boolean(activeSearch.pending) : false
-
   return {
     accessibilityScoreGradationMap:
       state.otp.config.accessibilityScore?.gradationMap,
@@ -511,7 +507,8 @@ const mapStateToProps = (state: any, ownProps: Props) => {
     currency: state.otp.config.localization?.currency || 'USD',
     defaultFareKey: state.otp.config.itinerary?.defaultFareKey,
     enableDot: !state.otp.config.itinerary?.disableMetroSeperatorDot,
-    pending,
+    // @ts-expect-error TODO: type activeSearch
+    pending: activeSearch ? Boolean(activeSearch.pending) : false,
     showLegDurations: state.otp.config.itinerary?.showLegDurations
   }
 }


### PR DESCRIPTION
This PR does a tiny bit of cleanup on the co2 display to add final polish.

* removes period at the end of the statement
* the number is blurred until all results are no longer pending -- this ensures that the number "jump" when a driving leg arrives is less jarring.