### PR TITLE
Remove Extra Border

### DIFF
--- a/lib/components/narrative/default/itinerary.css
+++ b/lib/components/narrative/default/itinerary.css
@@ -37,6 +37,7 @@
   border-top-right-radius: 10px;
 }
 .otp .option.metro-itin.expanded:first-of-type div.header .itin-wrapper {
+  border-bottom: none;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }


### PR DESCRIPTION
During the a11y work, I believe we re-added a border that should have been removed. This PR re-adds this border.

Before:
<img width="482" alt="Screenshot 2023-02-01 at 11 12 15 AM" src="https://user-images.githubusercontent.com/86619099/216099006-2d592828-e39b-496c-b418-b2020e27deab.png">

After:
<img width="484" alt="Screenshot 2023-02-01 at 11 11 56 AM" src="https://user-images.githubusercontent.com/86619099/216099016-5046bf9c-6421-48fe-b4cf-54cdb33dc763.png">
