### PR TITLE
Update trip viewer semantic HTML

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -550,6 +550,7 @@ components:
     accessible: Accessible
     bicyclesAllowed: Allowed
     header: Trip Viewer
+    listOfRouteStops: List of stops on this route
     routeHeader: "Route: <strong>{routeShortName}</strong> {routeLongName}"
     viewStop: View
   UserAccountScreen:

--- a/lib/components/viewers/trip-viewer.js
+++ b/lib/components/viewers/trip-viewer.js
@@ -15,7 +15,7 @@ import styled from 'styled-components'
 import * as apiActions from '../../actions/api'
 import * as mapActions from '../../actions/map'
 import * as uiActions from '../../actions/ui'
-import { IconWithText, StyledIconWrapper } from '../utilnpx/styledIcon'
+import { IconWithText, StyledIconWrapper } from '../util/styledIcon'
 import SpanWithSpace from '../util/span-with-space'
 import Strong from '../util/strong-text'
 

--- a/lib/components/viewers/trip-viewer.js
+++ b/lib/components/viewers/trip-viewer.js
@@ -4,7 +4,7 @@ import { Bicycle } from '@styled-icons/fa-solid/Bicycle'
 import { Label as BsLabel, Button } from 'react-bootstrap'
 import { Circle } from '@styled-icons/fa-solid/Circle'
 import { connect } from 'react-redux'
-import { FormattedMessage } from 'react-intl'
+import { FormattedMessage, injectIntl } from 'react-intl'
 import { toDate } from 'date-fns-tz'
 import { Wheelchair } from '@styled-icons/fa-solid/Wheelchair'
 import coreUtils from '@opentripplanner/core-utils'
@@ -24,7 +24,7 @@ import ViewStopButton from './view-stop-button'
 
 const { getCurrentDate } = coreUtils.time
 
-const StopList = styled.ul`
+const StopList = styled.ol`
   padding-left: 0;
 `
 const Stop = styled.li`
