### PR TITLE
refactor(itineraries): Spell CO₂ with the Unicode character.

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -426,8 +426,8 @@ itinerary:
 #     airplane: 0.382
 #     micromobility: 0
 #   massUnit: "ounce"
-#   showIfHigher: false // show the relative CO2 even if it's higher than driving
-#   cutoffPercentage: 33 // Only show the CO2 comparison if the % difference from driving is at least this much
+#   showIfHigher: false // show the relative CO₂ even if it's higher than driving
+#   cutoffPercentage: 33 // Only show the CO₂ comparison if the % difference from driving is at least this much
 
 ### Popup config
 ### OTP-RR supports a full-screen modal popup that can be launched from a set of

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -703,7 +703,7 @@ common:
       {isMore, select,
       true {more}
       other {less}
-      } CO<sub>2</sub> than driving alone
+      } CO₂ than driving alone
 
   # Note to translator: the strings below are used in sentences such as:
   # "No trip found for bike, walk, and transit."

--- a/i18n/es.yml
+++ b/i18n/es.yml
@@ -614,7 +614,7 @@ common:
     transfers: '{transfers, plural, =0 {} one {# transferencia} other {# transferencias}}'
     relativeCo2: >
       {co2}
-      de CO<sub>2</sub> en  {isMore, select,
+      de CO₂ en  {isMore, select,
       true {más}
       other {menos}
       } que conducir

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -687,7 +687,7 @@ common:
     transfers: "{transfers, plural, =0 {} one {# correspondance} other {# correspondances}}"
     relativeCo2: >
       {co2}
-      de CO<sub>2</sub> en  {isMore, select,
+      de CO₂ en  {isMore, select,
       true {plus}
       other {moins}
       } qu'en voiture

--- a/i18n/ko.yml
+++ b/i18n/ko.yml
@@ -545,7 +545,7 @@ common:
     noTransitFareProvided: 운임 정보가 없습니다
     relativeCo2: >
       {co2}
-      CO<sub>2</sub> 를 자동차보다
+      CO₂ 를 자동차보다
       {isMore, select,
       true {더}
       other {덜}

--- a/i18n/vi.yml
+++ b/i18n/vi.yml
@@ -554,7 +554,7 @@ common:
     noTransitFareProvided: Không có thông tin giá vé
     relativeCo2: >
       {co2}
-      CO<sub>2</sub> {isMore, select,
+      CO₂ {isMore, select,
       true {nhiều}
       other {ít}
       } hơn so với xe hơi

--- a/i18n/zh.yml
+++ b/i18n/zh.yml
@@ -537,7 +537,7 @@ common:
       {isMore, select,
       true {更多}
       other {更少}
-      } CO<sub>2</sub>  比单独驾车
+      } CO₂  比单独驾车
   time:
     departureArrivalTimes: '{startTime, time, short}—{endTime, time, short}'
     durationAgo: "{duration}前"

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -28,7 +28,6 @@ import FormattedDuration from '../../util/formatted-duration'
 import ItineraryBody from '../line-itin/connected-itinerary-body'
 import NarrativeItinerary from '../narrative-itinerary'
 import SimpleRealtimeAnnotation from '../simple-realtime-annotation'
-import Sub from '../../util/sub-text'
 
 import { FlexIndicator } from './flex-indicator'
 import { ItineraryDescription } from './itinerary-description'
@@ -184,8 +183,7 @@ const ITINERARY_ATTRIBUTES = [
                   value={Math.abs(co2VsBaselineRounded)}
                 />
               ),
-              isMore: co2VsBaselineRounded > 0,
-              sub: Sub
+              isMore: co2VsBaselineRounded > 0
             }}
           />
           <StyledIconWrapperTextAlign>

--- a/lib/components/narrative/metro/metro-itinerary.tsx
+++ b/lib/components/narrative/metro/metro-itinerary.tsx
@@ -27,7 +27,6 @@ import FormattedDuration from '../../util/formatted-duration'
 import ItineraryBody from '../line-itin/connected-itinerary-body'
 import NarrativeItinerary from '../narrative-itinerary'
 import SimpleRealtimeAnnotation from '../simple-realtime-annotation'
-import Sub from '../../util/sub-text'
 
 import { DepartureTimesList } from './departure-times-list'
 import {
@@ -302,8 +301,7 @@ class MetroItinerary extends NarrativeItinerary {
                   />
                 </LoadingBlurred>
               ),
-              isMore: roundedCo2VsBaseline > 0,
-              sub: Sub
+              isMore: roundedCo2VsBaseline > 0
             }}
           />
         </IconWithText>

--- a/lib/components/util/sub-text.js
+++ b/lib/components/util/sub-text.js
@@ -1,3 +1,0 @@
-import React from 'react'
-const Sub = (contents) => <sub>{contents}</sub>
-export default Sub


### PR DESCRIPTION
**Description:**

This PR changes the spelling of CO₂ to use the Unicode character instead of the HTML `<sub>` tags for the dioxide subscript. See for instance https://symbolsalad.com.

**PR Checklist:**
- [na] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [na] Are appropriate Typescript types implemented?

