### PR TITLE
Route View to Pattern View Button

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -382,6 +382,8 @@ components:
     shortTitle: View Routes
     stopsInDirectionOfTravel: "Stops in this direction of travel:"
     title: Route Viewer
+    toggleRouteOnMap: Toggle route on map
+    openPatternViewer: Go to route pattern viewer
   SavedTripEditor:
     editSavedTrip: Edit saved trip
     saveNewTrip: Save new trip

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -238,13 +238,13 @@ export class RouteRow extends PureComponent {
                   getModeFromRoute(route).toLowerCase(),
                   intl
                 )}
-                height={22}
+                height={28}
                 leg={{
                   routeLongName: route?.longName,
                   routeShortName: route?.shortName
                 }}
                 mode={getModeFromRoute(route)}
-                width={22}
+                width={28}
               />
             </ModeIconElement>
           )}

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -52,8 +52,9 @@ export const OperatorImg = styled.img`
 `
 
 export const ModeIconElement = styled.span`
+  height: 28px;
   padding-left: inherit;
-  padding-top: 3px;
+  width: 28px;
 `
 
 const RouteNameElement = styled.span`

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -3,9 +3,9 @@
 import { ArrowRight } from '@styled-icons/fa-solid'
 import { Button } from 'react-bootstrap'
 
+import { Icon } from '../util/styledIcon'
 import React, { PureComponent } from 'react'
 import styled from 'styled-components'
-import { Icon } from '../util/styledIcon'
 
 import { ComponentContext } from '../../util/contexts'
 import {

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -33,7 +33,7 @@ export const RouteRowButton = styled(Button)`
   left: 0;
   position: absolute;
   top: 0;
-  transition: all ease-out 0.17s;
+  transition: all ease-out 0.1s;
   width: 100%;
 
   &:before {
@@ -55,7 +55,7 @@ export const RouteRowButton = styled(Button)`
   &:active:before,
   &.btn-default:active:focus:before {
     background-color: #eee;
-    transition: all ease-out 0.17s;
+    transition: all ease-out 0.1s;
   }
 `
 
@@ -111,12 +111,12 @@ const PatternButton = styled.button`
   border: none;
   border-radius: 50%;
   color: #004f96;
-  opacity: ${(props) => (props.display ? 100 : 0)};
   height: 40px;
   margin-right: 8px;
-  position: relative;
-  transition: all ease-out 0.17s;
   min-width: 40px;
+  opacity: ${(props) => (props.display ? 100 : 0)};
+  position: relative;
+  transition: all ease-out 0.1s;
   z-index: ${(props) => (props.display ? 2 : -2)};
 
   svg {
@@ -125,9 +125,14 @@ const PatternButton = styled.button`
     width: 22px !important;
   }
 
+  :active {
+    opacity: 80%;
+    transition: all ease-out 0.1s;
+  }
+
   &:hover {
     background: #eee;
-    transition: all ease-out 0.17s;
+    transition: all ease-out 0.1s;
   }
 `
 

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -1,7 +1,9 @@
 // TODO: Typescript, which doesn't make sense to do in this file until common types are established
 /* eslint-disable react/prop-types */
+import { ArrowRight } from '@styled-icons/fa-solid'
 import { Button } from 'react-bootstrap'
-import AnimateHeight from 'react-animate-height'
+
+import { Icon } from '../util/styledIcon'
 import React, { PureComponent } from 'react'
 import styled from 'styled-components'
 
@@ -14,20 +16,31 @@ import { getFormattedMode } from '../../util/i18n'
 import DefaultRouteRenderer from '../narrative/metro/default-route-renderer'
 import OperatorLogo from '../util/operator-logo'
 
-import RouteDetails from './route-details'
-
 export const StyledRouteRow = styled.li`
-  background-color: white;
-  margin: 10px 0;
-  list-style: none;
-`
-
-export const RouteRowButton = styled(Button)`
   align-items: center;
+  background-color: white;
   display: flex;
