### PR TITLE
Update map tiles URL in example config

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -93,11 +93,10 @@ map:
   initLon: -122.682
   baseLayers:
     - name: Streets
-      url: //cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}@2x.png
-      subdomains: "abcd"
+      # These tiles are free to use, but not in production
+      url: //basemaps.cartocdn.com/gl/positron-gl-style/style.json
       attribution: 'Map tiles: &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy; <a href="https://carto.com/attributions">CARTO</a>'
       maxZoom: 20
-      hasRetinaSupport: true
     - name: Stamen Toner Lite
       url: http://tile.stamen.com/toner-lite/{z}/{x}/{y}.png
       attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'


### PR DESCRIPTION
Currently, doing `yarn start` with the example configuration leads to a blank map, because the configuration is still referencing raster tile server URL.