### PR TITLE
fix(trip-viewer): fix otp1 trip viewer crash

### DIFF
--- a/lib/components/viewers/trip-viewer.js
+++ b/lib/components/viewers/trip-viewer.js
@@ -127,11 +127,13 @@ class TripViewer extends Component {
                   values={{
                     boardAtStop: (
                       <strong>
-                        {tripData.stops[viewedTrip.fromIndex].name}
+                        {tripData.stops?.[viewedTrip.fromIndex].name}
                       </strong>
                     ),
                     disembarkAtStop: (
-                      <strong>{tripData.stops[viewedTrip.toIndex].name}</strong>
+                      <strong>
+                        {tripData.stops?.[viewedTrip.toIndex].name}
+                      </strong>
                     )
                   }}
                 />


### PR DESCRIPTION
Some trip viewer a11y changes caused crashes with OTP1. Percy is catching this across most PRs. This PR repairs this