-  padding: 6px;
+  gap: 7px;
+  justify-content: space-between;
+  list-style: none;
+  margin: 5px 0;
+  padding: 5px;
+  position: relative;
+`
+// Route Row Button sits invisble on top of the route name and info.
+export const RouteRowButton = styled(Button)`
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
   transition: all ease-in-out 0.1s;
   width: 100%;
+
+  &:active,
+  &.btn-default:active:focus {
+    background-color: rgba(212, 212, 212, 0.2);
+    transition: all ease-in-out 0.1s;
+  }
 `
 
 export const RouteRowElement = styled.span`
@@ -39,8 +52,6 @@ export const OperatorImg = styled.img`
 `
 
 export const ModeIconElement = styled.span`
-  height: 28px;
-  width: 28px;
   padding-left: inherit;
   padding-top: 3px;
 `
@@ -51,6 +62,12 @@ const RouteNameElement = styled.span`
   font-weight: 400;
   margin-left: 8px;
 `
+const RouteDetailsContainer = styled.div`
+  align-items: center;
+  display: grid;
+  grid-template-columns: repeat(4, auto);
+  justify-items: center;
+`
 const RouteLongNameElement = styled.span`
   font-size: 16px;
   font-weight: 500;
@@ -60,12 +77,28 @@ const RouteLongNameElement = styled.span`
     of the route long name.
   */
   margin: 2px 0 0 15px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  width: 100%;
 `
 
 const SimpleRouteRenderer = styled.span`
   font-size: 18px;
   margin: 0;
   padding: 0;
+`
+
+const PatternButton = styled.button`
+  background: transparent;
+  border: none;
+  color: #004f96;
+  opacity: ${(props) => (props.display ? 100 : 0)};
+  height: 40px;
+  position: relative;
+  transition: all ease-in-out 0.3s;
+  width: 40px;
+  z-index: ${(props) => (props.display ? 2 : -2)};
 `
 
 export const RouteName = ({ basicRender, route, RouteRenderer }) => {
@@ -98,7 +131,6 @@ export class RouteRow extends PureComponent {
     super(props)
     // Create a ref used to scroll to
     this.activeRef = React.createRef()
-    this.state = { newHeight: 0 }
   }
 
   componentDidMount = () => {
@@ -138,26 +170,29 @@ export class RouteRow extends PureComponent {
     }
   }
 
-  // Used to ensure details are visible until animation completes
-  setNewHeight = (newHeight) => {
-    this.setState({ newHeight })
+  _headSignButtonClicked = (e) => {
+    const { route, setViewedRoute } = this.props
+    const { id, patterns } = route
+    const firstPattern = Object.values(patterns)[0]?.id
+    setViewedRoute({ patternId: firstPattern, routeId: id })
   }
 
   render() {
     const { intl, isActive, operator, route } = this.props
-    const { newHeight } = this.state
     const { ModeIcon, RouteRenderer } = this.context
+
+    const patternViewerButtonText = intl.formatMessage({
+      description: 'identifies the purpose of the pattern viewer button',
+      id: 'components.RouteViewer.openPatternViewer'
+    })
+    const routeMapToggleText = intl.formatMessage({
+      description: 'identifies the behavior of the route viewer button',
+      id: 'components.RouteViewer.toggleRouteOnMap'
+    })
 
     return (
       <StyledRouteRow isActive={isActive} ref={this.activeRef}>
-        <RouteRowButton
-          className="clear-button-formatting"
-          isActive={isActive}
-          onClick={this._onClick}
-          onFocus={this._onFocusOrEnter}
-          onMouseEnter={this._onFocusOrEnter}
-          onTouchStart={this._onFocusOrEnter}
-        >
+        <RouteDetailsContainer>
           <RouteRowElement>
             <OperatorLogo operator={operator} />
           </RouteRowElement>
@@ -179,16 +214,27 @@ export class RouteRow extends PureComponent {
             </ModeIconElement>
           )}
           <RouteName route={route} RouteRenderer={RouteRenderer} />
-        </RouteRowButton>
-        <AnimateHeight
-          duration={500}
-          height={isActive ? 'auto' : 0}
-          onHeightAnimationEnd={this.setNewHeight}
+        </RouteDetailsContainer>
+        <RouteRowButton
+          aria-label={routeMapToggleText}
+          className="clear-button-formatting"
+          isActive={isActive}
+          onClick={this._onClick}
+          onFocus={this._onFocusOrEnter}
+          onMouseEnter={this._onFocusOrEnter}
+          onTouchStart={this._onFocusOrEnter}
+          title={routeMapToggleText}
+        />
+        <PatternButton
+          aria-label={patternViewerButtonText}
+          display={isActive}
+          onClick={this._headSignButtonClicked}
+          // Cannot keyboard navigate to the button unless it is visible
+          tabIndex={isActive ? 0 : -1}
+          title={patternViewerButtonText}
         >
-          {(newHeight > 0 || isActive) && (
-            <RouteDetails operator={operator} route={route} />
-          )}
-        </AnimateHeight>
+          <Icon Icon={ArrowRight} />
+        </PatternButton>
       </StyledRouteRow>
     )
   }

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -241,7 +241,7 @@ export class RouteRow extends PureComponent {
         <PatternButton
           aria-label={patternViewerButtonText}
           display={isActive}
-          id="pattern-button"
+          id={`pattern-button-${route.shortName || route.longName}`}
           onClick={this._patternButtonClicked}
           // Cannot keyboard navigate to the button unless it is visible
           tabIndex={isActive ? 0 : -1}

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -92,13 +92,23 @@ const SimpleRouteRenderer = styled.span`
 const PatternButton = styled.button`
   background: transparent;
   border: none;
+  border-radius: 50%;
   color: #004f96;
   opacity: ${(props) => (props.display ? 100 : 0)};
   height: 40px;
   position: relative;
-  transition: all ease-in-out 0.3s;
+  transition: all ease-in-out 0.2s;
   width: 40px;
   z-index: ${(props) => (props.display ? 2 : -2)};
+
+  svg {
+    margin-top: -3px;
+  }
+
+  &:hover {
+    background: #eee;
+    transition: all ease-in-out 0.3s;
+  }
 `
 
 export const RouteName = ({ basicRender, route, RouteRenderer }) => {
@@ -170,7 +180,7 @@ export class RouteRow extends PureComponent {
     }
   }
 
