### PR TITLE
Reformat popup time display

### DIFF
--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -1483,6 +1483,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                         >
                                           <FormattedDuration
                                             duration={3124}
+                                            includeSeconds={false}
                                           >
                                             <FormattedMessage
                                               id="common.time.tripDurationFormat"
@@ -1490,6 +1491,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                                 Object {
                                                   "hours": 0,
                                                   "minutes": 52,
+                                                  "seconds": 0,
                                                 }
                                               }
                                             >
@@ -3809,6 +3811,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                         >
                                           <FormattedDuration
                                             duration={3124}
+                                            includeSeconds={false}
                                           >
                                             <FormattedMessage
                                               id="common.time.tripDurationFormat"
@@ -3816,6 +3819,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                                 Object {
                                                   "hours": 0,
                                                   "minutes": 52,
+                                                  "seconds": 0,
                                                 }
                                               }
                                             >

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -452,12 +452,11 @@ components:
       improve transit services in my area. <termsOfStorageLink>More info...</termsOfStorageLink>
   TransitVehicleOverlay:
     # keys designed to match API output
-    incoming_at: "approaching {stop}"
-    in_transit_to: "next stop {stop}"
-    realtimeVehicleInfo: "<strong>{vehicleNameOrBlank}</strong>{relativeTime}"
-    stopped_at: "doors open at {stop}"
-    travelingAt: "traveling at {milesPerHour}"
-    vehicleName: "Vehicle {vehicleNumber}: "
+    incoming_at: "Approaching: {stop}"
+    in_transit_to: "Next stop: {stop}"
+    stopped_at: "Doors open at {stop}"
+    travelingAt: "Traveling at {milesPerHour}"
+    vehicleName: "Vehicle {vehicleNumber}"
   TripBasicsPane:
     checkingItineraryExistence: Checking itinerary existence for each day of the week...
     selectAtLeastOneDay: Please select at least one day to monitor.
@@ -616,7 +615,6 @@ common:
     today: Today
     tomorrow: Tomorrow
     yesterday: Yesterday
-
   daysOfWeek:
     monday: Monday
     tuesday: Tuesday
@@ -727,6 +725,7 @@ common:
     # Use ordered placeholders for the departure-arrival string
     # (this will accommodate right-to-left languages by swapping the order in this string).
     departureArrivalTimes: "{startTime, time, short}—{endTime, time, short}"
+    durationAgo: "{duration} ago"
     # Replacing (sort of) moment.js fromNow() functionality. This is not a direct 1:1, since
     # moment.js formats text to "a minute ago" once 44 seconds are reached, etc. This has
     # been simplified here.
@@ -744,7 +743,7 @@ common:
         other {# days ago}
       }
     # TODO: Distinguish between one hour (singular) and 2 hours or more?
-    tripDurationFormat: "{hours, plural, =0 {} other {# hr }}{minutes} min"
+    tripDurationFormat: "{hours, plural, =0 {} other {# hr }}{minutes} min { seconds, plural, =0 {} other {# sec}}"
 
 util:
   state:

--- a/i18n/es.yml
+++ b/i18n/es.yml
@@ -264,10 +264,9 @@ components:
     viewNextArrivals: Ver próximas llegadas
     zoomToStop: Zoom a la parada
   TransitVehicleOverlay:
-    vehicleName: 'Vehículo {vehicleNumber}: '
+    vehicleName: 'Vehículo {vehicleNumber}'
     in_transit_to: Próxima parada {stop}
     incoming_at: acercándose a {stop}
-    realtimeVehicleInfo: <strong>{vehicleNameOrBlank}</strong>{relativeTime}
     stopped_at: puertas abiertas en la {stop}
     travelingAt: Viajando a {milesPerHour}
   TripBasicsPane:
@@ -640,10 +639,11 @@ common:
     tap: toque
   time:
     departureArrivalTimes: '{startTime, time, short}—{endTime, time, short}'
+    durationAgo: "hace {duration}"
     fromNowUpdate: "{days, plural,\n =0 {{hours,plural,\n =0 {{minutes, plural,\n\
       \ =0 {hace unos segundos}\n =1 {hace un minuto}\n other {hace # minutos}\n }}\n\
       \ =1 {hace una hora}\n other {hace # horas}\n }}\n other {hace # días}\n }\n"
