### PR TITLE
Feb 23 Percy Test Repair

### DIFF
--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -279,7 +279,7 @@ class DefaultMap extends Component {
     const baseLayerNames = baseLayersWithNames?.map((bl) => bl.name)
 
     return (
-      <MapContainer>
+      <MapContainer className="percy-hide">
         <BaseMap
           baseLayer={
             baseLayerUrls?.length > 1 ? baseLayerUrls : baseLayerUrls?.[0]

--- a/percy/percy.test.js
+++ b/percy/percy.test.js
@@ -11,7 +11,7 @@ const OTP_RR_TEST_JS_CONFIG_PATH = OTP_RR_PERCY_CALL_TAKER
   ? './percy/har-mock-config-call-taker.js'
   : './percy/har-mock-config.js'
 
-const MOCK_SERVER_PORT = 5000
+const MOCK_SERVER_PORT = 5486
 
 // Puppeteer can take a long time to load, especially in some ci environments
 jest.setTimeout(600000)
@@ -307,6 +307,7 @@ test('OTP-RR', async () => {
     await page.waitForTimeout(200)
 
     await page.click('#plan-trip')
+    await page.waitForTimeout(1000) // wait extra time for all results to load
   } else {
     // take initial screenshot
     await page.waitForTimeout(1000) // wait extra time for all results to load


### PR DESCRIPTION
This PR resolves a few of the Percy test issues we've been having.

Map is hidden to avoid unnecessary changes being flagged, port is changed for MacOS Ventura support, and extra timeouts should mean fewer failures