### PR TITLE
Trip adv settings a11y

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -476,7 +476,7 @@ components:
     howToReceiveAlerts: >
       To receive alerts for your saved trips, enable notifications
       in your account settings, and try saving a trip again.
-    monitorThisTrip: Monitor this trip {minutes} before it begins until it ends.
+    monitorThisTrip: "Monitor this trip prior to departure:"
     notificationsTurnedOff: Notifications are turned off for your account.
     # Note to translator: The notifyViaChannelWhen message, combined with
     # altRouteRecommended, delaysAboveTHreshold, realtimeAlertFlagged,
@@ -484,6 +484,7 @@ components:
     notifyViaChannelWhen: "Notify me via {channel} when:"
     oneHour: 1 hour
     realtimeAlertFlagged: There is a realtime alert flagged on my journey
+    timeBefore: "{time} before"
     toggleAdvancedSettings: Toggle advanced settings
   TripStatus:
     alerts: "{alerts, plural, one {# alert!} other {# alerts!}}"

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -476,7 +476,7 @@ components:
     howToReceiveAlerts: >
       To receive alerts for your saved trips, enable notifications
       in your account settings, and try saving a trip again.
-    monitorThisTrip: "Monitor this trip prior to departure:"
+    monitorThisTrip: "Monitor this trip before it begins:"
     notificationsTurnedOff: Notifications are turned off for your account.
     # Note to translator: The notifyViaChannelWhen message, combined with
     # altRouteRecommended, delaysAboveTHreshold, realtimeAlertFlagged,

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -476,14 +476,13 @@ components:
       vous annulez, les changements seront perdus.
   TripNotificationsPane:
     advancedSettings: Paramètres avancés
-    altRouteRecommended: Un autre trajet ou une autre correspondance est conseillé·e
+    altRouteRecommended: Un·e autre trajet ou correspondance est conseillé·e
     delaysAboveThreshold: Il y a des perturbations ou retards de plus de
     howToReceiveAlerts: >
       Pour recevoir les alertes pour vos trajets suivis, activez les notifications
       dans la section Préférences de votre compte, et essayez d'enregistrer un trajet
       à nouveau.
-    monitorThisTrip: Effectuer le suivi du trajet {minutes} avant le départ et jusqu'à
-      l'arrivée.
+    monitorThisTrip: "Faire le suivi du trajet avant le départ :"
     notificationsTurnedOff: Les notifications sont désactivées pour votre compte.
     # Note to translator: The notifyViaChannelWhen message, combined with
     # altRouteRecommended, delaysAboveTHreshold, realtimeAlertFlagged,
@@ -491,6 +490,7 @@ components:
     notifyViaChannelWhen: "Recevoir des notifications par {channel} lorsque :"
     oneHour: 1 heure
     realtimeAlertFlagged: Une alerte en temps réel affecte mon trajet
+    timeBefore: "{time} avant"
     toggleAdvancedSettings: Paramètres avancés
   TripStatus:
     alerts: "{alerts, plural, =0 {# alerte !} one {# alerte !} other {# alertes !}}"

--- a/lib/components/user/monitored-trip/trip-notifications-pane.js
+++ b/lib/components/user/monitored-trip/trip-notifications-pane.js
@@ -1,14 +1,12 @@
 /* eslint-disable react/prop-types */
 import { Alert, FormControl } from 'react-bootstrap'
-import { CaretDown } from '@styled-icons/fa-solid/CaretDown'
-import { CaretRight } from '@styled-icons/fa-solid/CaretRight'
 import { ExclamationTriangle } from '@styled-icons/fa-solid/ExclamationTriangle'
 import { Field } from 'formik'
-import { FormattedMessage, injectIntl, useIntl } from 'react-intl'
+import { FormattedMessage, useIntl } from 'react-intl'
 import React, { Component } from 'react'
 import styled from 'styled-components'
 