-    tripDurationFormat: "{hours, plural, =0 {} other {# hr }}{minutes} min"
+    tripDurationFormat: "{hours, plural, =0 {} other {# hr }}{minutes} min { seconds, plural, =0 {} other {# seg}}"
   places:
     custom: personalizado
     dining: restaurante

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -457,10 +457,9 @@ components:
     # keys designed to match API output
     incoming_at: "Approchant {stop}"
     in_transit_to: "Prochain arrêt : {stop}"
-    realtimeVehicleInfo: "<strong>{vehicleNameOrBlank}</strong>{relativeTime}"
     stopped_at: "À quai à {stop}"
     travelingAt: "Vitesse : {milesPerHour}"
-    vehicleName: "Véhicule {vehicleNumber} : "
+    vehicleName: "Véhicule {vehicleNumber}"
   TripBasicsPane:
     checkingItineraryExistence: Vérification du trajet pour chaque jour de la semaine...
     selectAtLeastOneDay: Veuillez choisir au moins un jour pour effectuer le suivi.
@@ -730,6 +729,7 @@ common:
 
   time:
     departureArrivalTimes: "{startTime, time, short}—{endTime, time, short}"
+    durationAgo: "il y a {duration}"
     fromNowUpdate: >
       {days, plural,
         =0 {{hours,plural,
@@ -743,7 +743,7 @@ common:
         }}
         other {il y a # jours}
       }
-    tripDurationFormat: "{hours, plural, =0 {} other {# h }}{minutes} mn"
+    tripDurationFormat: "{hours, plural, =0 {} other {# hr }}{minutes} mn { seconds, plural, =0 {} other {# sec}}"
 
 util:
   state:

--- a/i18n/ko.yml
+++ b/i18n/ko.yml
@@ -256,10 +256,9 @@ components:
       \ 데 동의합니다. <termsOfStorageLink>더 많은 정보...</termsOfStorageLink>\n"
   TransitVehicleOverlay:
     stopped_at: '{stop} 에서 문이 열립니다'
-    vehicleName: '차량 {vehicleNumber}: '
+    vehicleName: '차량 {vehicleNumber}'
     in_transit_to: 다음 중지 {stop}
     incoming_at: '{stop} 과 가까움'
-    realtimeVehicleInfo: <strong>{vehicleNameOrBlank}</strong>{relativeTime}
     travelingAt: 현재 {milesPerHour} 로 주행 중
   TripBasicsPane:
     tripDaysPrompt: 이 여행은 몇 일에 걸립니까?
@@ -583,10 +582,11 @@ common:
     tuesday: 화요일
   time:
     departureArrivalTimes: '{startTime, time, short}—{endTime, time, short}'
+    durationAgo: "{duration} 전"
     fromNowUpdate: "{days, plural,\n =0 {{hours,plural,\n =0 {{minutes, plural,\n\
       \ =0 {몇 초 전에}\n =1 {1 분 전}\n other {# 분 전}\n }}\n =1 {한 시간 전에}\n other {# 시간\
       \ 전}\n }}\n other {# 일 전}\n }\n"
-    tripDurationFormat: "{hours, plural, =0 {} other {# 시간 }}{minutes, number} 분"
+    tripDurationFormat: "{hours, plural, =0 {} other {# 시간 }}{minutes, number} 분 { seconds, plural, =0 {} other {# 초}}"
   coordinates: '{lat}, {lon}'
 util:
   state:

--- a/i18n/vi.yml
+++ b/i18n/vi.yml
@@ -257,8 +257,7 @@ components:
     incoming_at: Đang tiếp cận {stop}
     in_transit_to: Điểm dừng tiếp theo {stop}
     stopped_at: Cửa mở tại {stop}
-    vehicleName: 'Phương tiện giao thông {vehicleNumber}: '
-    realtimeVehicleInfo: <strong>{vehicleNameOrBlank}</strong>{relativeTime}
+    vehicleName: 'Phương tiện giao thông {vehicleNumber}'
     travelingAt: di chuyển với tốc độ {milesPerHour}
   TripBasicsPane:
     checkingItineraryExistence: Kiểm tra sự tồn tại của hành trình cho mỗi ngày trong
@@ -581,7 +580,8 @@ common:
     click: nhấp
   time:
     departureArrivalTimes: '{startTime, time, short}—{endTime, time, short}'
-    tripDurationFormat: "{hours, plural, =0 {} other {# giờ }}{minutes} phút"
+    durationAgo: "{duration} trước"
+    tripDurationFormat: "{hours, plural, =0 {} other {# giờ }}{minutes} phút { seconds, plural, =0 {} other {# giây}}"
     fromNowUpdate: "{days, plural,\n =0 {{hours,plural,\n =0 {{minutes, plural,\n\
       \ =0 {vài giây trước}\n =1 {một phút trước}\n other {# phút trước}\n }}\n =1\
       \ {một tiếng trước}\n other {# giờ trước}\n }}\n other {# ngày trước}\n }\n"

--- a/i18n/zh.yml
+++ b/i18n/zh.yml
@@ -272,8 +272,7 @@ components:
   TransitVehicleOverlay:
     incoming_at: 接近 {stop}
     in_transit_to: 下一车站 {stop}
-    vehicleName: '车辆 {vehicleNumber}: '
-    realtimeVehicleInfo: <strong>{vehicleNameOrBlank}</strong>{relativeTime}
+    vehicleName: '车辆 {vehicleNumber}'
     stopped_at: 巴士车门在 {stop} 打开
     travelingAt: 以 {milesPerHour}
   TripNotificationsPane:
@@ -528,10 +527,11 @@ common:
     transfers: '{transfers, plural, =0 {} one {# 换乘} other {# 换乘}}'
   time:
     departureArrivalTimes: '{startTime, time, short}—{endTime, time, short}'
+    durationAgo: "{duration}前"
     fromNowUpdate: "{days, plural,\n =0 {{hours,plural,\n =0 {{minutes, plural,\n\
       \ =0 {几秒钟前}\n =1 {一分钟前}\n other {# 分钟前}\n }}\n =1 {一小时前}\n other {# 小时前}\n }}\n\
       \ other {# 天之前}\n }\n"
-    tripDurationFormat: "{hours, plural, =0 {} other {# 小时 }}{minutes} 分钟}"
+    tripDurationFormat: "{hours, plural, =0 {} other {# 小时 }}{minutes} 分钟} { seconds, plural, =0 {} other {# 秒}}"
   dateExpressions:
     today: 今天
     tomorrow: 明天

--- a/lib/components/map/connected-transit-vehicle-overlay.js
+++ b/lib/components/map/connected-transit-vehicle-overlay.js
@@ -12,16 +12,19 @@
  * 5) This overlay has a custom popup on vehicle hover
  */
 