@@ -43,6 +43,7 @@ class TripViewer extends Component {
     findTrip: apiActions.findTrip.type,
     hideBackButton: PropTypes.bool,
     homeTimezone: PropTypes.string,
+    intl: PropTypes.object,
     setViewedTrip: uiActions.setViewedTrip.type,
     tripData: PropTypes.object,
     viewedTrip: PropTypes.object
@@ -59,7 +60,8 @@ class TripViewer extends Component {
   }
 
   render() {
-    const { hideBackButton, homeTimezone, tripData, viewedTrip } = this.props
+    const { hideBackButton, homeTimezone, intl, tripData, viewedTrip } =
+      this.props
     const startOfDay = toDate(getCurrentDate(homeTimezone), {
       timeZone: homeTimezone
     })
@@ -109,6 +111,7 @@ class TripViewer extends Component {
                 tripData.bikesAllowed === 1) && (
                 <div>
                   {tripData.wheelchairAccessible === 1 && (
+                    // TODO: these labels are currently insufficient for screen readers
                     <BsLabel bsStyle="primary">
                       <IconWithText Icon={Wheelchair}>
                         <FormattedMessage id="components.TripViewer.accessible" />
@@ -129,7 +132,11 @@ class TripViewer extends Component {
           )}
 
           {/* Stop Listing */}
-          <StopList>
+          <StopList
+            aria-label={intl.formatMessage({
+              id: 'components.TripViewer.listOfRouteStops'
+            })}
+          >
             {tripData &&
               tripData.stops &&
               tripData.stopTimes &&
@@ -174,6 +181,8 @@ class TripViewer extends Component {
 
                     {/* the stop-viewer button */}
                     <div className="stop-button-container">
+                      {/* TODO: To a screen reader, "View" appears before the stop name. 
+                      A separate label for screen readers will need to be set up. */}
                       <ViewStopButton
                         stopId={stop.id}
                         text={
@@ -211,4 +220,7 @@ const mapDispatchToProps = {
   setViewedTrip: uiActions.setViewedTrip
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(TripViewer)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(injectIntl(TripViewer))

--- a/lib/components/viewers/trip-viewer.js
+++ b/lib/components/viewers/trip-viewer.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-indent */
 import { ArrowLeft } from '@styled-icons/fa-solid/ArrowLeft'
 import { Bicycle } from '@styled-icons/fa-solid/Bicycle'
 import { Label as BsLabel, Button } from 'react-bootstrap'
@@ -9,11 +10,12 @@ import { Wheelchair } from '@styled-icons/fa-solid/Wheelchair'
 import coreUtils from '@opentripplanner/core-utils'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
+import styled from 'styled-components'
 
 import * as apiActions from '../../actions/api'
 import * as mapActions from '../../actions/map'
 import * as uiActions from '../../actions/ui'
-import { IconWithText, StyledIconWrapper } from '../util/styledIcon'
+import { IconWithText, StyledIconWrapper } from '../utilnpx/styledIcon'
 import SpanWithSpace from '../util/span-with-space'
 import Strong from '../util/strong-text'
 
@@ -21,6 +23,17 @@ import DepartureTime from './departure-time'
 import ViewStopButton from './view-stop-button'
 
 const { getCurrentDate } = coreUtils.time
+
+const StopList = styled.ul`
+  padding-left: 0;
+`
+const Stop = styled.li`
+  list-style: none;
+`
+const RouteName = styled.h2`
+  margin-bottom: 20px;
+  font-size: inherit;
+`
 
 class TripViewer extends Component {
   static propTypes = {
@@ -65,9 +78,9 @@ class TripViewer extends Component {
           )}
 
           {/* Header Text */}
-          <div className="header-text">
+          <h1 className="header-text">
             <FormattedMessage id="components.TripViewer.header" />
-          </div>
+          </h1>
           <div style={{ clear: 'both' }} />
         </div>
 
@@ -75,8 +88,7 @@ class TripViewer extends Component {
           {/* Basic Trip Info */}
           {tripData && (
             <div>
-              {/* Route name */}
-              <div>
+              <RouteName>
                 {tripData.route && (
                   <FormattedMessage
                     id="components.TripViewer.routeHeader"
@@ -87,89 +99,94 @@ class TripViewer extends Component {
                     }}
                   />
                 )}
-              </div>
+              </RouteName>
 
               {/* Wheelchair/bike accessibility badges, if applicable */}
-              <h4>
-                {tripData.wheelchairAccessible === 1 && (
-                  <BsLabel bsStyle="primary">
-                    <IconWithText Icon={Wheelchair}>
-                      <FormattedMessage id="components.TripViewer.accessible" />
-                    </IconWithText>
-                  </BsLabel>
-                )}
-                <SpanWithSpace margin={0.25} />
-                {tripData.bikesAllowed === 1 && (
-                  <BsLabel bsStyle="success">
-                    <IconWithText Icon={Bicycle}>
-                      <FormattedMessage id="components.TripViewer.bicyclesAllowed" />
-                    </IconWithText>
-                  </BsLabel>
-                )}
-              </h4>
+              {(tripData.wheelchairAccessible === 1 ||
+                tripData.bikesAllowed === 1) && (
+                <div>
+                  {tripData.wheelchairAccessible === 1 && (
+                    <BsLabel bsStyle="primary">
+                      <IconWithText Icon={Wheelchair}>
+                        <FormattedMessage id="components.TripViewer.accessible" />
+                      </IconWithText>
+                    </BsLabel>
+                  )}
+                  <SpanWithSpace margin={0.25} />
+                  {tripData.bikesAllowed === 1 && (
+                    <BsLabel bsStyle="success">
+                      <IconWithText Icon={Bicycle}>
+                        <FormattedMessage id="components.TripViewer.bicyclesAllowed" />
+                      </IconWithText>
+                    </BsLabel>
+                  )}
+                </div>
+              )}
             </div>
           )}
 
           {/* Stop Listing */}
-          {tripData &&
-            tripData.stops &&
-            tripData.stopTimes &&
-            tripData.stops.map((stop, i) => {
-              // determine whether to use special styling for first/last stop
-              let stripMapLineClass = 'strip-map-line'
-              if (i === 0) stripMapLineClass = 'strip-map-line-first'
-              else if (i === tripData.stops.length - 1) {
-                stripMapLineClass = 'strip-map-line-last'
-              }
+          <StopList>
+            {tripData &&
+              tripData.stops &&
+              tripData.stopTimes &&
+              tripData.stops.map((stop, i) => {
+                // determine whether to use special styling for first/last stop
+                let stripMapLineClass = 'strip-map-line'
+                if (i === 0) stripMapLineClass = 'strip-map-line-first'
+                else if (i === tripData.stops.length - 1) {
+                  stripMapLineClass = 'strip-map-line-last'
+                }
 
-              // determine whether to show highlight in strip map
-              let highlightClass
-              if (i === viewedTrip.fromIndex) {
-                highlightClass = 'strip-map-highlight-first'
-              } else if (i > viewedTrip.fromIndex && i < viewedTrip.toIndex) {
-                highlightClass = 'strip-map-highlight'
-              } else if (i === viewedTrip.toIndex) {
-                highlightClass = 'strip-map-highlight-last'
-              }
+                // determine whether to show highlight in strip map
+                let highlightClass
+                if (i === viewedTrip.fromIndex) {
+                  highlightClass = 'strip-map-highlight-first'
+                } else if (i > viewedTrip.fromIndex && i < viewedTrip.toIndex) {
+                  highlightClass = 'strip-map-highlight'
+                } else if (i === viewedTrip.toIndex) {
+                  highlightClass = 'strip-map-highlight-last'
+                }
 
-              return (
-                <div key={i}>
-                  {/* the departure time */}
-                  <div className="stop-time">
-                    <DepartureTime
-                      originDate={startOfDay}
-                      stopTime={tripData.stopTimes[i]}
-                    />
-                  </div>
-
-                  {/* the vertical strip map */}
-                  <div className="strip-map-container">
-                    {highlightClass && <div className={highlightClass} />}
-                    <div className={stripMapLineClass} />
-                    <div className="strip-map-icon">
-                      <StyledIconWrapper>
-                        <Circle />
-                      </StyledIconWrapper>
+                return (
+                  <Stop key={i}>
+                    {/* the departure time */}
+                    <div className="stop-time">
+                      <DepartureTime
+                        originDate={startOfDay}
+                        stopTime={tripData.stopTimes[i]}
+                      />
                     </div>
-                  </div>
 
-                  {/* the stop-viewer button */}
-                  <div className="stop-button-container">
-                    <ViewStopButton
-                      stopId={stop.id}
-                      text={
-                        <FormattedMessage id="components.TripViewer.viewStop" />
-                      }
-                    />
-                  </div>
+                    {/* the vertical strip map */}
+                    <div className="strip-map-container">
+                      {highlightClass && <div className={highlightClass} />}
+                      <div className={stripMapLineClass} />
+                      <div className="strip-map-icon">
+                        <StyledIconWrapper>
+                          <Circle />
+                        </StyledIconWrapper>
+                      </div>
+                    </div>
 
-                  {/* the main stop label */}
-                  <div className="stop-name">{stop.name}</div>
+                    {/* the stop-viewer button */}
+                    <div className="stop-button-container">
+                      <ViewStopButton
+                        stopId={stop.id}
+                        text={
+                          <FormattedMessage id="components.TripViewer.viewStop" />
+                        }
+                      />
+                    </div>
 
-                  <div style={{ clear: 'both' }} />
-                </div>
-              )
-            })}
+                    {/* the main stop label */}
+                    <div className="stop-name">{stop.name}</div>
+
+                    <div style={{ clear: 'both' }} />
+                  </Stop>
+                )
+              })}
+          </StopList>
         </div>
       </div>
     )

--- a/lib/components/viewers/trip-viewer.js
+++ b/lib/components/viewers/trip-viewer.js
@@ -34,6 +34,9 @@ const RouteName = styled.h2`
   margin-bottom: 20px;
   font-size: inherit;
 `
+const HeaderText = styled.h1`
+  margin: 2px 0 0 0;
+`
 
 class TripViewer extends Component {
   static propTypes = {
@@ -78,9 +81,9 @@ class TripViewer extends Component {
           )}
 
           {/* Header Text */}
-          <h1 className="header-text">
+          <HeaderText className="header-text">
             <FormattedMessage id="components.TripViewer.header" />
-          </h1>
+          </HeaderText>
           <div style={{ clear: 'both' }} />
         </div>
 

--- a/percy/percy.test.js
+++ b/percy/percy.test.js
@@ -352,7 +352,7 @@ test('OTP-RR', async () => {
 
   // Open stop viewer from trip viewer
   await page.click(
-    'div.trip-viewer-body > ul > li > div.stop-button-container > button'
+    'div.trip-viewer-body > ul > li:nth-child(3) > div.stop-button-container > button'
   )
   await page.waitForSelector('.stop-viewer')
 

--- a/percy/percy.test.js
+++ b/percy/percy.test.js
@@ -352,7 +352,7 @@ test('OTP-RR', async () => {
 
   // Open stop viewer from trip viewer
   await page.click(
-    'div.trip-viewer-body > div:nth-child(3) > div.stop-button-container > button'
+    'div.trip-viewer-body > ul > li > div.stop-button-container > button'
   )
   await page.waitForSelector('.stop-viewer')
 

--- a/percy/percy.test.js
+++ b/percy/percy.test.js
@@ -352,7 +352,7 @@ test('OTP-RR', async () => {
 
   // Open stop viewer from trip viewer
   await page.click(
-    'div.trip-viewer-body > ul > li:nth-child(3) > div.stop-button-container > button'
+    'div.trip-viewer-body > ol > li:nth-child(3) > div.stop-button-container > button'
   )
   await page.waitForSelector('.stop-viewer')
 


### PR DESCRIPTION
Upgrading the semantic HTML of the Trip Viewer for a11y purposes:
- Change Trip Viewer header to `h1`
- Change route name to `h2`
- Remove h4, and conditionally render wheelchair and bike accessibility container
- Add styled components to avoid inline styles
- Group stops in a `ul`