-import { IconWithText, StyledIconWrapper } from '../../util/styledIcon'
+import { IconWithText } from '../../util/styledIcon'
 
 // Element styles
 const SettingsList = styled.ul`
@@ -22,6 +20,13 @@ const SettingsList = styled.ul`
   & > li {
     align-items: center;
     display: block;
+  }
+`
+
+const Summary = styled.summary`
+  display: revert;
+  & > h4 {
+    display: inline;
   }
 `
 
@@ -43,12 +48,6 @@ const InlineFormControl = styled(FormControl)`
   display: inline-block;
   margin: 0 0.5em;
   width: auto;
-`
-
-const SettingsToggle = styled.button`
-  background: none;
-  border: none;
-  padding: 0;
 `
 
 /**
@@ -133,14 +132,6 @@ function DurationOptions({ defaultValue, minuteOptions }) {
  * This component wraps the elements to edit trip notification settings.
  */
 class TripNotificationsPane extends Component {
-  state = {
-    showAdvancedSettings: false
-  }
-
-  _handleToggleAdvancedSettings = () => {
-    this.setState({ showAdvancedSettings: !this.state.showAdvancedSettings })
-  }
-
   _handleDelayThresholdChange = (e) => {
     // To spare users the complexity of the departure/arrival delay thresholds,
     // set both the arrival and departure variance delays to the selected value.
@@ -151,7 +142,7 @@ class TripNotificationsPane extends Component {
   }
 
   render() {
-    const { intl, notificationChannel, values } = this.props
+    const { notificationChannel, values } = this.props
     const areNotificationsDisabled = notificationChannel === 'none'
     // Define a common trip delay field for simplicity, set to the smallest between the
     // retrieved departure/arrival delay attributes.
@@ -177,7 +168,6 @@ class TripNotificationsPane extends Component {
         </Alert>
       )
     } else {
-      const { showAdvancedSettings } = this.state
       notificationSettingsContent = (
         <>
           <h4>
@@ -235,45 +225,33 @@ class TripNotificationsPane extends Component {
             </li>
           </SettingsListWithAlign>
 
-          <h4>
-            <SettingsToggle
-              aria-expanded={showAdvancedSettings}
-              aria-label={intl.formatMessage({
-                id: 'components.TripNotificationsPane.toggleAdvancedSettings'
-              })}
-              onClick={this._handleToggleAdvancedSettings}
-              type="button"
-            >
-              <StyledIconWrapper>
-                {showAdvancedSettings ? <CaretDown /> : <CaretRight />}
-              </StyledIconWrapper>
-              <FormattedMessage id="components.TripNotificationsPane.advancedSettings" />
-            </SettingsToggle>
-          </h4>
-          {showAdvancedSettings && (
-            <SettingsList>
-              <li>
-                <label htmlFor="leadTimeInMinutes">
-                  <FormattedMessage
-                    id="components.TripNotificationsPane.monitorThisTrip"
-                    values={{
-                      minutes: (
-                        <Select
-                          Control={InlineFormControl}
-                          name="leadTimeInMinutes"
-                        >
-                          <DurationOptions
-                            defaultValue={30}
-                            minuteOptions={[15, 30, 45, 60]}
-                          />
-                        </Select>
-                      )
-                    }}
-                  />
-                </label>
-              </li>
+          <details>
+            <Summary>
+              <h4>
+                <FormattedMessage id="components.TripNotificationsPane.advancedSettings" />
+              </h4>
+            </Summary>
+            <SettingsList as="p">
+              <label htmlFor="leadTimeInMinutes">
+                <FormattedMessage
+                  id="components.TripNotificationsPane.monitorThisTrip"
+                  values={{
+                    minutes: (
+                      <Select
+                        Control={InlineFormControl}
+                        name="leadTimeInMinutes"
+                      >
+                        <DurationOptions
+                          defaultValue={30}
+                          minuteOptions={[15, 30, 45, 60]}
+                        />
+                      </Select>
+                    )
+                  }}
+                />
+              </label>
             </SettingsList>
-          )}
+          </details>
         </>
       )
     }
@@ -282,4 +260,4 @@ class TripNotificationsPane extends Component {
   }
 }
 
-export default injectIntl(TripNotificationsPane)
+export default TripNotificationsPane

--- a/lib/components/user/monitored-trip/trip-notifications-pane.js
+++ b/lib/components/user/monitored-trip/trip-notifications-pane.js
@@ -55,12 +55,6 @@ const SettingsListWithAlign = styled(SettingsList)`
   }
 `
 
-const InlineFormControl = styled(FormControl)`
-  display: inline-block;
-  margin: 0 0.5em;
-  width: auto;
-`
-
 /**
  * A label followed by a dropdown control.
  */
@@ -120,10 +114,10 @@ function YesNoOptions({ defaultValue }) {
 /**
  * Produces a list of duration options with the specified default value.
  */
-function DurationOptions({ defaultValue, minuteOptions }) {
+function DurationOptions({ decoratorFunc, defaultValue, minuteOptions }) {
   // <FormattedMessage> can't be used inside <option>.
   const intl = useIntl()
-  const options = minuteOptions.map((minutes) => ({
+  const localizedMinutes = minuteOptions.map((minutes) => ({
     text:
       minutes === 60
         ? intl.formatMessage(
@@ -136,6 +130,12 @@ function DurationOptions({ defaultValue, minuteOptions }) {
           ),
     value: minutes
   }))
+  const options = decoratorFunc
+    ? localizedMinutes.map(({ text, value }) => ({
+        text: decoratorFunc(text, intl),
+        value
+      }))
+    : localizedMinutes
   return <Options defaultValue={defaultValue} options={options} />
 }
 
@@ -240,26 +240,27 @@ class TripNotificationsPane extends Component {
             <Summary>
               <FormattedMessage id="components.TripNotificationsPane.advancedSettings" />
             </Summary>
-            <SettingsList as="p">
-              <label htmlFor="leadTimeInMinutes">
-                <FormattedMessage
-                  id="components.TripNotificationsPane.monitorThisTrip"
-                  values={{
-                    minutes: (
-                      <Select
-                        Control={InlineFormControl}
-                        name="leadTimeInMinutes"
-                      >
-                        <DurationOptions
-                          defaultValue={30}
-                          minuteOptions={[15, 30, 45, 60]}
-                        />
-                      </Select>
-                    )
-                  }}
-                />
-              </label>
-            </SettingsList>
+            <SettingsListWithAlign>
+              <li>
+                <Select
+                  label={
+                    <FormattedMessage id="components.TripNotificationsPane.monitorThisTrip" />
+                  }
+                  name="leadTimeInMinutes"
+                >
+                  <DurationOptions
+                    decoratorFunc={(time, intl) => {
+                      return intl.formatMessage(
+                        { id: 'components.TripNotificationsPane.timeBefore' },
+                        { time }
+                      )
+                    }}
+                    defaultValue={30}
+                    minuteOptions={[15, 30, 45, 60]}
+                  />
+                </Select>
+              </li>
+            </SettingsListWithAlign>
           </details>
         </NotificationSettings>
       )

--- a/lib/components/user/monitored-trip/trip-notifications-pane.js
+++ b/lib/components/user/monitored-trip/trip-notifications-pane.js
@@ -16,10 +16,16 @@ const SettingsList = styled.ul`
   width: 100%;
   label {
     font-weight: inherit;
+    padding-right: 10px;
   }