-import { connect } from 'react-redux'
 import { FormattedMessage, FormattedNumber, injectIntl } from 'react-intl'
-import React from 'react'
 import TransitVehicleOverlay, {
   Circle,
   withCaret,
   withRouteColorBackground
 } from '@opentripplanner/transit-vehicle-overlay'
 
+import { capitalizeFirst } from '../../util/ui'
+import { connect } from 'react-redux'
+import { formatDuration } from '../util/formatted-duration'
 import FormattedTransitVehicleStatus from '../util/formatted-transit-vehicle-status'
+
+import React from 'react'
 
 function VehicleTooltip(props) {
   const { intl, vehicle } = props
@@ -51,19 +54,24 @@ function VehicleTooltip(props) {
   // However, the needed coreUtils methods are not updated to support this
   return (
     <>
-      <span>
-        {/* FIXME: move back to core-utils for time handling */}
-        <FormattedMessage
-          id="components.TransitVehicleOverlay.realtimeVehicleInfo"
-          values={{
-            relativeTime: intl.formatRelativeTime(
-              Math.floor(vehicle?.seconds - Date.now() / 1000)
-            ),
-            strong: (m) => <strong style={{ fontSize: '110%' }}>{m}</strong>,
-            vehicleNameOrBlank: vehicleLabel
-          }}
-        />
-      </span>
+      {/* FIXME: move back to core-utils for time handling */}
+      <div>
+        <strong>{vehicleLabel}</strong>
+      </div>
+      <div>
+        {capitalizeFirst(
+          intl.formatMessage(
+            { id: 'common.time.durationAgo' },
+            {
+              duration: formatDuration(
+                Math.floor(Date.now() / 1000 - vehicle?.seconds),
+                intl,
+                true
+              )
+            }
+          )
+        )}
+      </div>
       {stopStatus !== 'STOPPED_AT' && vehicle?.speed > 0 && (
         <div>
           <FormattedMessage

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -148,7 +148,10 @@ const ITINERARY_ATTRIBUTES = [
       return (
         // FIXME: For CAR mode, walk time considers driving time.
         <>
-          <FormattedDuration duration={itinerary.walkTime} />
+          <FormattedDuration
+            duration={itinerary.walkTime}
+            includeSeconds={false}
+          />
           <LegIconWrapper noSpace>
             <LegIcon leg={leg} size={5} />
           </LegIconWrapper>

--- a/lib/components/narrative/default/tnc-leg.js
+++ b/lib/components/narrative/default/tnc-leg.js
@@ -62,7 +62,10 @@ class TransportationNetworkCompanyLeg extends Component {
         {tncData && tncData.estimatedArrival ? (
           <p>
             ETA for a driver:{' '}
-            <FormattedDuration duration={tncData.estimatedArrival} />
+            <FormattedDuration
+              duration={tncData.estimatedArrival}
+              includeSeconds={false}
+            />
           </p>
         ) : (
           <p>

--- a/lib/components/narrative/line-itin/itin-summary.tsx
+++ b/lib/components/narrative/line-itin/itin-summary.tsx
@@ -123,7 +123,10 @@ export class ItinerarySummary extends Component<Props> {
         <Details>
           {/* Travel time in hrs/mins */}
           <Header>
-            <FormattedDuration duration={itinerary.duration} />
+            <FormattedDuration
+              duration={itinerary.duration}
+              includeSeconds={false}
+            />
           </Header>
 
           {/* Duration as time range */}

--- a/lib/components/narrative/metro/metro-itinerary.tsx
+++ b/lib/components/narrative/metro/metro-itinerary.tsx
@@ -340,7 +340,10 @@ class MetroItinerary extends NarrativeItinerary {
             <RouteBlock
               footer={
                 showLegDurations && (
-                  <FormattedDuration duration={leg.duration} />
+                  <FormattedDuration
+                    duration={leg.duration}
+                    includeSeconds={false}
+                  />
                 )
               }
               hideLongName
@@ -398,7 +401,7 @@ class MetroItinerary extends NarrativeItinerary {
               },
               {
                 routes: getItineraryRoutes(itinerary, intl),
-                time: formatDuration(itinerary.duration, intl)
+                time: formatDuration(itinerary.duration, intl, false)
               }
             )}
             className={`itin-wrapper${mini ? '-small' : ''}`}
@@ -422,7 +425,10 @@ class MetroItinerary extends NarrativeItinerary {
                   })}
                 >
                   <PrimaryInfo>
-                    <FormattedDuration duration={itinerary.duration} />
+                    <FormattedDuration
+                      duration={itinerary.duration}
+                      includeSeconds={false}
+                    />
                   </PrimaryInfo>
                   <SecondaryInfo className={isFlexItinerary ? 'flex' : ''}>
                     {isFlexItinerary ? (
@@ -462,7 +468,10 @@ class MetroItinerary extends NarrativeItinerary {
                       id="components.MetroUI.timeWalking"
                       values={{
                         time: (
-                          <FormattedDuration duration={itinerary.walkTime} />
+                          <FormattedDuration
+                            duration={itinerary.walkTime}
+                            includeSeconds={false}
+                          />
                         )
                       }}
                     />
@@ -481,7 +490,10 @@ class MetroItinerary extends NarrativeItinerary {
             {mini && (
               <ItineraryGridSmall>
                 <PrimaryInfo as="span">
-                  <FormattedDuration duration={itinerary.duration} />
+                  <FormattedDuration
+                    duration={itinerary.duration}
+                    includeSeconds={false}
+                  />
                 </PrimaryInfo>
                 <SecondaryInfo as="span">
                   <ItineraryDescription itinerary={itinerary} />

--- a/lib/components/narrative/realtime-annotation.js
+++ b/lib/components/narrative/realtime-annotation.js
@@ -37,6 +37,7 @@ export default class RealtimeAnnotation extends Component {
                 normalDuration: (
                   <FormattedDuration
                     duration={realtimeEffects.normalDuration}
+                    includeSeconds={false}
                   />
                 ),
                 routes: (

--- a/lib/components/user/monitored-trip/trip-status-rendering-strategies/active-trip-renderer.js
+++ b/lib/components/user/monitored-trip/trip-status-rendering-strategies/active-trip-renderer.js
@@ -45,7 +45,10 @@ export default function activeTripRenderer({
           id="components.TripStatusRenderers.active.delayedHeading"
           values={{
             formattedDuration: (
-              <FormattedDuration duration={Math.abs(arrivalDeviationSeconds)} />
+              <FormattedDuration
+                duration={Math.abs(arrivalDeviationSeconds)}
+                includeSeconds={false}
+              />
             )
           }}
         />
@@ -58,7 +61,10 @@ export default function activeTripRenderer({
           id="components.TripStatusRenderers.active.earlyHeading"
           values={{
             formattedDuration: (
-              <FormattedDuration duration={Math.abs(arrivalDeviationSeconds)} />
+              <FormattedDuration
+                duration={Math.abs(arrivalDeviationSeconds)}
+                includeSeconds={false}
+              />
             )
           }}
         />

--- a/lib/components/user/monitored-trip/trip-status-rendering-strategies/base-renderer.js
+++ b/lib/components/user/monitored-trip/trip-status-rendering-strategies/base-renderer.js
@@ -40,7 +40,10 @@ export default function baseRenderer(monitoredTrip) {
         id="components.TripStatusRenderers.base.lastCheckedText"
         values={{
           formattedDuration: (
-            <FormattedDuration duration={secondsSinceLastCheck} />
+            <FormattedDuration
+              duration={secondsSinceLastCheck}
+              includeSeconds={false}
+            />
           )
         }}
       />

--- a/lib/components/user/monitored-trip/trip-status-rendering-strategies/upcoming-trip-renderer.js
+++ b/lib/components/user/monitored-trip/trip-status-rendering-strategies/upcoming-trip-renderer.js
@@ -89,7 +89,12 @@ export default function upcomingTripRenderer({
           <FormattedMessage
             id="components.TripStatusRenderers.upcoming.tripStartIsDelayed"
             values={{
-              duration: <FormattedDuration duration={absDeviation} />
+              duration: (
+                <FormattedDuration
+                  duration={absDeviation}
+                  includeSeconds={false}
+                />
+              )
             }}
           />
         )
@@ -100,7 +105,12 @@ export default function upcomingTripRenderer({
           <FormattedMessage
             id="components.TripStatusRenderers.upcoming.tripStartIsEarly"
             values={{
-              duration: <FormattedDuration duration={absDeviation} />
+              duration: (
+                <FormattedDuration
+                  duration={absDeviation}
+                  includeSeconds={false}
+                />
+              )
             }}
           />
         )

--- a/lib/components/user/monitored-trip/trip-summary.js
+++ b/lib/components/user/monitored-trip/trip-summary.js
@@ -1,10 +1,11 @@
+/* eslint-disable react/prop-types */ // TODO: Prop types
 import { ClassicLegIcon } from '@opentripplanner/icons'
-import React from 'react'
 import { FormattedMessage } from 'react-intl'
+import React from 'react'
 
 import FormattedDuration from '../../util/formatted-duration'
-import SpanWithSpace from '../../util/span-with-space'
 import ItinerarySummary from '../../narrative/default/itinerary-summary'
+import SpanWithSpace from '../../util/span-with-space'
 
 const TripSummary = ({ monitoredTrip }) => {
   const { itinerary } = monitoredTrip
@@ -12,18 +13,19 @@ const TripSummary = ({ monitoredTrip }) => {
   // TODO: use the modern itinerary summary built for trip comparison.
   return (
     <div
-      className={`otp option default-itin`}
-      style={{borderTop: '0px', padding: '0px'}}>
-      <div className='header'>
-        <SpanWithSpace className='title' margin={0.125}>
-          <FormattedMessage id='components.TripSummary.itinerary' />
+      className="otp option default-itin"
+      style={{ borderTop: '0px', padding: '0px' }}
+    >
+      <div className="header">
+        <SpanWithSpace className="title" margin={0.125}>
+          <FormattedMessage id="components.TripSummary.itinerary" />
         </SpanWithSpace>
-        <SpanWithSpace className='duration pull-right' margin={0.125}>
-          <FormattedDuration duration={duration} />
+        <SpanWithSpace className="duration pull-right" margin={0.125}>
+          <FormattedDuration duration={duration} includeSeconds={false} />
         </SpanWithSpace>
-        <span className='arrivalTime'>
+        <span className="arrivalTime">
           <FormattedMessage
-            id='common.time.departureArrivalTimes'
+            id="common.time.departureArrivalTimes"
             values={{
               endTime: endTime,
               startTime: startTime

--- a/lib/components/util/formatted-duration.tsx
+++ b/lib/components/util/formatted-duration.tsx
@@ -8,15 +8,17 @@ const { toHoursMinutesSeconds } = coreUtils.time
  * Formats the given duration according to the selected locale.
  */
 export default function FormattedDuration({
-  duration
+  duration,
+  includeSeconds
 }: {
   duration: number
+  includeSeconds: boolean
 }): JSX.Element {
-  const { hours, minutes } = toHoursMinutesSeconds(duration)
+  const { hours, minutes, seconds } = toHoursMinutesSeconds(duration)
   return (
     <FormattedMessage
       id="common.time.tripDurationFormat"
-      values={{ hours, minutes }}
+      values={{ hours, minutes, seconds: includeSeconds ? seconds : 0 }}
     />
   )
 }
@@ -25,14 +27,18 @@ export default function FormattedDuration({
  * Non-component version of FormatDuration component above
  * Formats the given duration according to the selected locale.
  */
-const formatDuration = (duration: number, intl: IntlShape): string => {
-  const { hours, minutes } = toHoursMinutesSeconds(duration)
+export const formatDuration = (
+  duration: number,
+  intl: IntlShape,
+  includeSeconds: boolean
+): string => {
+  const { hours, minutes, seconds } = toHoursMinutesSeconds(duration)
   return intl.formatMessage(
     { id: 'common.time.tripDurationFormat' },
     {
       hours,
-      minutes
+      minutes,
+      seconds: includeSeconds ? seconds : 0
     }
   )
 }
-export { formatDuration }

--- a/lib/components/viewers/realtime-status-label.tsx
+++ b/lib/components/viewers/realtime-status-label.tsx
@@ -121,7 +121,10 @@ const RealtimeStatusLabel = ({
           minutes={
             isEarlyOrLate ? (
               <DelayText>
-                <FormattedDuration duration={Math.abs(delay)} />
+                <FormattedDuration
+                  duration={Math.abs(delay)}
+                  includeSeconds={false}
+                />
               </DelayText>
             ) : (
               <>{null}</>

--- a/lib/components/viewers/stop-time-cell.tsx
+++ b/lib/components/viewers/stop-time-cell.tsx
@@ -145,7 +145,10 @@ const StopTimeCell = ({
           isDue ? (
             <FormattedMessage id="components.StopTimeCell.imminentArrival" />
           ) : (
-            <FormattedDuration duration={secondsUntilDeparture} />
+            <FormattedDuration
+              duration={secondsUntilDeparture}
+              includeSeconds={false}
+            />
           )
         ) : (
           <DepartureTime realTime stopTime={stopTime} />


### PR DESCRIPTION
- Changed the transit overlay popup to now display hours, minutes and seconds instead of just seconds using the `formatDuration` function

Co-authored by Binh!

**Before:**
<img width="221" alt="image" src="https://user-images.githubusercontent.com/62163307/218539054-e98686c9-dd40-4b1b-8720-d8280c375e72.png">


**After:**
English Example: 
<img width="220" alt="Pasted Graphic 16" src="https://user-images.githubusercontent.com/62163307/218538079-ae094f1d-3046-4bf9-b290-e75b0ba38f82.png">

French example: 
<img width="224" alt="Pasted Graphic 15" src="https://user-images.githubusercontent.com/62163307/218538123-421ecc01-54e3-4d80-a2eb-c866f869d96d.png">

 ... etc. changes also made in all translation configs
