### PR TITLE
Fix: Dismissed App Menu does not re-open 

### DIFF
--- a/lib/components/app/app-menu.tsx
+++ b/lib/components/app/app-menu.tsx
@@ -216,7 +216,7 @@ class AppMenu extends Component<
           from="left"
           hideHeader
           isOpen={isPaneOpen}
-          onRequestClose={this._togglePane}
+          onRequestClose={() => this.setState({ isPaneOpen: false })}
           shouldCloseOnEsc
           width="320px"
         >


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Fixes a small bug where `AppMenu` could be opened and closed by clicking anywhere on the page if you clicked before `react-sliding-pane`'s transition ended.

To reproduce bug:
- Open app menu
- Click outside app menu to dismiss menu
- Immediately click again (within 500ms)
- App menu should re-open


https://user-images.githubusercontent.com/115499534/225717982-37e06c76-d499-4129-b2ce-ec4067bef522.mov



<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?