### PR TITLE
Stop Viewer Departure Layout

### DIFF
--- a/lib/components/viewers/live-stop-times.tsx
+++ b/lib/components/viewers/live-stop-times.tsx
@@ -231,7 +231,7 @@ class LiveStopTimes extends Component<Props, State> {
           )}
           {tomorrowTimes.length > 0 && (
             <div className="list-container">
-              <p>
+              <p className="day-label">
                 <FormattedDayOfWeek
                   // 'iiii' returns the long ISO day of the week (independent of browser locale).
                   // See https://date-fns.org/v2.28.0/docs/format
@@ -265,7 +265,7 @@ class LiveStopTimes extends Component<Props, State> {
           )}
           {dayAfterTomorrowTimes.length > 0 && (
             <div className="list-container">
-              <p>
+              <p className="day-label">
                 <FormattedDayOfWeek
                   day={format(dayAfterTomorrow, 'iiii', {
                     timeZone: homeTimezone

--- a/lib/components/viewers/live-stop-times.tsx
+++ b/lib/components/viewers/live-stop-times.tsx
@@ -1,7 +1,12 @@
+import { format, utcToZonedTime } from 'date-fns-tz'
 import { FormattedMessage, FormattedTime } from 'react-intl'
 import { Redo } from '@styled-icons/fa-solid/Redo'
 import { TransitOperator } from '@opentripplanner/types'
+import addDays from 'date-fns/addDays'
 import coreUtils from '@opentripplanner/core-utils'
+
+import FormattedDayOfWeek from '../util/formatted-day-of-week'
+import isSameDay from 'date-fns/isSameDay'
 import React, { Component } from 'react'
 
 import {
@@ -11,6 +16,7 @@ import {
 } from '../../util/viewer'
 import { IconWithText } from '../util/styledIcon'
 import SpanWithSpace from '../util/span-with-space'
+import type { Time } from '../util/types'
 
 import AmenitiesPanel from './amenities-panel'
 import PatternRow from './pattern-row'
@@ -23,10 +29,12 @@ const defaultState = {
   timer: null
 }
 
+const ONE_DAY_IN_SECONDS = 86400
+
 type Props = {
   autoRefreshStopTimes: boolean
   findStopTimesForStop: ({ stopId }: { stopId: string }) => void
-  homeTimezone?: string
+  homeTimezone: string
   nearbyStops: any // TODO: shared types
   setHoveredStop: (stopId: string) => void
   showNearbyStops: boolean
@@ -151,35 +159,143 @@ class LiveStopTimes extends Component<Props, State> {
       return patternHeadsignComparator(patternA, patternB)
     }
 
+    const routeTimes = Object.values(stopTimesByPattern)
+      .sort(patternComparator)
+      .filter(({ pattern, route }) =>
+        routeIsValid(route, getRouteIdForPattern(pattern))
+      )
+
+    // Determine if arrival occurs on different day, making sure to account for
+    // any extra days added to the service day if it arrives after midnight. Note:
+    // this can handle the rare (and non-existent?) case where an arrival occurs
+    // 48:00 hours (or more) from the start of the service day.
+
+    const now = utcToZonedTime(Date.now(), homeTimezone)
+    const tomorrow = addDays(now, 1)
+    const dayAfterTomorrow = addDays(now, 2)
+
+    const findTimes = (times: any, date: any): any[] => {
+      return times
+        .map((route: any) => {
+          return {
+            ...route,
+            times: route.times.filter((time: Time) => {
+              const departureTime = time.realtimeDeparture
+              const serviceDay = utcToZonedTime(
+                new Date(time.serviceDay * 1000),
+                homeTimezone
+              )
+              const departureTimeRemainder = departureTime % ONE_DAY_IN_SECONDS
+              const daysAfterServiceDay =
+                (departureTime - departureTimeRemainder) / ONE_DAY_IN_SECONDS
+              const departureDay = addDays(serviceDay, daysAfterServiceDay)
+              return isSameDay(date, departureDay)
+            })
+          }
+        })
+        .filter((route: any) => route.times.length > 0)
+    }
+
+    const todayTimes = findTimes(routeTimes, now)
+    const tomorrowTimes = findTimes(routeTimes, tomorrow)
+    const dayAfterTomorrowTimes = findTimes(routeTimes, dayAfterTomorrow)
+
     return (
       <>
-        <ul className="route-row-container">
-          {Object.values(stopTimesByPattern)
-            .sort(patternComparator)
-            .filter(({ pattern, route }) =>
-              routeIsValid(route, getRouteIdForPattern(pattern))
-            )
-            .map(({ id, pattern, route, times }) => {
-              // Only add pattern if route info is returned by OTP.
-              return (
-                <PatternRow
-                  homeTimezone={homeTimezone}
-                  key={id}
-                  pattern={pattern}
-                  route={{
-                    ...route,
-                    operator: transitOperators.find(
-                      (o: TransitOperator) => o.agencyId === route.agencyId
-                    )
-                  }}
-                  showOperatorLogo={showOperatorLogo}
-                  stopTimes={times}
-                  stopViewerArriving={stopViewerArriving}
-                  stopViewerConfig={stopViewerConfig}
+        <div>
+          {todayTimes.length > 0 && (
+            <div className="list-container">
+              <ul className="route-row-container">
+                {todayTimes.map(({ id, pattern, route, times }) => {
+                  // Only add pattern if route info is returned by OTP.
+                  return (
+                    <PatternRow
+                      homeTimezone={homeTimezone}
+                      key={id}
+                      pattern={pattern}
+                      route={{
+                        ...route,
+                        operator: transitOperators.find(
+                          (o: TransitOperator) => o.agencyId === route.agencyId
+                        )
+                      }}
+                      showOperatorLogo={showOperatorLogo}
+                      stopTimes={times}
+                      stopViewerArriving={stopViewerArriving}
+                      stopViewerConfig={stopViewerConfig}
+                    />
+                  )
+                })}
+              </ul>
+            </div>
+          )}
+          {tomorrowTimes.length > 0 && (
+            <div className="list-container">
+              <p>
+                <FormattedDayOfWeek
+                  // 'iiii' returns the long ISO day of the week (independent of browser locale).
+                  // See https://date-fns.org/v2.28.0/docs/format
+                  day={format(tomorrow, 'iiii', {
+                    timeZone: homeTimezone
+                  }).toLowerCase()}
                 />
-              )
-            })}
-        </ul>
+              </p>
+              <ul className="route-row-container">
+                {tomorrowTimes.map(({ id, pattern, route, times }) => {
+                  return (
+                    <PatternRow
+                      homeTimezone={homeTimezone}
+                      key={id}
+                      pattern={pattern}
+                      route={{
+                        ...route,
+                        operator: transitOperators.find(
+                          (o: TransitOperator) => o.agencyId === route.agencyId
+                        )
+                      }}
+                      showOperatorLogo={showOperatorLogo}
+                      stopTimes={times}
+                      stopViewerArriving={stopViewerArriving}
+                      stopViewerConfig={stopViewerConfig}
+                    />
+                  )
+                })}
+              </ul>
+            </div>
+          )}
+          {dayAfterTomorrowTimes.length > 0 && (
+            <div className="list-container">
+              <p>
+                <FormattedDayOfWeek
+                  day={format(dayAfterTomorrow, 'iiii', {
+                    timeZone: homeTimezone
+                  }).toLowerCase()}
+                />
+              </p>
+              <ul className="route-row-container">
+                {dayAfterTomorrowTimes.map(({ id, pattern, route, times }) => {
+                  return (
+                    <PatternRow
+                      homeTimezone={homeTimezone}
+                      key={id}
+                      pattern={pattern}
+                      route={{
+                        ...route,
+                        operator: transitOperators.find(
+                          (o: TransitOperator) => o.agencyId === route.agencyId
+                        )
+                      }}
+                      showOperatorLogo={showOperatorLogo}
+                      stopTimes={times}
+                      stopViewerArriving={stopViewerArriving}
+                      stopViewerConfig={stopViewerConfig}
+                    />
+                  )
+                })}
+              </ul>
+            </div>
+          )}
+        </div>
 
         {/* Auto update controls for realtime arrivals */}
         <div style={{ marginTop: '20px' }}>

--- a/lib/components/viewers/next-arrival-for-pattern.tsx
+++ b/lib/components/viewers/next-arrival-for-pattern.tsx
@@ -83,7 +83,7 @@ function NextArrivalForPattern({
       }}
     >
       {/* route name */}
-      <div className="next-arrival-label overflow-ellipsis" title={title}>
+      <div className="next-arrival-label" title={title}>
         <span className="route-name">
           <RouteRenderer
             isOnColoredBackground={route.operator?.colorMode?.includes('gtfs')}
@@ -91,7 +91,7 @@ function NextArrivalForPattern({
             leg={generateFakeLegForRouteRenderer(route, true)}
           />
         </span>
-        {toHeadsign}
+        <span className="overflow-ellipsis">{toHeadsign}</span>
       </div>
       {/* next departure preview */}
       {hasStopTimes && (

--- a/lib/components/viewers/pattern-row.tsx
+++ b/lib/components/viewers/pattern-row.tsx
@@ -73,12 +73,21 @@ class PatternRow extends Component<Props, State> {
 
     const routeName = route.shortName ? route.shortName : route.longName
     const routeColor = getRouteColorBasedOnSettings(route.operator, route)
+    console.log(stopTimes)
+    let style
+    if (routeName && routeName?.length >= 4 && routeName?.length <= 6) {
+      style = { fontSize: '20px' }
+    } else if (routeName && routeName?.length > 7) {
+      style = { fontSize: '16px' }
+    } else {
+      style = { fontSize: '32px' }
+    }
 
     return (
       <li className="route-row">
         {/* header row */}
         <div
-          className="header"
+          className="header stop-view"
           style={{
             backgroundColor: routeColor,
             color: getMostReadableTextColor(routeColor, route?.textColor)
@@ -86,11 +95,7 @@ class PatternRow extends Component<Props, State> {
         >
           {/* route name */}
           <div className="route-name">
-            <strong
-              style={
-                routeName && routeName?.length >= 4 ? { fontSize: '50%' } : {}
-              }
-            >
+            <strong style={style}>
               <div
                 style={{
                   alignContent: 'center',
@@ -98,6 +103,7 @@ class PatternRow extends Component<Props, State> {
                   justifyContent: 'center',
                   whiteSpace: 'nowrap'
                 }}
+                title={routeName}
               >
                 {showOperatorLogo && (
                   <OperatorLogo operator={route?.operator} />
@@ -111,7 +117,7 @@ class PatternRow extends Component<Props, State> {
                 />
               </div>
             </strong>
-            <span>{pattern.headsign}</span>
+            <span title={pattern.headsign}>{pattern.headsign}</span>
           </div>
           {/* next departure preview */}
           {hasStopTimes && (

--- a/lib/components/viewers/stop-time-cell.tsx
+++ b/lib/components/viewers/stop-time-cell.tsx
@@ -21,7 +21,6 @@ import DepartureTime from './departure-time'
 
 const { getUserTimezone } = coreUtils.time
 const ONE_HOUR_IN_SECONDS = 3600
-const ONE_DAY_IN_SECONDS = 86400
 
 const PulsingRss = styled(Rss)`
   animation: pulse-opacity 2s ease-in-out infinite;
@@ -63,22 +62,6 @@ const StopTimeCell = ({
       </div>
     )
   }
-  const departureTime = stopTime.realtimeDeparture
-  const now = utcToZonedTime(Date.now(), homeTimezone)
-  const serviceDay = utcToZonedTime(
-    new Date(stopTime.serviceDay * 1000),
-    homeTimezone
-  )
-
-  // Determine if arrival occurs on different day, making sure to account for
-  // any extra days added to the service day if it arrives after midnight. Note:
-  // this can handle the rare (and non-existent?) case where an arrival occurs
-  // 48:00 hours (or more) from the start of the service day.
-  const departureTimeRemainder = departureTime % ONE_DAY_IN_SECONDS
-  const daysAfterServiceDay =
-    (departureTime - departureTimeRemainder) / ONE_DAY_IN_SECONDS
-  const departureDay = addDays(serviceDay, daysAfterServiceDay)
-  const vehicleDepartsToday = isSameDay(now, departureDay)
 
   // Determine whether to show departure as countdown (e.g. "5 min") or as HH:mm
   // time, using realtime updates if available.
@@ -93,12 +76,6 @@ const StopTimeCell = ({
     secondsUntilDeparture < ONE_HOUR_IN_SECONDS && departsInFuture
   // Whether to display "Due" or a countdown (used in conjunction with showCountdown).
   const isDue = secondsUntilDeparture < 60
-
-  // We only want to show the day of the week if the arrival is on a
-  // different day and we're not showing the countdown string. This avoids
-  // cases such as when it's Wednesday at 11:55pm and an arrival occurs at
-  // Thursday 12:19am. We don't want the time to read: 'Thursday, 24 minutes'.
-  const showDayOfWeek = !vehicleDepartsToday && !showCountdown
 
   const realtime = stopTime.realtimeState === 'UPDATED'
   const realtimeLabel = realtime
@@ -121,17 +98,6 @@ const StopTimeCell = ({
         {realtime ? <PulsingRss /> : <Clock />}
       </StyledIconWrapperTextAlign>
 
-      {showDayOfWeek && (
-        <span className="percy-hide" style={{ marginBottom: -4 }}>
-          <FormattedDayOfWeek
-            // 'iiii' returns the long ISO day of the week (independent of browser locale).
-            // See https://date-fns.org/v2.28.0/docs/format
-            day={format(departureDay, 'iiii', {
-              timeZone: homeTimezone
-            }).toLowerCase()}
-          />{' '}
-        </span>
-      )}
       <span
         className="percy-hide"
         title={getRealtimeStatusLabel({

--- a/lib/components/viewers/viewers.css
+++ b/lib/components/viewers/viewers.css
@@ -102,23 +102,35 @@
 
 /* stop viewer styles */
 
-.otp .stop-viewer .route-row {
-}
 .otp .stop-viewer .route-row-container,
 .related-panel-container {
-  border-radius: 10px;
   box-shadow: 2px 2px 5px 1px rgba(0, 0, 0, 0.1);
   list-style-type: none;
   padding-left: 0;
 }
+.otp .stop-viewer .list-container .route-row-container li .header.stop-view {
+  border-radius: 0;
+} 
+
+.otp .stop-viewer .list-container:first-of-type .route-row-container li:first-of-type .header.stop-view {
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+}
+.otp .stop-viewer .list-container:last-of-type .route-row-container li:last-of-type .header.stop-view  {
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
+}
+
 .otp .stop-viewer .route-row:first-of-type {
   margin-top: 10px;
 }
 
 .otp .stop-viewer .route-row .header {
   align-items: center;
-  display: grid;
-  grid-template-columns: 2fr 1fr;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
+  overflow: hidden;
   width: 100%;
 }
 .otp .stop-viewer .route-row .header .route-name {
@@ -126,24 +138,30 @@
   display: grid;
   font-size: 42px;
   gap: 5px;
-  grid-template-columns: 4ch 2fr;
+  grid-template-columns: fit-content(8ch) fit-content(8ch);
 }
 .otp .stop-viewer .route-row .header .route-name span {
+  display: -webkit-box;
   font-size: 15px;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
 }
 .otp .stop-viewer .route-row .header .route-name strong span {
-  font-size: 32px;
+  font-size: inherit;
+  max-width: 120px;
+  min-width: 75px;
+  text-align: left;
+  -webkit-line-clamp: 2;
+  width: fit-content;
 }
 
 .otp .stop-viewer .route-row .header .next-trip-preview {
   display: grid;
   grid-template-rows: fit-content(8ch);
-  justify-self: end;
   list-style-type: none;
   padding: 15px;
   text-align: right;
   white-space: nowrap;
-  width: 100%;
 }
 
 .otp .stop-viewer .route-row .header .next-trip-preview li:first-of-type {
@@ -174,6 +192,22 @@
   outline: 0px;
 }
 
+@media (max-width: 450px) {
+  .otp .stop-viewer .route-row .header .next-trip-preview {
+    width: 100%;
+    padding: 15px 7px;
+    max-width: min-content;
+  }
+
+  .otp .stop-viewer .route-row .header .route-name strong span {
+    min-width: auto;
+  }
+
+  .otp .stop-viewer .route-row .header .next-trip-preview li:first-of-type {
+    font-size: 18px;
+  }
+}
+
 /* child stop details */
 
 .otp .stop-viewer .stop-viewer-body .stop-label {
@@ -197,6 +231,7 @@
 }
 .otp .stop-viewer .stop-viewer-body .related-panel-container {
   background: #fffffff8;
+  border-radius: 10px;
   color: #333;
   padding: 0.5rem;
   margin: 1.5rem 0;
@@ -246,7 +281,7 @@
 .otp .stop-viewer .stop-viewer-body .next-arrival-row .next-arrival-label {
   align-items: center;
   display: flex;
-  max-width: 250px;
+  width: 75%;
 }
 
 .otp .stop-viewer .stop-viewer-body .next-arrival-row .route-name {
@@ -261,9 +296,10 @@
 }
 
 .otp .stop-viewer .stop-viewer-body .next-arrival-row .next-arrival-time {
-  flex-shrink: 0;
   font-weight: 700;
-  width: 90px;
+  margin-right: 8px;
+  text-align: right;
+  white-space: nowrap;
 }
 
 .otp .stop-viewer .stop-viewer-body .related-item .child-stop-icon {
@@ -285,6 +321,11 @@
   color: #000080;
 }
 
+@media (max-width: 450px) {
+  .otp .stop-viewer .stop-viewer-body .next-arrival-row .next-arrival-label {
+    width: 65%;
+  }
+}
 /* end of child-stop-details */
 
 /*.otp .stop-viewer .trip-table {

--- a/lib/components/viewers/viewers.css
+++ b/lib/components/viewers/viewers.css
@@ -112,6 +112,10 @@
   border-radius: 0;
 } 
 
+.otp .stop-viewer .list-container .day-label {
+  font-weight: 500;
+}
+
 .otp .stop-viewer .list-container:first-of-type .route-row-container li:first-of-type .header.stop-view {
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;


### PR DESCRIPTION
Separates upcoming stop times by day and tweaks flexbox/grid elements to avoid clipping and overflow at smaller screen sizes.

Definitely looking for feedback around how the times are being sorted by day (it feels like there may be a more efficient way to render each day!)

Before                                 |  After
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/115499534/217331841-960d64b1-558b-4962-b8ac-0c3aad149219.png)  |  
![image](https://user-images.githubusercontent.com/115499534/217333085-93834f6b-9492-478d-8111-de97c2d3fc0a.png)