+  /* Use table display for this element, so that all dropdowns occupy the same width.
+    (Bootstrap already sets them to occupy 100% of the width of the parent, i.e. the logical cell.) */
   & > li {
     align-items: center;
-    display: block;
+    display: table-row;
+    & > * {
+      display: table-cell;
+    }
   }
 `
 
@@ -38,20 +44,6 @@ const NotificationSettings = styled.fieldset`
     font-size: inherit;
     font-weight: 700;
     margin-bottom: 5px;
-  }
-`
-
-// Using table display for this element, so that all dropdowns occupy the same width.
-// (Bootstrap already sets them to occupy 100% of the width of the parent, i.e. the logical cell.)
-const SettingsListWithAlign = styled(SettingsList)`
-  & > li {
-    display: table-row;
-    & > * {
-      display: table-cell;
-    }
-    & > label {
-      padding-right: 10px;
-    }
   }
 `
 
@@ -199,7 +191,7 @@ class TripNotificationsPane extends Component {
               }
             />
           </legend>
-          <SettingsListWithAlign>
+          <SettingsList>
             <li>
               <Select
                 label={
@@ -234,13 +226,13 @@ class TripNotificationsPane extends Component {
                 <DurationOptions defaultValue={5} minuteOptions={[5, 10, 15]} />
               </FormControl>
             </li>
-          </SettingsListWithAlign>
+          </SettingsList>
 
           <details>
             <Summary>
               <FormattedMessage id="components.TripNotificationsPane.advancedSettings" />
             </Summary>
-            <SettingsListWithAlign>
+            <SettingsList>
               <li>
                 <Select
                   label={
@@ -260,7 +252,7 @@ class TripNotificationsPane extends Component {
                   />
                 </Select>
               </li>
-            </SettingsListWithAlign>
+            </SettingsList>
           </details>
         </NotificationSettings>
       )

--- a/lib/components/user/monitored-trip/trip-notifications-pane.js
+++ b/lib/components/user/monitored-trip/trip-notifications-pane.js
@@ -24,9 +24,20 @@ const SettingsList = styled.ul`
 `
 
 const Summary = styled.summary`
