### PR TITLE
chore: update route viewer semantic html

### DIFF
--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -16,9 +16,10 @@ import OperatorLogo from '../util/operator-logo'
 
 import RouteDetails from './route-details'
 
-export const StyledRouteRow = styled.div`
+export const StyledRouteRow = styled.li`
   background-color: white;
   margin: 10px;
+  list-style: none;
 `
 
 export const RouteRowButton = styled(Button)`
@@ -47,7 +48,7 @@ const RouteNameElement = styled.span`
   font-weight: 400;
   margin-left: 8px;
 `
-const RouteLongNameElement = styled.span`
+const RouteLongNameElement = styled.h1`
   font-size: 16px;
   font-weight: 500;
   /*

--- a/lib/components/viewers/route-details.js
+++ b/lib/components/viewers/route-details.js
@@ -24,7 +24,8 @@ import {
   PatternContainer,
   RouteNameContainer,
   Stop,
-  StopContainer
+  StopContainer,
+  StopLink
 } from './styled'
 
 class RouteDetails extends Component {
@@ -169,11 +170,9 @@ class RouteDetails extends Component {
         </RouteNameContainer>
         {headsigns && headsigns.length > 0 && (
           <PatternContainer>
-            <h4>
-              <label htmlFor="headsign-selector" id="headsign-selector-label">
-                <FormattedMessage id="components.RouteDetails.stopsTo" />
-              </label>
-            </h4>
+            <label htmlFor="headsign-selector" id="headsign-selector-label">
+              <FormattedMessage id="components.RouteDetails.stopsTo" />
+            </label>
             <select
               id="headsign-selector"
               name="headsigns"
@@ -214,7 +213,15 @@ class RouteDetails extends Component {
                   route?.textColor
                 )}
               >
-                {stop.name}
+                <StopLink
+                  onClick={() => this._stopLinkClicked(stop.id)}
+                  textColor={getMostReadableTextColor(
+                    routeColor,
+                    route?.textColor
+                  )}
+                >
+                  {stop.name}
+                </StopLink>
               </Stop>
             ))}
           </StopContainer>

--- a/lib/components/viewers/route-viewer.js
+++ b/lib/components/viewers/route-viewer.js
@@ -218,9 +218,9 @@ class RouteViewer extends Component {
           )}
 
           {/* Header Text */}
-          <div className="header-text">
+          <h1 className="header-text">
             <FormattedMessage id="components.RouteViewer.title" />
-          </div>
+          </h1>
           <div>
             <FormattedMessage id="components.RouteViewer.details" />
           </div>
@@ -286,7 +286,7 @@ class RouteViewer extends Component {
           </section>
         </div>
 
-        <div className="route-viewer-body">
+        <ul className="route-viewer-body">
           {sortedRoutes.map((route) => {
             // Find operator based on agency_id (extracted from OTP route ID).
             const operator =
@@ -314,7 +314,7 @@ class RouteViewer extends Component {
               <FormattedMessage id="components.RouteViewer.noFilteredRoutesFound" />
             </span>
           )}
-        </div>
+        </ul>
       </div>
     )
   }

--- a/lib/components/viewers/styled.js
+++ b/lib/components/viewers/styled.js
@@ -41,7 +41,7 @@ export const PatternContainer = styled.div`
 }
 `
 
-export const StopContainer = styled.div`
+export const StopContainer = styled.ul`
   color: ${(props) => props?.textColor || '#333'};
   background-color: ${(props) => props?.backgroundColor || '#fff'};
   overflow-y: scroll;
@@ -50,18 +50,21 @@ export const StopContainer = styled.div`
   are shown when browsers don't calculate 100% sensibly */
   padding: 15px 0 100px;
 `
-export const Stop = styled.a`
+export const StopLink = styled.a`
   cursor: pointer;
   color: ${(props) => props?.textColor + 'da' || '#333'};
+
+  &:hover {
+    color: ${(props) => props?.textColor || '#23527c'};
+  }
+`
+export const Stop = styled.li`
+  cursor: pointer;
   display: block;
   white-space: nowrap;
   margin-left: 45px;
   /* negative margin accounts for the height of the stop blob */
   margin-top: -28px;
-
-  &:hover {
-    color: ${(props) => props?.textColor || '#23527c'};
-  }
 
   /* this is the station blob */
   &::before {

--- a/lib/components/viewers/viewers.css
+++ b/lib/components/viewers/viewers.css
@@ -63,6 +63,7 @@
 .otp .trip-viewer-body {
   overflow-x: hidden;
   overflow-y: auto;
+  padding-left: 0;
 }
 .otp .stop-viewer-body,
 .otp .trip-viewer-body {
@@ -81,6 +82,7 @@
 .otp .route-viewer .header-text {
   font-weight: 700;
   font-size: 24px;
+  margin: 0;
 }
 .otp .route-viewer .header-text.route-expanded {
   display: flex;


### PR DESCRIPTION
Upgrading the semantic HTML of the Route Viewer for a11y purposes:
- Groups list of routes in a `<ul>`
- Groups list of stops/links in a `<ul>`
- Changes the Route Viewer header to an `h1`
- Changes the Pattern Details header to an `h1`
- Changes the h4 for the "toward" select into a label 