### PR TITLE
fix(forms): Adjust icon layout and remove .fa references.

### DIFF
--- a/index.css
+++ b/index.css
@@ -119,12 +119,6 @@ input[type="text"]::-ms-clear {
   }
 }
 
-/* increase icon size */
-.app-menu li a .fa,
-.expand-submenu-button span .fa {
-  font-size: 2rem;
-}
-
 .menu-item:hover *,
 .app-menu li a span *:hover {
   color: #4c97f5;

--- a/lib/components/form/batch-styled.ts
+++ b/lib/components/form/batch-styled.ts
@@ -53,15 +53,15 @@ export const PlanTripButton = styled(Button)`
   background-color: green;
   color: #ffffffdd;
   margin-left: auto;
-  padding: 5px;
   &:active {
     ${activeCss}
     filter: saturate(50%);
     background: green;
   }
 
-  span.fa {
-    margin-left: -2.5px; /* without HiDPI things still look fine, just a little off center */
+  span {
+    display: inline-block;
+    margin-top: -5px;
   }
 `
 

--- a/lib/components/user/monitored-trip/trip-notifications-pane.js
+++ b/lib/components/user/monitored-trip/trip-notifications-pane.js
@@ -49,9 +49,6 @@ const SettingsToggle = styled.button`
   background: none;
   border: none;
   padding: 0;
-  & span.fa {
-    line-height: 150%;
-  }
 `
 
 /**


### PR DESCRIPTION
This PR adjust icon positioning within their buttons in the trip form, and removes references to unused fontawesome element classes.