### PR TITLE
Align agency icons in route viewer

### DIFF
--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -31,7 +31,9 @@ export const RouteRowButton = styled(Button)`
 `
 
 export const RouteRowElement = styled.span`
-  padding-right: 8px;
+  width: 50px;
+  display: flex;
+  justify-content: center;
 `
 export const OperatorImg = styled.img`
   height: 25px;

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -31,9 +31,7 @@ export const RouteRowButton = styled(Button)`
 `
 
 export const RouteRowElement = styled.span`
-  width: 50px;
-  display: flex;
-  justify-content: center;
+  padding-right: 8px;
 `
 export const OperatorImg = styled.img`
   height: 25px;
@@ -160,7 +158,7 @@ export class RouteRow extends PureComponent {
           onMouseEnter={this._onFocusOrEnter}
           onTouchStart={this._onFocusOrEnter}
         >
-          <RouteRowElement>
+          <RouteRowElement className="route-row-element">
             <OperatorLogo operator={operator} />
           </RouteRowElement>
           {route.mode && (


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Agency icons in route viewer have different widths with a fixed height. This route names to appear in a non-justified, clunky manner beside the icons. This PR sets a fixed, justified width to all icons for cleanliness.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

