### PR TITLE
Remove caret if bearing is null

### DIFF
--- a/lib/components/map/connected-transit-vehicle-overlay.js
+++ b/lib/components/map/connected-transit-vehicle-overlay.js
@@ -102,15 +102,28 @@ function VehicleTooltip(props) {
   )
 }
 
-// Round vehicle symbol with arrow/caret on the border,
-// and showing the route color with a transparent effect on hover.
-const IconContainer = withRouteColorBackground(
-  withCaret(Circle, { height: 5, offset: 1.5, width: 10 }),
-  {
+/**
+ *
+ * @param {Object} props vehicle object (includes heading)
+ * @returns circlular mode icon overlay that includes a caret only if bearing is not null
+ */
+const IconContainer = (props) => {
+  const { vehicle } = props
+  const caretHeight = vehicle?.heading === null ? -1 : 5
+
+  const OverlayIcon = withCaret(Circle, {
+    height: caretHeight,
+    offset: 1.5,
+    width: 10
+  })
+
+  const IconWithBackground = withRouteColorBackground(OverlayIcon, {
     alphaHex: 'aa',
     display: 'onhover'
-  }
-)
+  })
+
+  return <IconWithBackground {...props} />
+}
 
 // connect to the redux store
 

--- a/lib/components/map/connected-transit-vehicle-overlay.js
+++ b/lib/components/map/connected-transit-vehicle-overlay.js
@@ -105,7 +105,7 @@ function VehicleTooltip(props) {
 /**
  *
  * @param {Object} props vehicle object (includes heading)
- * @returns circlular mode icon overlay that includes a caret only if bearing is not null
+ * @returns circular mode icon overlay that includes a caret only if bearing is not null
  */
 const IconContainer = (props) => {
   const { vehicle } = props


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Some feeds do not include vehicle bearing, making transit overlay carets default to pointing upwards. This PR removes the caret if vehicle.heading is null. Let me know if you think there's a better way to go about this; I had to break up the original function a bit. The `waterloo` instance is a good example of a feed without bearings (shown below).

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
| ![Pasted Graphic 63](https://user-images.githubusercontent.com/62163307/222554533-45c59805-70bd-472d-996a-639669b863d4.png) | ![Pasted Graphic 60](https://user-images.githubusercontent.com/62163307/222554453-e3bb0673-4d85-4f2e-bf08-a2e35d163923.png) |

