### PR TITLE
Fix transit overlay highlight color

### DIFF
--- a/lib/components/map/connected-transit-vehicle-overlay.js
+++ b/lib/components/map/connected-transit-vehicle-overlay.js
@@ -124,7 +124,10 @@ const mapStateToProps = (state) => {
   if (viewedRoute?.routeId) {
     vehicleList = route?.vehicles?.map((vehicle) => {
       vehicle.routeType = route?.mode
-      vehicle.routeColor = route?.color ? '#' + route.color : null
+      vehicle.routeColor =
+        route.color && !route.color.includes('#')
+          ? '#' + route.color
+          : route?.color || '#5A5A5A'
       // Try to populate this attribute, which is required for the vehicle popup to appear.
       vehicle.routeShortName = vehicle.routeShortName || route?.shortName
       vehicle.textColor = route?.routeTextColor

--- a/lib/components/map/connected-transit-vehicle-overlay.js
+++ b/lib/components/map/connected-transit-vehicle-overlay.js
@@ -124,7 +124,7 @@ const mapStateToProps = (state) => {
   if (viewedRoute?.routeId) {
     vehicleList = route?.vehicles?.map((vehicle) => {
       vehicle.routeType = route?.mode
-      vehicle.routeColor = route?.color
+      vehicle.routeColor = route?.color ? '#' + route.color : null
       // Try to populate this attribute, which is required for the vehicle popup to appear.
       vehicle.routeShortName = vehicle.routeShortName || route?.shortName
       vehicle.textColor = route?.routeTextColor


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
When hovered over, transit overlay vehicles show up as a low-contrast white color on a light grey background. This PR unblocks `otp-ui` route color highlight functionality w/ contrast. 

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/62163307/222178302-39a54a92-0dfe-411e-80cb-4af58321368b.png) | ![image](https://user-images.githubusercontent.com/62163307/222177732-6f742e43-35cd-4645-857f-6b2eaac0ac3f.png) |

