### PR TITLE
Add a11y Label to LegIcon

### DIFF
--- a/lib/components/narrative/line-itin/LegIconWithA11y.tsx
+++ b/lib/components/narrative/line-itin/LegIconWithA11y.tsx
@@ -1,0 +1,28 @@
+import { getFormattedMode } from '../../../util/i18n'
+import coreUtils from '@opentripplanner/core-utils'
+import InvisibleA11yLabel from '../../util/invisible-a11y-label'
+
+import React, { useContext } from 'react'
+
+import { ComponentContext } from '../../../util/contexts'
+
+import { useIntl } from 'react-intl'
+
+const { isTransit } = coreUtils.itinerary
+
+const LegIconWithA11y = (props: any) => {
+  // @ts-expect-error No type on ComponentContext
+  const { LegIcon } = useContext(ComponentContext)
+  const intl = useIntl()
+  const { leg } = props
+  const { mode } = leg
+  const ariaLabel = isTransit(mode) ? getFormattedMode(mode, intl) : null
+  return (
+    <>
+      <LegIcon {...props} />
+      {ariaLabel && <InvisibleA11yLabel>{ariaLabel}</InvisibleA11yLabel>}
+    </>
+  )
+}
+
+export default LegIconWithA11y

--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 // TODO: Typescript (otp-rr config object)
 import { connect } from 'react-redux'
+import { isTransit } from '@opentripplanner/core-utils/lib/itinerary'
 import {
   LegDescriptionHeadsignPrefix,
   PlaceName as PlaceNameWrapper,
@@ -23,9 +24,12 @@ import {
   getFirstLegStartTime,
   getLastLegEndTime
 } from '../../../util/itinerary'
+import { getFormattedMode } from '../../../util/i18n'
+import { injectIntl } from 'react-intl'
 import { MainPanelContent } from '../../../actions/ui-constants'
 import { setLegDiagram, setMapillaryId } from '../../../actions/map'
 import { setMainPanelContent, setViewedTrip } from '../../../actions/ui'
+import InvisibleA11yLabel from '../../util/invisible-a11y-label'
 import TripDetails from '../connected-trip-details'
 import TripTools from '../trip-tools'
 
@@ -73,6 +77,7 @@ class ConnectedItineraryBody extends Component {
       activeItineraryTimeIndex,
       config,
       diagramVisible,
+      intl,
       itinerary,
       RouteDescriptionOverride,
       setActiveLeg,
@@ -126,6 +131,18 @@ class ConnectedItineraryBody extends Component {
       }
     }
 
+    const LegIconWithA11y = (props) => {
+      const { leg } = props
+      const { mode } = leg
+      const ariaLabel = isTransit(mode) ? getFormattedMode(mode, intl) : null
+      return (
+        <>
+          <LegIcon {...props} />
+          {ariaLabel && <InvisibleA11yLabel>{ariaLabel}</InvisibleA11yLabel>}
+        </>
+      )
+    }
+
     return (
       <ItineraryBodyContainer>
         <StyledItineraryBody
@@ -134,7 +151,7 @@ class ConnectedItineraryBody extends Component {
           diagramVisible={diagramVisible}
           itinerary={clonedItinerary}
           key={activeItineraryTimeIndex}
-          LegIcon={LegIcon}
+          LegIcon={LegIconWithA11y}
           LineColumnContent={LineColumnContent}
           mapillaryCallback={setMapillaryId}
           mapillaryKey={config?.mapillary?.key}
@@ -186,4 +203,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(ConnectedItineraryBody)
+)(injectIntl(ConnectedItineraryBody))

--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 // TODO: Typescript (otp-rr config object)
 import { connect } from 'react-redux'
-import { isTransit } from '@opentripplanner/core-utils/lib/itinerary'
 import {
   LegDescriptionHeadsignPrefix,
   PlaceName as PlaceNameWrapper,
@@ -24,15 +23,14 @@ import {
   getFirstLegStartTime,
   getLastLegEndTime
 } from '../../../util/itinerary'
-import { getFormattedMode } from '../../../util/i18n'
 import { injectIntl } from 'react-intl'
 import { MainPanelContent } from '../../../actions/ui-constants'
 import { setLegDiagram, setMapillaryId } from '../../../actions/map'
 import { setMainPanelContent, setViewedTrip } from '../../../actions/ui'
-import InvisibleA11yLabel from '../../util/invisible-a11y-label'
 import TripDetails from '../connected-trip-details'
 import TripTools from '../trip-tools'
 
+import LegIconWithA11y from './LegIconWithA11y'
 import RealtimeTimeColumn from './realtime-time-column'
 import TransitLegSubheader from './connected-transit-leg-subheader'
 
@@ -77,7 +75,6 @@ class ConnectedItineraryBody extends Component {
       activeItineraryTimeIndex,
       config,
       diagramVisible,
-      intl,
       itinerary,
       RouteDescriptionOverride,
       setActiveLeg,
@@ -86,7 +83,6 @@ class ConnectedItineraryBody extends Component {
       setMapillaryId,
       setViewedTrip
     } = this.props
-    const { LegIcon } = this.context
     const clonedItinerary = clone(itinerary)
 
     // Support OTP1 flex messages in Trip Details
@@ -129,18 +125,6 @@ class ConnectedItineraryBody extends Component {
           daysPrior: 0
         }
       }
-    }
-
-    const LegIconWithA11y = (props) => {
-      const { leg } = props
-      const { mode } = leg
-      const ariaLabel = isTransit(mode) ? getFormattedMode(mode, intl) : null
-      return (
-        <>
-          <LegIcon {...props} />
-          {ariaLabel && <InvisibleA11yLabel>{ariaLabel}</InvisibleA11yLabel>}
-        </>
-      )
     }
 
     return (

--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -23,7 +23,6 @@ import {
   getFirstLegStartTime,
   getLastLegEndTime
 } from '../../../util/itinerary'
-import { injectIntl } from 'react-intl'
 import { MainPanelContent } from '../../../actions/ui-constants'
 import { setLegDiagram, setMapillaryId } from '../../../actions/map'
 import { setMainPanelContent, setViewedTrip } from '../../../actions/ui'
@@ -187,4 +186,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(injectIntl(ConnectedItineraryBody))
+)(ConnectedItineraryBody)


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Adds an invisible label to `LegIcon` which identifies the represented mode for screen readers.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/115499534/225417967-3e88c340-9d16-4b59-a122-26556c07a347.png) | ![image](https://user-images.githubusercontent.com/115499534/225417657-b36ee150-8c97-46fa-a829-f3a744f62e46.png)|