-  _headSignButtonClicked = (e) => {
+  _patternButtonClicked = () => {
     const { route, setViewedRoute } = this.props
     const { id, patterns } = route
     const firstPattern = Object.values(patterns)[0]?.id
@@ -228,7 +238,7 @@ export class RouteRow extends PureComponent {
         <PatternButton
           aria-label={patternViewerButtonText}
           display={isActive}
-          onClick={this._headSignButtonClicked}
+          onClick={this._patternButtonClicked}
           // Cannot keyboard navigate to the button unless it is visible
           tabIndex={isActive ? 0 : -1}
           title={patternViewerButtonText}

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -3,9 +3,9 @@
 import { ArrowRight } from '@styled-icons/fa-solid'
 import { Button } from 'react-bootstrap'
 
-import { Icon } from '../util/styledIcon'
 import React, { PureComponent } from 'react'
 import styled from 'styled-components'
+import { Icon } from '../util/styledIcon'
 
 import { ComponentContext } from '../../util/contexts'
 import {
@@ -38,8 +38,7 @@ export const RouteRowButton = styled(Button)`
 
   &:active,
   &.btn-default:active:focus {
-    background-color: rgba(212, 212, 212, 0.2);
-    transition: all ease-in-out 0.1s;
+    background-color: transparent;
   }
 `
 
@@ -242,6 +241,7 @@ export class RouteRow extends PureComponent {
         <PatternButton
           aria-label={patternViewerButtonText}
           display={isActive}
+          id="pattern-button"
           onClick={this._patternButtonClicked}
           // Cannot keyboard navigate to the button unless it is visible
           tabIndex={isActive ? 0 : -1}

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -33,7 +33,7 @@ export const RouteRowButton = styled(Button)`
   left: 0;
   position: absolute;
   top: 0;
-  transition: all ease-in-out 0.1s;
+  transition: all ease-out 0.17s;
   width: 100%;
 
   &:before {
@@ -55,7 +55,7 @@ export const RouteRowButton = styled(Button)`
   &:active:before,
   &.btn-default:active:focus:before {
     background-color: #eee;
-    transition: all ease-in-out 0.1s;
+    transition: all ease-out 0.17s;
   }
 `
 
@@ -115,8 +115,8 @@ const PatternButton = styled.button`
   height: 40px;
   margin-right: 8px;
   position: relative;
-  transition: all ease-in-out 0.2s;
-  width: 40px;
+  transition: all ease-out 0.17s;
+  min-width: 40px;
   z-index: ${(props) => (props.display ? 2 : -2)};
 
   svg {
@@ -127,7 +127,7 @@ const PatternButton = styled.button`
 
   &:hover {
     background: #eee;
-    transition: all ease-in-out 0.3s;
+    transition: all ease-out 0.17s;
   }
 `
 

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -114,7 +114,7 @@ const PatternButton = styled.button`
   height: 40px;
   margin-right: 8px;
   min-width: 40px;
-  opacity: ${(props) => (props.display ? 100 : 0)};
+  opacity: ${(props) => (props.display ? '80%' : 0)};
   position: relative;
   transition: all ease-out 0.1s;
   z-index: ${(props) => (props.display ? 2 : -2)};
@@ -126,7 +126,7 @@ const PatternButton = styled.button`
   }
 
   :active {
-    opacity: 80%;
+    opacity: 100%;
     transition: all ease-out 0.1s;
   }
 

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -27,7 +27,7 @@ export const StyledRouteRow = styled.li`
   padding: 5px;
   position: relative;
 `
-// Route Row Button sits invisble on top of the route name and info.
+// Route Row Button sits invisible on top of the route name and info.
 export const RouteRowButton = styled(Button)`
   height: 100%;
   left: 0;
@@ -96,6 +96,7 @@ const PatternButton = styled.button`
   color: #004f96;
   opacity: ${(props) => (props.display ? 100 : 0)};
   height: 40px;
+  margin-right: 8px;
   position: relative;
   transition: all ease-in-out 0.2s;
   width: 40px;
@@ -103,6 +104,8 @@ const PatternButton = styled.button`
 
   svg {
     margin-top: -3px;
+    height: 22px !important;
+    width: 22px !important;
   }
 
   &:hover {

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -18,7 +18,7 @@ import OperatorLogo from '../util/operator-logo'
 
 export const StyledRouteRow = styled.li`
   align-items: center;
-  background-color: white;
+  background-color: transparent;
   display: flex;
   gap: 7px;
   justify-content: space-between;
@@ -36,9 +36,26 @@ export const RouteRowButton = styled(Button)`
   transition: all ease-in-out 0.1s;
   width: 100%;
 
+  &:before {
+    background-color: white;
+    border-radius: 4px;
+    content: '';
+    height: 100%;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: -4;
+  }
+
   &:active,
   &.btn-default:active:focus {
-    background-color: transparent;
+    background-color: transparent !important;
+  }
+
+  &:active:before,
+  &.btn-default:active:focus:before {
+    background-color: #eee;
+    transition: all ease-in-out 0.1s;
   }
 `
 
@@ -186,7 +203,7 @@ export class RouteRow extends PureComponent {
   _patternButtonClicked = () => {
     const { route, setViewedRoute } = this.props
     const { id, patterns } = route
-    const firstPattern = route && patterns && Object.values(patterns)[0]?.id
+    const firstPattern = route && patterns && Object.values(patterns)?.[0]?.id
     setViewedRoute({ patternId: firstPattern, routeId: id })
   }
 
@@ -241,7 +258,7 @@ export class RouteRow extends PureComponent {
         <PatternButton
           aria-label={patternViewerButtonText}
           display={isActive}
-          id={`pattern-button-${route.shortName || route.longName}`}
+          id={`open-route-button-${route.shortName || route.longName}`}
           onClick={this._patternButtonClicked}
           // Cannot keyboard navigate to the button unless it is visible
           tabIndex={isActive ? 0 : -1}

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -186,7 +186,7 @@ export class RouteRow extends PureComponent {
   _patternButtonClicked = () => {
     const { route, setViewedRoute } = this.props
     const { id, patterns } = route
-    const firstPattern = Object.values(patterns)[0]?.id
+    const firstPattern = route && patterns && Object.values(patterns)[0]?.id
     setViewedRoute({ patternId: firstPattern, routeId: id })
   }
 

--- a/percy/percy.test.js
+++ b/percy/percy.test.js
@@ -388,7 +388,7 @@ test('OTP-RR', async () => {
   await page.waitForTimeout(500)
 
   // click the little pattern arrow
-  await page.click('open-route-button-1')
+  await page.click('#open-route-button-1')
 
   await page.waitForSelector('#headsign-selector')
 

--- a/percy/percy.test.js
+++ b/percy/percy.test.js
@@ -162,7 +162,7 @@ if (OTP_RR_PERCY_MOBILE) {
     await page.waitForTimeout(500)
 
     // click the little pattern arrow
-    await page.click('#pattern-button-Green')
+    await page.click('#open-route-button-Green')
 
     await page.waitForSelector('#headsign-selector')
     const secondPatternOption = await page.$$eval(
@@ -388,7 +388,7 @@ test('OTP-RR', async () => {
   await page.waitForTimeout(500)
 
   // click the little pattern arrow
-  await page.click('#pattern-button-1')
+  await page.click('open-route-button-1')
 
   await page.waitForSelector('#headsign-selector')
 

--- a/percy/percy.test.js
+++ b/percy/percy.test.js
@@ -158,6 +158,13 @@ if (OTP_RR_PERCY_MOBILE) {
     }
     const [subwayRouteButton] = await page.$x("//span[contains(., 'Green')]")
     await subwayRouteButton.click()
+
+    await page.waitForTimeout(500)
+
+    // click the little pattern arrow
+    await page.keyboard.press('Tab')
+    await page.keyboard.press('Enter')
+
     await page.waitForSelector('#headsign-selector')
     const secondPatternOption = await page.$$eval(
       'option',
@@ -378,6 +385,13 @@ test('OTP-RR', async () => {
   }
   const [busRouteButton] = await page.$x("//span[contains(., 'Marietta Blvd')]")
   await busRouteButton.click()
+
+  await page.waitForTimeout(500)
+
+  // click the little pattern arrow
+  await page.keyboard.press('Tab')
+  await page.keyboard.press('Enter')
+
   await page.waitForSelector('#headsign-selector')
 
   await percySnapshotWithWait(page, 'Route Viewer Showing Route 1')

--- a/percy/percy.test.js
+++ b/percy/percy.test.js
@@ -162,8 +162,7 @@ if (OTP_RR_PERCY_MOBILE) {
     await page.waitForTimeout(500)
 
     // click the little pattern arrow
-    await page.keyboard.press('Tab')
-    await page.keyboard.press('Enter')
+    await page.click('#pattern-button-Green')
 
     await page.waitForSelector('#headsign-selector')
     const secondPatternOption = await page.$$eval(
@@ -389,8 +388,7 @@ test('OTP-RR', async () => {
   await page.waitForTimeout(500)
 
   // click the little pattern arrow
-  await page.keyboard.press('Tab')
-  await page.keyboard.press('Enter')
+  await page.click('#pattern-button-1')
 
   await page.waitForSelector('#headsign-selector')
 


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
This PR removes the "route details" with headsign select from the active route in the route viewer. Instead, an active route will have an arrow button that brings the user directly to the pattern viewer.

The pattern view button will only show up when route is active for sighted users, similarly to how the route details were only displayed when the route was active. However, the button is available to all screen readers.

I'm worried the arrow button being displayed for active routes looks strange when you keyboard navigate further down the page. Maybe the button should disappear when the parent `li` element loses focus?

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
|<img width="489" alt="image" src="https://user-images.githubusercontent.com/115499534/226040385-ec37e71c-4209-45f4-b022-a86c6565f63c.png">|<img width="489" alt="image" src="https://user-images.githubusercontent.com/115499534/226040111-f84a87b9-6f7b-4826-98ae-1fc1ec3fd2a3.png">| -->

