### PR TITLE
Set Long and Short Name for Leg of Route

### DIFF
--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -166,6 +166,10 @@ export class RouteRow extends PureComponent {
                   intl
                 )}
                 height={22}
+                leg={{
+                  routeLongName: route?.longName,
+                  routeShortName: route?.shortName
+                }}
                 mode={getModeFromRoute(route)}
                 width={22}
               />


### PR DESCRIPTION
This change sets a short or long name for a specific leg of a journey. Important to distinguish routes by name in config logic or otherwise.