### PR TITLE
(Fix): Work and Home location saving bug

### DIFF
--- a/lib/components/user/places/favorite-place-screen.js
+++ b/lib/components/user/places/favorite-place-screen.js
@@ -111,6 +111,9 @@ class FavoritePlaceScreen extends Component {
       place.name = ''
     }
     const isFixed = place && isHomeOrWork(place)
+    if (isFixed) {
+      place.name = place.type
+    }
     const isMobileView = isMobile()
 
     let heading


### PR DESCRIPTION
Adding onto @miles-grant-ibigroup's [PR](https://github.com/opentripplanner/otp-react-redux/pull/750) with help from Binh.

Fixes problem where Work or Home lack of `name` doesn't pass Formik name validation checks before saving. Rather than removing name validation method, assign Home or Work location a name with its type.

UI:
![image](https://user-images.githubusercontent.com/62163307/213287956-c7001740-44ee-439c-9691-61809c1a3544.png)

Don't mind fork PR, I don't have permissions to push/commit yet 👍 