+  /* Revert display:block set by Bootstrap */
   display: revert;
-  & > h4 {
-    display: inline;
+  /* Format summary as labels */
+  font-weight: 700;
+  margin-bottom: 5px;
+`
+
+const NotificationSettings = styled.fieldset`
+  /* Format <legend> like labels. */
+  legend {
+    border: none;
+    font-size: inherit;
+    font-weight: 700;
+    margin-bottom: 5px;
   }
 `
 
@@ -169,8 +180,8 @@ class TripNotificationsPane extends Component {
       )
     } else {
       notificationSettingsContent = (
-        <>
-          <h4>
+        <NotificationSettings>
+          <legend>
             <FormattedMessage
               id="components.TripNotificationsPane.notifyViaChannelWhen"
               values={
@@ -187,7 +198,7 @@ class TripNotificationsPane extends Component {
                     }
               }
             />
-          </h4>
+          </legend>
           <SettingsListWithAlign>
             <li>
               <Select
@@ -227,9 +238,7 @@ class TripNotificationsPane extends Component {
 
           <details>
             <Summary>
-              <h4>
-                <FormattedMessage id="components.TripNotificationsPane.advancedSettings" />
-              </h4>
+              <FormattedMessage id="components.TripNotificationsPane.advancedSettings" />
             </Summary>
             <SettingsList as="p">
               <label htmlFor="leadTimeInMinutes">
@@ -252,7 +261,7 @@ class TripNotificationsPane extends Component {
               </label>
             </SettingsList>
           </details>
-        </>
+        </NotificationSettings>
       )
     }
 

--- a/lib/components/user/monitored-trip/trip-notifications-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-notifications-pane.tsx
@@ -29,8 +29,8 @@ const SettingsList = styled.ul`
 `
 
 const Summary = styled.summary`
-  /* Revert display:block set by Bootstrap */
-  display: revert;
+  /* Revert display:block set by Bootstrap that hides the native expand/collapse caret. */
+  display: revert-layer;
   /* Format summary as labels */
   font-weight: 700;
   margin-bottom: 5px;


### PR DESCRIPTION
This PR contains accessibility improvements to the advanced trip settings pane.
The main change is around the trip monitoring start setting which I simplified the labeling, so we don't end up with nested labels as was the case before.