### PR TITLE
Fix dropdown menus

### DIFF
--- a/index.css
+++ b/index.css
@@ -122,7 +122,7 @@ input[type="text"]::-ms-clear {
 }
 
 .app-menu button[aria-selected="true"],
-#locale-selector li[aria-selected="true"] {
+#locale-selector button[aria-selected="true"] {
   font-weight: bold;
 }
 

--- a/lib/components/app/app-menu.tsx
+++ b/lib/components/app/app-menu.tsx
@@ -28,10 +28,10 @@ import AppMenuItem from './app-menu-item'
 type AppMenuProps = {
   activeLocale: string
   callTakerEnabled?: boolean
-  // Typescript TODO configLanguageType
-  configLanguages?: Record<string, any>
   extraMenuItems?: menuItem[]
   fieldTripEnabled?: boolean
+  // Typescript TODO language options based on configLanguage.
+  languageOptions: Record<string, any> | null
   location: { search: string }
   mailablesEnabled?: boolean
   popupTarget: string
@@ -155,10 +155,10 @@ class AppMenu extends Component<
     const {
       activeLocale,
       callTakerEnabled,
-      configLanguages,
       extraMenuItems,
       fieldTripEnabled,
       intl,
+      languageOptions,
       mailablesEnabled,
       popupTarget,
       resetAndToggleCallHistory,
@@ -166,9 +166,6 @@ class AppMenu extends Component<
       setLocale,
       toggleMailables
     } = this.props
-
-    const languageOptions: Record<string, any> | null =
-      getLanguageOptions(configLanguages)
     const languageMenuItems: menuItem[] | null = languageOptions && [
       {
         children: Object.keys(languageOptions).map((locale: string) => ({
@@ -293,9 +290,9 @@ const mapStateToProps = (state: Record<string, any>) => {
   return {
     activeLocale: state.otp.ui.locale,
     callTakerEnabled: isModuleEnabled(state, Modules.CALL_TAKER),
-    configLanguages: language,
     extraMenuItems,
     fieldTripEnabled: isModuleEnabled(state, Modules.FIELD_TRIP),
+    languageOptions: getLanguageOptions(language),
     mailablesEnabled: isModuleEnabled(state, Modules.MAILABLES),
     popupTarget: state.otp.config?.popups?.launchers?.sidebarLink
   }

--- a/lib/components/app/desktop-nav.tsx
+++ b/lib/components/app/desktop-nav.tsx
@@ -41,7 +41,6 @@ export type Props = {
  */
 const DesktopNav = ({ otpConfig, popupTarget, setPopupContent }: Props) => {
   const { branding, persistence, title = DEFAULT_APP_TITLE } = otpConfig
-  const { language: configLanguages } = otpConfig
   const showLogin = Boolean(getAuth0Config(persistence))
 
   return (
@@ -72,7 +71,7 @@ const DesktopNav = ({ otpConfig, popupTarget, setPopupContent }: Props) => {
                 <FormattedMessage id={`config.popups.${popupTarget}`} />
               </NavItemOnLargeScreens>
             )}
-            <LocaleSelector configLanguages={configLanguages} />
+            <LocaleSelector />
             {showLogin && (
               <NavLoginButtonAuth0
                 id="login-control"

--- a/lib/components/app/locale-selector.tsx
+++ b/lib/components/app/locale-selector.tsx
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
 import { GlobeAmericas } from '@styled-icons/fa-solid/GlobeAmericas'
 import { useIntl } from 'react-intl'
-import React, { KeyboardEvent } from 'react'
+import React from 'react'
 
 import * as uiActions from '../../actions/ui'
 import { getLanguageOptions } from '../../util/i18n'
@@ -13,12 +13,6 @@ interface LocaleSelectorProps {
   languageOptions: Record<string, any> | null
   locale: string
   setLocale: (locale: string) => void
-}
-
-const onEnterOrSpace = (e: KeyboardEvent, action: () => void): void => {
-  if (e.key === 'Space' || e.key === 'Enter') {
-    action()
-  }
 }
 
 const LocaleSelector = (props: LocaleSelectorProps): JSX.Element | null => {
@@ -44,18 +38,12 @@ const LocaleSelector = (props: LocaleSelectorProps): JSX.Element | null => {
       // TODO: How to make this work without block ruby?
     >
       {Object.keys(languageOptions).map((locale: string) => (
-        <li
-          aria-selected={locale === currentLocale || undefined}
-          key={locale}
-          lang={locale}
-          onClick={() => setLocale(locale)}
-          onKeyPress={(e) => onEnterOrSpace(e, () => setLocale(locale))}
-          // We are correct, not eslint: https://w3c.github.io/aria-practices/examples/combobox/combobox-select-only.html
-          // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
-          role="option"
-          tabIndex={0}
-        >
-          <UnstyledButton tabIndex={-1}>
+        <li key={locale} lang={locale} role="none">
+          <UnstyledButton
+            aria-selected={locale === currentLocale || undefined}
+            onClick={() => setLocale(locale)}
+            role="option"
+          >
             {languageOptions[locale].name}
           </UnstyledButton>
         </li>

--- a/lib/components/app/locale-selector.tsx
+++ b/lib/components/app/locale-selector.tsx
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
 import { GlobeAmericas } from '@styled-icons/fa-solid/GlobeAmericas'
 import { useIntl } from 'react-intl'
-import React from 'react'
+import React, { KeyboardEvent } from 'react'
 
 import * as uiActions from '../../actions/ui'
 import { getLanguageOptions } from '../../util/i18n'
@@ -15,17 +15,17 @@ interface LocaleSelectorProps {
   setLocale: (locale: string) => void
 }
 
+const onEnterOrSpace = (e: KeyboardEvent, action: () => void): void => {
+  if (e.key === 'Space' || e.key === 'Enter') {
+    action()
+  }
+}
+
 const LocaleSelector = (props: LocaleSelectorProps): JSX.Element | null => {
   const { configLanguages, locale: currentLocale, setLocale } = props
   const languageOptions: Record<string, any> | null =
     getLanguageOptions(configLanguages)
   const intl = useIntl()
-
-  const onEnterOrSpace = (e: KeyboardEvent, action: () => void): void => {
-    if (e.key === 'Space' || e.key === 'Enter') {
-      action()
-    }
-  }
 
   // Only render if two or more languages are configured.
   return languageOptions ? (
@@ -51,7 +51,6 @@ const LocaleSelector = (props: LocaleSelectorProps): JSX.Element | null => {
           key={locale}
           lang={locale}
           onClick={() => setLocale(locale)}
-          // @ts-expect-error TODO: repair this type. Handler is not guaranteed to have 'key'
           onKeyPress={(e) => onEnterOrSpace(e, () => setLocale(locale))}
           // We are correct, not eslint: https://w3c.github.io/aria-practices/examples/combobox/combobox-select-only.html
           // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
@@ -70,6 +69,7 @@ const LocaleSelector = (props: LocaleSelectorProps): JSX.Element | null => {
 // Typescript TODO: type state properly
 const mapStateToProps = (state: any) => {
   return {
+    configLanguages: state.otp.config.language,
     locale: state.otp.ui.locale
   }
 }

--- a/lib/components/app/locale-selector.tsx
+++ b/lib/components/app/locale-selector.tsx
@@ -9,8 +9,8 @@ import { UnstyledButton } from '../util/unstyled-button'
 import Dropdown from '../util/dropdown'
 
 interface LocaleSelectorProps {
-  // Typescript TODO configLanguageType
-  configLanguages: Record<string, any>
+  // Typescript TODO languageOptions based on configLanguage type.
+  languageOptions: Record<string, any> | null
   locale: string
   setLocale: (locale: string) => void
 }
@@ -22,9 +22,7 @@ const onEnterOrSpace = (e: KeyboardEvent, action: () => void): void => {
 }
 
 const LocaleSelector = (props: LocaleSelectorProps): JSX.Element | null => {
-  const { configLanguages, locale: currentLocale, setLocale } = props
-  const languageOptions: Record<string, any> | null =
-    getLanguageOptions(configLanguages)
+  const { languageOptions, locale: currentLocale, setLocale } = props
   const intl = useIntl()
 
   // Only render if two or more languages are configured.
@@ -69,7 +67,7 @@ const LocaleSelector = (props: LocaleSelectorProps): JSX.Element | null => {
 // Typescript TODO: type state properly
 const mapStateToProps = (state: any) => {
   return {
-    configLanguages: state.otp.config.language,
+    languageOptions: getLanguageOptions(state.otp.config.language),
     locale: state.otp.ui.locale
   }
 }

--- a/lib/components/user/nav-login-button.tsx
+++ b/lib/components/user/nav-login-button.tsx
@@ -85,8 +85,8 @@ const NavLoginButton = ({
               target={link.target}
               to={link.url}
             >
-              <li tabIndex={0}>
-                <UnstyledButton tabIndex={-1}>
+              <li>
+                <UnstyledButton>
                   {link.messageId === 'myAccount' ? ( // messageId is 'myAccount' or 'help'
                     <FormattedMessage id="components.NavLoginButton.myAccount" />
                   ) : (
@@ -99,9 +99,8 @@ const NavLoginButton = ({
 
         <hr role="presentation" />
 
-        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-        <li onClick={onSignOutClick} onKeyDown={handleKeydown} tabIndex={0}>
-          <UnstyledButton tabIndex={-1}>
+        <li>
+          <UnstyledButton onClick={onSignOutClick}>
             <FormattedMessage id="components.NavLoginButton.signOut" />
           </UnstyledButton>
         </li>

--- a/lib/components/user/nav-login-button.tsx
+++ b/lib/components/user/nav-login-button.tsx
@@ -2,7 +2,7 @@
 import { FormattedMessage, useIntl } from 'react-intl'
 import { NavItem } from 'react-bootstrap'
 import { User } from '@auth0/auth0-react'
-import React, { HTMLAttributes, KeyboardEvent, useCallback } from 'react'
+import React, { HTMLAttributes } from 'react'
 import styled from 'styled-components'
 
 import { LinkContainerWithQuery } from '../form/connected-links'
@@ -50,12 +50,6 @@ const NavLoginButton = ({
     id,
     style
   }
-
-  const handleKeydown = useCallback((e: KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === 'Space') {
-      onSignOutClick()
-    }
-  }, [])
 
   // If a profile is passed (a user is logged in), display avatar and drop-down menu.
   if (profile) {

--- a/lib/components/user/nav-login-button.tsx
+++ b/lib/components/user/nav-login-button.tsx
@@ -2,7 +2,7 @@
 import { FormattedMessage, useIntl } from 'react-intl'
 import { NavItem } from 'react-bootstrap'
 import { User } from '@auth0/auth0-react'
-import React, { HTMLAttributes } from 'react'
+import React, { HTMLAttributes, KeyboardEvent, useCallback } from 'react'
 import styled from 'styled-components'
 
 import { LinkContainerWithQuery } from '../form/connected-links'
@@ -51,6 +51,12 @@ const NavLoginButton = ({
     style
   }
 
+  const handleKeydown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === 'Space') {
+      onSignOutClick()
+    }
+  }, [])
+
   // If a profile is passed (a user is logged in), display avatar and drop-down menu.
   if (profile) {
     const displayedName = profile.nickname || profile.name
@@ -93,7 +99,8 @@ const NavLoginButton = ({
 
         <hr role="presentation" />
 
-        <li onSelect={onSignOutClick} tabIndex={0}>
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+        <li onClick={onSignOutClick} onKeyDown={handleKeydown} tabIndex={0}>
           <UnstyledButton tabIndex={-1}>
             <FormattedMessage id="components.NavLoginButton.signOut" />
           </UnstyledButton>

--- a/lib/components/util/dropdown.tsx
+++ b/lib/components/util/dropdown.tsx
@@ -37,7 +37,6 @@ const DropdownMenu = styled.ul`
   border: 1px solid rgba(0, 0, 0, 0.15);
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
   color: #111;
-  cursor: default;
   float: left;
   list-style: none;
   margin: 2px 0 0;
@@ -45,7 +44,6 @@ const DropdownMenu = styled.ul`
   padding: 5px 0;
   position: absolute;
   right: 0;
-  text-align: left;
   top: 100%;
   z-index: 1000;
 
@@ -53,9 +51,12 @@ const DropdownMenu = styled.ul`
     margin: 0;
     padding: 0;
   }
-  li {
+  a,
+  button {
     cursor: pointer;
     padding: 5px 15px;
+    text-align: start;
+    width: 100%;
   }
   li.header {
     cursor: default;

--- a/lib/components/util/dropdown.tsx
+++ b/lib/components/util/dropdown.tsx
@@ -8,7 +8,6 @@ import React, {
 import styled from 'styled-components'
 
 interface Props extends HTMLAttributes<HTMLElement> {
-  children: React.ReactNode
   label?: string
   listLabel?: string
   name: JSX.Element
@@ -37,7 +36,6 @@ const DropdownMenu = styled.ul`
   border: 1px solid rgba(0, 0, 0, 0.15);
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
   color: #111;
-  float: left;
   list-style: none;
   margin: 2px 0 0;
   min-width: 160px;
@@ -52,11 +50,15 @@ const DropdownMenu = styled.ul`
     padding: 0;
   }
   a,
-  button {
-    cursor: pointer;
+  button,
+  li.header {
     padding: 5px 15px;
     text-align: start;
     width: 100%;
+  }
+  a,
+  button {
+    cursor: pointer;
   }
   li.header {
     cursor: default;
@@ -83,33 +85,24 @@ const Dropdown = ({
   style
 }: Props): JSX.Element => {
   const [open, setOpen] = useState(false)
-  const containerRef = useRef(null)
+  const containerRef = useRef<HTMLLIElement>(null)
 
   const toggleOpen = () => setOpen(!open)
 
   // Adding document event listeners allows us to close the dropdown
   // when the user interacts with any part of the page that isn't the dropdown
   useEffect(() => {
-    // TODO: TYPE
-    const handleExternalAction = (
-      e: MouseEvent | FocusEvent | KeyboardEvent
-    ) => {
-      if (
-        !!containerRef.current &&
-        // @ts-expect-error Typescript doesn't like this check
-        !(containerRef?.current).contains(e.target)
-      ) {
+    const handleExternalAction = (e: Event): void => {
+      if (!containerRef?.current?.contains(e.target as HTMLElement)) {
         setOpen(false)
       }
     }
     document.addEventListener('mousedown', handleExternalAction)
-    document.addEventListener('focus', handleExternalAction)
-    // @ts-expect-error not sure what type is expected here
+    document.addEventListener('focusin', handleExternalAction)
     document.addEventListener('keydown', handleExternalAction)
     return () => {
       document.removeEventListener('mousedown', handleExternalAction)
-      document.removeEventListener('focus', handleExternalAction)
-      // @ts-expect-error not sure what type is expected here
+      document.removeEventListener('focusin', handleExternalAction)
       document.removeEventListener('keydown', handleExternalAction)
     }
   }, [containerRef])
@@ -150,7 +143,7 @@ const Dropdown = ({
     offset: 1 | -1
   ): HTMLElement {
     const entries = Array.from(
-      document.querySelectorAll(`#${id} li, #${id}-label`)
+      document.querySelectorAll(`#${id} button, #${id}-label`)
     )
     const elementIndex = entries.indexOf(element as HTMLElement)
 

--- a/lib/components/util/dropdown.tsx
+++ b/lib/components/util/dropdown.tsx
@@ -113,7 +113,7 @@ const Dropdown = ({
     }
   }, [containerRef])
 
-  const _handleKeyDown = (e: any): void => {
+  const _handleKeyDown = (e: KeyboardEvent): void => {
     const element = e.target as HTMLElement
     switch (e.key) {
       case 'ArrowUp':
@@ -183,6 +183,7 @@ const Dropdown = ({
           aria-label={listLabel}
           aria-labelledby={listLabel ? '' : `${id}-label`}
           id={id}
+          onClick={toggleOpen}
           role="list"
           tabIndex={-1}
         >


### PR DESCRIPTION
This PR fixes broken menu behavior for the language selector and the user account menu:
- the dropdown menu is now dismissed when selecting a language,
- the dropdown menu is now hidden when the keyboard focus reaches another element not in the menu.
- the logout command works again.

The PR also cleans up code and types and moves event handling from `<li>`s to `<button>`s.
