### PR TITLE
refactor: prioritize config transit operators over gtfs agencies

### DIFF
--- a/lib/components/viewers/route-details.js
+++ b/lib/components/viewers/route-details.js
@@ -146,7 +146,7 @@ class RouteDetails extends Component {
               <FormattedMessage
                 id="components.RouteDetails.operatedBy"
                 values={{
-                  agencyName: agency.name
+                  agencyName: operator.name ? operator.name : agency.name
                 }}
               />
             )}

--- a/lib/components/viewers/route-viewer.js
+++ b/lib/components/viewers/route-viewer.js
@@ -203,6 +203,10 @@ class RouteViewer extends Component {
       )
     }
     const { search } = filter
+    const operators =
+      transitOperators.length > 0
+        ? [...new Set(transitOperators.map((x) => x.name))]
+        : agencies
 
     return (
       <div className="route-viewer">
@@ -246,9 +250,9 @@ class RouteViewer extends Component {
                     id: 'components.RouteViewer.allAgencies'
                   })}
                 </option>
-                {agencies.map((agency) => (
-                  <option key={agency} value={agency}>
-                    {agency}
+                {operators.map((operator) => (
+                  <option key={operator} value={operator}>
+                    {operator}
                   </option>
                 ))}
               </select>

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -581,17 +581,25 @@ function getItineraryToRender(state) {
 const routeSelector = (state) => Object.values(state.otp.transitIndex.routes)
 const routeViewerFilterSelector = (state) => state.otp.ui.routeViewer.filter
 
+const getAgencyIdForFilter = (name, transitOperators) => {
+  const operator = transitOperators.find((operator) => operator.name === name)
+  return operator.agencyId
+}
+
 /**
  * Returns all routes that match the route viewer filters
  */
 export const getFilteredRoutes = createSelector(
   routeSelector,
   routeViewerFilterSelector,
-  (routes, filter) =>
+  (state) => state.otp.config.transitOperators,
+  (routes, filter, transitOperators) =>
     routes.filter(
       (route) =>
-        // If the filter isn't defined, don't check.
-        (!filter.agency || filter.agency === route.agencyName) &&
+        (!filter.agency ||
+          getAgencyIdForFilter(filter.agency, transitOperators) ===
+            route.agencyId ||
+          filter.agency === route.agencyName) &&
         (!filter.mode || filter.mode === route.mode) &&
         // If user search is active, filter by either the long or short name
         (!filter.search ||
@@ -623,14 +631,18 @@ export const getSortedFilteredRoutes = createSelector(
 export const getModesForActiveAgencyFilter = createSelector(
   routeSelector,
   routeViewerFilterSelector,
-  (routes, filter) =>
+  (state) => state.otp.config.transitOperators,
+  (routes, filter, transitOperators) =>
     Array.from(
       new Set(
         routes
           .filter(
             (route) =>
               route.mode &&
-              (!filter.agency || filter.agency === route.agencyName)
+              (!filter.agency ||
+                getAgencyIdForFilter(filter.agency, transitOperators) ===
+                  route.agencyId ||
+                filter.agency === route.agencyName)
           )
           .map((route) => route.mode)
           .filter((mode) => mode !== undefined)


### PR DESCRIPTION
This PR prioritizes using the Transit Operator names in the client's config file and will fall back on using the GTFS agency if no Transit operators are specified in the config file.

OTP-UI: https://github.com/ibi-group/otp-ui/tree/prioritize-config-operators
Config: https://github.com/ibi-group/configurations/tree/atl-temp-flex-feeds