### PR TITLE
style: adjust color contrast for a11y

### DIFF
--- a/lib/components/form/form.css
+++ b/lib/components/form/form.css
@@ -319,6 +319,11 @@
   background-color: #f0f0f0;
 }
 
+.otp .user-settings .manage-link {
+  color: #2c6ba1;
+  font-weight: 600;
+}
+
 .otp .place-button {
   padding: 5px 0 0 0;
   text-align: left;

--- a/lib/components/form/user-settings.js
+++ b/lib/components/form/user-settings.js
@@ -225,9 +225,11 @@ class UserSettings extends Component {
                 id="components.UserSettings.mySavedPlaces"
                 values={{
                   manageLink: (linkText) => (
-                    <LinkWithQuery to="/account/settings">
-                      {linkText}
-                    </LinkWithQuery>
+                    <span className="manage-link">
+                      <LinkWithQuery to="/account/settings">
+                        {linkText}
+                      </LinkWithQuery>
+                    </span>
                   )
                 }}
               />

--- a/lib/components/user/phone-number-editor.tsx
+++ b/lib/components/user/phone-number-editor.tsx
@@ -256,7 +256,7 @@ class PhoneNumberEditor extends Component<Props, State> {
                     <FormattedMessage id="components.PhoneNumberEditor.pending" />
                   </BsLabel>
                 ) : (
-                  <BsLabel bsStyle="success">
+                  <BsLabel style={{ background: 'green' }}>
                     <FormattedMessage id="components.PhoneNumberEditor.verified" />
                   </BsLabel>
                 )}

--- a/lib/components/viewers/trip-viewer.js
+++ b/lib/components/viewers/trip-viewer.js
@@ -151,7 +151,8 @@ class TripViewer extends Component {
                   )}
                   <SpanWithSpace margin={0.25} />
                   {tripData.bikesAllowed === 1 && (
-                    <BsLabel bsStyle="success">
+                    // Bootstrap's default green ('success') does not pass a11y contrast checks
+                    <BsLabel style={{ background: 'green' }}>
                       <IconWithText Icon={Bicycle}>
                         <FormattedMessage id="components.TripViewer.bicyclesAllowed" />
                       </IconWithText>


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
Changes a11y color contrast on following elements:
- "Bikes allowed" span on Trip Viewer
- "Manage" places link in user settings

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/115499534/223187747-47c51aea-9813-473f-8ae3-bad097c7b9d7.png) | ![image](https://user-images.githubusercontent.com/115499534/223187949-f4b26be1-1094-4f0f-9852-4a274e34eeec.png)| 
| ![image](https://user-images.githubusercontent.com/115499534/223188837-fbfedd00-446e-44ff-a95a-cabae13b93a2.png)| ![image](https://user-images.githubusercontent.com/115499534/223188989-6d443dbb-91f4-4898-a9b6-f37f969a4c87.png) | 

