### PR TITLE
Basic a11y Support for Trip Settings 

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -148,6 +148,7 @@ components:
     header: Plan Your Trip
   BatchSettings:
     destination: destination
+    modeSelector: Mode Selector
     origin: origin
     planTripTooltip: Plan trip
     settings: Trip Settings

--- a/lib/components/form/batch-settings.tsx
+++ b/lib/components/form/batch-settings.tsx
@@ -195,12 +195,10 @@ class BatchSettings extends Component<Props, State> {
             aria-controls="date-time-modal"
             aria-expanded={expanded === 'DATE_TIME'}
             aria-label="Date/Time settings"
+            expanded={expanded === 'DATE_TIME'}
             onClick={this._toggleDateTime}
           >
-            <StyledDateTimePreview
-              expanded={expanded === 'DATE_TIME'}
-              hideButton
-            />
+            <StyledDateTimePreview hideButton />
           </StyledDateTimePreviewContainer>
           {expanded === 'DATE_TIME' && (
             <DateTimeModalContainer id="date-time-modal">

--- a/lib/components/form/batch-settings.tsx
+++ b/lib/components/form/batch-settings.tsx
@@ -21,15 +21,13 @@ import {
   MainSettingsRow,
   PlanTripButton,
   SettingsPreview,
-  StyledDateTimePreview
+  StyledDateTimePreview,
+  StyledDateTimePreviewContainer
 } from './batch-styled'
 import { Dot } from './styled'
 import BatchPreferences, { replaceTransitMode } from './batch-preferences'
 import DateTimeModal from './date-time-modal'
-import ModeButtons, {
-  defaultModeOptions,
-  StyledModeButton
-} from './mode-buttons'
+import ModeButtons, { defaultModeOptions } from './mode-buttons'
 import type { Combination } from './batch-preferences'
 import type { Mode } from './mode-buttons'
 
@@ -37,6 +35,15 @@ const ModeButtonsFullWidthContainer = styled.div`
   display: flex;
   justify-content: space-between;
   margin-bottom: 5px;
+  margin-top: 0px;
+
+  /* <legend> is not shown visually. */
+  & > legend {
+    clip: rect(0, 0, 0, 0);
+    height: 0;
+    overflow: hidden;
+    width: 0;
+  }
 `
 
 // Define Mode Button styled components here to avoid circular imports. I.e., we
@@ -49,22 +56,6 @@ const ModeButtonsFullWidth = styled(ModeButtons)`
   }
 `
 
-const ModeButtonsContainerCompressed = styled.div`
-  display: contents;
-`
-
-const ModeButtonsCompressed = styled(ModeButtons)`
-  ${StyledModeButton} {
-    border-radius: 0px;
-  }
-  &:first-child {
-    border-radius: 5px 0px 0px 5px;
-  }
-  &:last-child {
-    margin-right: 5px;
-    border-radius: 0px 5px 5px 0px;
-  }
-`
 // TYPESCRIPT TODO: better types
 type Props = {
   activeSearch: any
@@ -161,17 +152,26 @@ class BatchSettings extends Component<Props, State> {
     const { activeSearch, config, currentQuery, intl, modeOptions } = this.props
     const { expanded, selectedModes } = this.state
     return (
-      <>
-        <ModeButtonsFullWidthContainer className="hidden-lg">
-          <ModeButtonsFullWidth
-            className="flex"
-            modeOptions={modeOptions}
-            onClick={this._onClickMode}
-            selectedModes={selectedModes}
-          />
-        </ModeButtonsFullWidthContainer>
+      <div role="group">
+        <fieldset>
+          <ModeButtonsFullWidthContainer>
+            <legend>
+              {intl.formatMessage({
+                id: 'components.BatchSettings.modeSelector'
+              })}
+            </legend>
+            <ModeButtonsFullWidth
+              className="flex"
+              modeOptions={modeOptions}
+              onClick={this._onClickMode}
+              selectedModes={selectedModes}
+            />
+          </ModeButtonsFullWidthContainer>
+        </fieldset>
         <MainSettingsRow>
           <SettingsPreview
+            aria-controls="batch-preferences"
+            aria-expanded={expanded === 'SETTINGS'}
             aria-label={intl.formatMessage({
               id: 'components.BatchSettings.settings'
             })}
@@ -185,20 +185,29 @@ class BatchSettings extends Component<Props, State> {
               <Cog />
             </StyledIconWrapper>
           </SettingsPreview>
-          <StyledDateTimePreview
-            // as='button'
-            expanded={expanded === 'DATE_TIME'}
-            hideButton
+          {expanded === 'SETTINGS' && (
+            <BatchPreferencesContainer id="batch-preferences">
+              <BatchPreferences />
+            </BatchPreferencesContainer>
+          )}
+
+          <StyledDateTimePreviewContainer
+            aria-controls="date-time-modal"
+            aria-expanded={expanded === 'DATE_TIME'}
+            aria-label="Date/Time settings"
             onClick={this._toggleDateTime}
-          />
-          <ModeButtonsContainerCompressed>
-            <ModeButtonsCompressed
-              className="visible-lg straight-corners"
-              modeOptions={modeOptions}
-              onClick={this._onClickMode}
-              selectedModes={selectedModes}
+          >
+            <StyledDateTimePreview
+              expanded={expanded === 'DATE_TIME'}
+              hideButton
             />
-          </ModeButtonsContainerCompressed>
+          </StyledDateTimePreviewContainer>
+          {expanded === 'DATE_TIME' && (
+            <DateTimeModalContainer id="date-time-modal">
+              <DateTimeModal />
+            </DateTimeModalContainer>
+          )}
+
           <PlanTripButton
             id="plan-trip"
             onClick={this._planTrip}
@@ -217,17 +226,7 @@ class BatchSettings extends Component<Props, State> {
             </StyledIconWrapper>
           </PlanTripButton>
         </MainSettingsRow>
-        {expanded === 'DATE_TIME' && (
-          <DateTimeModalContainer>
-            <DateTimeModal />
-          </DateTimeModalContainer>
-        )}
-        {expanded === 'SETTINGS' && (
-          <BatchPreferencesContainer>
-            <BatchPreferences />
-          </BatchPreferencesContainer>
-        )}
-      </>
+      </div>
     )
   }
 }

--- a/lib/components/form/batch-styled.ts
+++ b/lib/components/form/batch-styled.ts
@@ -32,23 +32,20 @@ export const Button = styled.button`
 export const StyledDateTimePreviewContainer = styled(Button)<{
   expanded?: boolean
 }>`
+  ${buttonCss}
   margin-right: 5px;
-  position: relative;
   padding: 0;
+  position: relative;
+  width: 120px;
   ${(props) => (props.expanded ? activeCss : null)}
 `
 
 export const StyledDateTimePreview = styled(DateTimePreview)`
-  ${buttonCss}
-  background-color: rgb(239, 239, 239);
-  cursor: pointer;
   font-size: 12px;
   margin-right: 5px;
-  padding: 7px 5px;
+  padding: 4px 5px;
   text-align: left;
   white-space: nowrap;
-  width: 120px;
-  ${(props) => (props.expanded ? activeCss : null)}
 `
 export const SettingsPreview = styled(Button)<{ expanded?: boolean }>`
   margin-right: 5px;

--- a/lib/components/form/batch-styled.ts
+++ b/lib/components/form/batch-styled.ts
@@ -12,7 +12,6 @@ const activeCss = css`
   -webkit-box-shadow: ${SHADOW};
   -moz-box-shadow: ${SHADOW};
   box-shadow: ${SHADOW};
-  outline: none;
 `
 
 export const buttonCss = css`

--- a/lib/components/form/batch-styled.ts
+++ b/lib/components/form/batch-styled.ts
@@ -30,6 +30,15 @@ export const Button = styled.button`
   ${buttonCss}
 `
 
+export const StyledDateTimePreviewContainer = styled(Button)<{
+  expanded?: boolean
+}>`
+  margin-right: 5px;
+  position: relative;
+  padding: 0;
+  ${(props) => (props.expanded ? activeCss : null)}
+`
+
 export const StyledDateTimePreview = styled(DateTimePreview)`
   ${buttonCss}
   background-color: rgb(239, 239, 239);
@@ -77,11 +86,13 @@ const expandableBoxCss = css`
 
 export const DateTimeModalContainer = styled.div`
   ${expandableBoxCss}
+  margin-top: 50px;
   padding: 10px 20px;
 `
 
 export const BatchPreferencesContainer = styled.div`
   ${expandableBoxCss}
+  margin-top: 50px;
   padding: 5px 10px;
 `
 

--- a/lib/components/form/mode-buttons.tsx
+++ b/lib/components/form/mode-buttons.tsx
@@ -50,6 +50,7 @@ const ModeButton = ({
     <OverlayTrigger overlay={overlayTooltip} placement="bottom">
       <button
         aria-label={label || getFormattedMode(mode, intl)}
+        aria-pressed={selected}
         className={className}
         onClick={() => onClick(mode)}
       >

--- a/percy/percy.test.js
+++ b/percy/percy.test.js
@@ -273,12 +273,12 @@ test('OTP-RR', async () => {
 
   if (!OTP_RR_PERCY_CALL_TAKER) {
     // Change the modes
-    await page.click('.visible-lg.straight-corners:first-of-type')
+    await page.click('button[aria-label="Transit"]')
     await page.click('#plan-trip')
 
     await percySnapshotWithWait(page, 'Metro Itinerary No Transit')
     // Restore transit
-    await page.click('.visible-lg.straight-corners:first-of-type')
+    await page.click('button[aria-label="Transit"]')
 
     // Change the time
     await page.click('.summary')


### PR DESCRIPTION

<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
Basic a11y support for trip settings form including current mode selector plus "gear" and date/time dropdown containers (actual dropdown content will be in otp-ui)

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

