### PR TITLE
Stop and Route Viewer a11y Tweaks

### DIFF
--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -804,9 +804,12 @@ exports[`components > viewers > stop viewer should render countdown times after 
                     </FromToLocationPicker>
                   </span>
                 </div>
-                <styled.div>
+                <styled.div
+                  tabIndex={0}
+                >
                   <div
                     className="sc-gVgoRu bqiCoT"
+                    tabIndex={0}
                   >
                     <LiveStopTimes
                       findStopTimesForStop={[Function]}
@@ -3406,9 +3409,12 @@ exports[`components > viewers > stop viewer should render countdown times for st
                     </FromToLocationPicker>
                   </span>
                 </div>
-                <styled.div>
+                <styled.div
+                  tabIndex={0}
+                >
                   <div
                     className="sc-gVgoRu bqiCoT"
+                    tabIndex={0}
                   >
                     <LiveStopTimes
                       findStopTimesForStop={[Function]}
@@ -5140,9 +5146,12 @@ exports[`components > viewers > stop viewer should render times after midnight w
                     </FromToLocationPicker>
                   </span>
                 </div>
-                <styled.div>
+                <styled.div
+                  tabIndex={0}
+                >
                   <div
                     className="sc-gVgoRu bqiCoT"
+                    tabIndex={0}
                   >
                     <LiveStopTimes
                       findStopTimesForStop={[Function]}
@@ -8133,9 +8142,12 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                     </FromToLocationPicker>
                   </span>
                 </div>
-                <styled.div>
+                <styled.div
+                  tabIndex={0}
+                >
                   <div
                     className="sc-gVgoRu bqiCoT"
+                    tabIndex={0}
                   >
                     <LiveStopTimes
                       findStopTimesForStop={[Function]}
@@ -14669,9 +14681,12 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                     </FromToLocationPicker>
                   </span>
                 </div>
-                <styled.div>
+                <styled.div
+                  tabIndex={0}
+                >
                   <div
                     className="sc-gVgoRu bqiCoT"
+                    tabIndex={0}
                   >
                     <LiveStopTimes
                       findStopTimesForStop={[Function]}

--- a/lib/components/map/map.css
+++ b/lib/components/map/map.css
@@ -17,9 +17,6 @@
   text-decoration: underline;
 }
 
-.otp .link-button:focus {
-  outline: 0;
-}
 
 /* leg diagram */
 

--- a/lib/components/viewers/stop-schedule-table.tsx
+++ b/lib/components/viewers/stop-schedule-table.tsx
@@ -17,7 +17,7 @@ import DepartureTime from './departure-time'
 
 // Styles for the schedule table and its contents.
 const StyledTable = styled.table`
-  border-spacing: collapse;
+  box-sizing: border-box;
   height: 100%;
   width: 100%;
   th {

--- a/lib/components/viewers/stop-viewer.js
+++ b/lib/components/viewers/stop-viewer.js
@@ -404,6 +404,8 @@ class StopViewer extends Component {
         {stopData && (
           <div className="stop-viewer-body">
             {this._renderControls()}
+            {/* scrollable list of scheduled stops requires tabIndex 
+            for keyboard navigation */}
             <Scrollable tabIndex={0}>{contents}</Scrollable>
             {/* Future: add stop details */}
           </div>

--- a/lib/components/viewers/stop-viewer.js
+++ b/lib/components/viewers/stop-viewer.js
@@ -296,16 +296,6 @@ class StopViewer extends Component {
               </IconWithText>
             </button>
           )}
-          {isShowingSchedule && (
-            <input
-              className="pull-right"
-              onChange={this.handleDateChange}
-              onKeyDown={this.props.onKeyDown}
-              required
-              type="date"
-              value={this.state.date}
-            />
-          )}
         </div>
         <span role="group">
           <FromToLocationPicker
@@ -314,6 +304,16 @@ class StopViewer extends Component {
             onToClick={this._onClickPlanTo}
           />
         </span>
+        {isShowingSchedule && (
+          <input
+            className="pull-right"
+            onChange={this.handleDateChange}
+            onKeyDown={this.props.onKeyDown}
+            required
+            type="date"
+            value={this.state.date}
+          />
+        )}
 
         {timezoneWarning}
       </div>
@@ -404,7 +404,7 @@ class StopViewer extends Component {
         {stopData && (
           <div className="stop-viewer-body">
             {this._renderControls()}
-            <Scrollable>{contents}</Scrollable>
+            <Scrollable tabIndex={0}>{contents}</Scrollable>
             {/* Future: add stop details */}
           </div>
         )}

--- a/lib/components/viewers/styled.js
+++ b/lib/components/viewers/styled.js
@@ -55,11 +55,17 @@ export const StopContainer = styled.ol`
   are shown when browsers don't calculate 100% sensibly */
   padding: 15px 0 100px;
 `
-export const StopLink = styled.a`
+export const StopLink = styled.button`
   color: ${(props) => props?.textColor + 'da' || '#333'};
+  background-color: transparent;
+  border: none;
+  padding: 0;
+  width: 95%;
+  text-align: left;
 
   &:hover {
     color: ${(props) => props?.textColor || '#23527c'};
+    text-decoration: underline;
   }
 `
 export const Stop = styled.li`

--- a/lib/components/viewers/styled.js
+++ b/lib/components/viewers/styled.js
@@ -29,15 +29,13 @@ export const PatternContainer = styled.div`
   display: flex;
   gap: 16px;
   justify-content: flex-start;
-  
-  
   margin: 0;
   padding: 8px;
-  
 
   label { 
     width: 30%;
   }
+  
   select {
     color: #333;
     text-overflow: ellipsis;
@@ -60,8 +58,8 @@ export const StopLink = styled.button`
   background-color: transparent;
   border: none;
   padding: 0;
-  width: 95%;
   text-align: left;
+  width: 95%;
 
   &:hover {
     color: ${(props) => props?.textColor || '#23527c'};

--- a/lib/components/viewers/styled.js
+++ b/lib/components/viewers/styled.js
@@ -23,24 +23,25 @@ export const HeadsignSelectLabel = styled.label`
 `
 
 export const PatternContainer = styled.div`
+  align-items: baseline;
   background-color: inherit;
   color: inherit;
   display: flex;
-  justify-content: flex-start;
-  align-items: baseline;
   gap: 16px;
-  padding: 0 8px 8px;
+  justify-content: flex-start;
+  
+  
   margin: 0;
+  padding: 8px;
+  
 
-  overflow-x: scroll;
-
-  h4 {
-      margin-bottom: 0px;
-      white-space: nowrap;
+  label { 
+    width: 30%;
   }
-
   select {
     color: #333;
+    text-overflow: ellipsis;
+    width: 100%;
   }
 }
 `

--- a/percy/percy.test.js
+++ b/percy/percy.test.js
@@ -418,7 +418,7 @@ test('OTP-RR', async () => {
   } catch {
     await page.reload({ waitUntil: 'networkidle0' })
   }
-  const [patternStopButton] = await page.$x("//a[contains(., 'West')]")
+  const [patternStopButton] = await page.$x("//button[contains(., 'West')]")
   await patternStopButton.click()
   await page.waitForSelector('.stop-viewer')
 

--- a/percy/percy.test.js
+++ b/percy/percy.test.js
@@ -182,7 +182,7 @@ if (OTP_RR_PERCY_MOBILE) {
 
     // Open stop viewer
     const [patternStopButton] = await page.$x(
-      "//a[contains(., 'Ashby Station')]"
+      "//button[contains(., 'Ashby Station')]"
     )
     await patternStopButton.click()
     await page.waitForSelector('.stop-viewer')


### PR DESCRIPTION
- Stops route viewer "towards" select from clipping into the edge of the sidebar
- Adds focus states and improves focus order for stop viewer controls
- Makes timetable container focusable (and therefore scrollable for keyboard navigation)
- Changes `StopLink` from `a` to `button` (and therefore focusable)

Follow up PRs necessary for:
- OTP-UI keyboard focusable stops on map
- OTP-RR stop-viewer updated departures layout