### PR TITLE
Prevent Search Interfering with Route Viewer

### DIFF
--- a/lib/components/map/route-preview-overlay.tsx
+++ b/lib/components/map/route-preview-overlay.tsx
@@ -36,7 +36,7 @@ const RoutePreviewOverlay = ({ geometries, visible }: Props) => {
       type: 'FeatureCollection'
     }
     return (
-      <Source data={geojson} id="route" type="geojson">
+      <Source data={geojson} id="route-preview-source" type="geojson">
         <Layer
           id="route-preview"
           layout={{


### PR DESCRIPTION
This PR renames the geojson source used by `RoutePreviewOverlay` so it does not interfere with the Route Viewer data.