### PR TITLE
Stop Viewer Departure Layout

### DIFF
--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -318,7 +318,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                 "nearbyRadius": 250,
                 "numberOfDepartures": 3,
                 "showBlockIds": false,
-                "timeRange": 345600,
+                "timeRange": 172800,
               }
             }
             toggleAutoRefresh={[Function]}
@@ -829,7 +829,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                   tabIndex={0}
                 >
                   <div
-                    className="sc-bQdRvg hGmYyp"
+                    className="sc-fXoxaI gHFXNE"
                     tabIndex={0}
                   >
                     <injectIntl(LiveStopTimes)
@@ -1009,7 +1009,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                           "nearbyRadius": 250,
                           "numberOfDepartures": 3,
                           "showBlockIds": false,
-                          "timeRange": 345600,
+                          "timeRange": 172800,
                         }
                       }
                       toggleAutoRefresh={[Function]}
@@ -1233,7 +1233,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                             "nearbyRadius": 250,
                             "numberOfDepartures": 3,
                             "showBlockIds": false,
-                            "timeRange": 345600,
+                            "timeRange": 172800,
                           }
                         }
                         toggleAutoRefresh={[Function]}
@@ -1249,7 +1249,6 @@ exports[`components > viewers > stop viewer should render countdown times after 
                         >
                           <injectIntl(PatternRow)
                             homeTimezone="America/Los_Angeles"
-                            key="TriMet:20-Gresham TC"
                             pattern={
                               Object {
                                 "desc": "20 to Gresham Transit Center (TriMet:8199) from Beaverton Transit Center (TriMet:9978) express",
@@ -1388,7 +1387,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                 "nearbyRadius": 250,
                                 "numberOfDepartures": 3,
                                 "showBlockIds": false,
-                                "timeRange": 345600,
+                                "timeRange": 172800,
                               }
                             }
                           >
@@ -1568,7 +1567,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                   "nearbyRadius": 250,
                                   "numberOfDepartures": 3,
                                   "showBlockIds": false,
-                                  "timeRange": 345600,
+                                  "timeRange": 172800,
                                 }
                               }
                             >
@@ -1576,7 +1575,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                 className="route-row"
                               >
                                 <div
-                                  className="header"
+                                  className="header stop-view"
                                   style={
                                     Object {
                                       "backgroundColor": "#333333",
@@ -1588,17 +1587,15 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                     className="route-name"
                                   >
                                     <strong
-                                      style={Object {}}
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "alignContent": "center",
-                                            "display": "flex",
-                                            "justifyContent": "center",
-                                            "whiteSpace": "nowrap",
-                                          }
+                                      style={
+                                        Object {
+                                          "fontSize": "32px",
                                         }
+                                      }
+                                    >
+                                      <span
+                                        className="route-name-container"
+                                        title="20"
                                       >
                                         <DefaultRouteRenderer
                                           leg={
@@ -1627,9 +1624,11 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                             </span>
                                           </styled.span>
                                         </DefaultRouteRenderer>
-                                      </div>
+                                      </span>
                                     </strong>
-                                    <span>
+                                    <span
+                                      title="Gresham TC"
+                                    >
                                       Gresham TC
                                     </span>
                                   </div>
@@ -1841,27 +1840,24 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="thursday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.thursday"
-                                              >
-                                                common.daysOfWeek.thursday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="wednesday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.wednesday"
+                                                  >
+                                                    common.daysOfWeek.wednesday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -1987,27 +1983,24 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="thursday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.thursday"
-                                              >
-                                                common.daysOfWeek.thursday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="wednesday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.wednesday"
+                                                  >
+                                                    common.daysOfWeek.wednesday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -2350,7 +2343,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                 "nearbyRadius": 250,
                                 "numberOfDepartures": 3,
                                 "showBlockIds": false,
-                                "timeRange": 345600,
+                                "timeRange": 172800,
                               }
                             }
                             transitOperators={Array []}
@@ -3196,7 +3189,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                 "nearbyRadius": 250,
                 "numberOfDepartures": 3,
                 "showBlockIds": false,
-                "timeRange": 345600,
+                "timeRange": 172800,
               }
             }
             toggleAutoRefresh={[Function]}
@@ -3707,7 +3700,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                   tabIndex={0}
                 >
                   <div
-                    className="sc-bQdRvg hGmYyp"
+                    className="sc-fXoxaI gHFXNE"
                     tabIndex={0}
                   >
                     <injectIntl(LiveStopTimes)
@@ -3788,7 +3781,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                           "nearbyRadius": 250,
                           "numberOfDepartures": 3,
                           "showBlockIds": false,
-                          "timeRange": 345600,
+                          "timeRange": 172800,
                         }
                       }
                       toggleAutoRefresh={[Function]}
@@ -3913,7 +3906,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                             "nearbyRadius": 250,
                             "numberOfDepartures": 3,
                             "showBlockIds": false,
-                            "timeRange": 345600,
+                            "timeRange": 172800,
                           }
                         }
                         toggleAutoRefresh={[Function]}
@@ -3927,9 +3920,22 @@ exports[`components > viewers > stop viewer should render countdown times for st
                         <ul
                           className="route-row-container"
                         >
+                          <p
+                            aria-hidden={true}
+                            className="day-label"
+                          >
+                            <FormattedDayOfWeek
+                              day="wednesday"
+                            >
+                              <FormattedMessage
+                                id="common.daysOfWeek.wednesday"
+                              >
+                                common.daysOfWeek.wednesday
+                              </FormattedMessage>
+                            </FormattedDayOfWeek>
+                          </p>
                           <injectIntl(PatternRow)
                             homeTimezone="America/Los_Angeles"
-                            key="TriMet:20-Gresham TC"
                             pattern={
                               Object {
                                 "desc": "20 to Gresham Transit Center (TriMet:8199) from Beaverton Transit Center (TriMet:9978) express",
@@ -3978,7 +3984,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                 "nearbyRadius": 250,
                                 "numberOfDepartures": 3,
                                 "showBlockIds": false,
-                                "timeRange": 345600,
+                                "timeRange": 172800,
                               }
                             }
                           >
@@ -4068,7 +4074,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                   "nearbyRadius": 250,
                                   "numberOfDepartures": 3,
                                   "showBlockIds": false,
-                                  "timeRange": 345600,
+                                  "timeRange": 172800,
                                 }
                               }
                             >
@@ -4076,7 +4082,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                 className="route-row"
                               >
                                 <div
-                                  className="header"
+                                  className="header stop-view"
                                   style={
                                     Object {
                                       "backgroundColor": "#333333",
@@ -4088,17 +4094,15 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                     className="route-name"
                                   >
                                     <strong
-                                      style={Object {}}
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "alignContent": "center",
-                                            "display": "flex",
-                                            "justifyContent": "center",
-                                            "whiteSpace": "nowrap",
-                                          }
+                                      style={
+                                        Object {
+                                          "fontSize": "32px",
                                         }
+                                      }
+                                    >
+                                      <span
+                                        className="route-name-container"
+                                        title="20"
                                       >
                                         <DefaultRouteRenderer
                                           leg={
@@ -4127,9 +4131,11 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                             </span>
                                           </styled.span>
                                         </DefaultRouteRenderer>
-                                      </div>
+                                      </span>
                                     </strong>
-                                    <span>
+                                    <span
+                                      title="Gresham TC"
+                                    >
                                       Gresham TC
                                     </span>
                                   </div>
@@ -4459,7 +4465,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                 "nearbyRadius": 250,
                                 "numberOfDepartures": 3,
                                 "showBlockIds": false,
-                                "timeRange": 345600,
+                                "timeRange": 172800,
                               }
                             }
                             transitOperators={Array []}
@@ -5107,7 +5113,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                 "nearbyRadius": 250,
                 "numberOfDepartures": 3,
                 "showBlockIds": false,
-                "timeRange": 345600,
+                "timeRange": 172800,
               }
             }
             toggleAutoRefresh={[Function]}
@@ -5618,7 +5624,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                   tabIndex={0}
                 >
                   <div
-                    className="sc-bQdRvg hGmYyp"
+                    className="sc-fXoxaI gHFXNE"
                     tabIndex={0}
                   >
                     <injectIntl(LiveStopTimes)
@@ -5798,7 +5804,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                           "nearbyRadius": 250,
                           "numberOfDepartures": 3,
                           "showBlockIds": false,
-                          "timeRange": 345600,
+                          "timeRange": 172800,
                         }
                       }
                       toggleAutoRefresh={[Function]}
@@ -6022,7 +6028,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                             "nearbyRadius": 250,
                             "numberOfDepartures": 3,
                             "showBlockIds": false,
-                            "timeRange": 345600,
+                            "timeRange": 172800,
                           }
                         }
                         toggleAutoRefresh={[Function]}
@@ -6036,9 +6042,22 @@ exports[`components > viewers > stop viewer should render times after midnight w
                         <ul
                           className="route-row-container"
                         >
+                          <p
+                            aria-hidden={true}
+                            className="day-label"
+                          >
+                            <FormattedDayOfWeek
+                              day="wednesday"
+                            >
+                              <FormattedMessage
+                                id="common.daysOfWeek.wednesday"
+                              >
+                                common.daysOfWeek.wednesday
+                              </FormattedMessage>
+                            </FormattedDayOfWeek>
+                          </p>
                           <injectIntl(PatternRow)
                             homeTimezone="America/Los_Angeles"
-                            key="TriMet:20-Gresham TC"
                             pattern={
                               Object {
                                 "desc": "20 to Gresham Transit Center (TriMet:8199) from Beaverton Transit Center (TriMet:9978) express",
@@ -6177,7 +6196,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                 "nearbyRadius": 250,
                                 "numberOfDepartures": 3,
                                 "showBlockIds": false,
-                                "timeRange": 345600,
+                                "timeRange": 172800,
                               }
                             }
                           >
@@ -6357,7 +6376,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                   "nearbyRadius": 250,
                                   "numberOfDepartures": 3,
                                   "showBlockIds": false,
-                                  "timeRange": 345600,
+                                  "timeRange": 172800,
                                 }
                               }
                             >
@@ -6365,7 +6384,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                 className="route-row"
                               >
                                 <div
-                                  className="header"
+                                  className="header stop-view"
                                   style={
                                     Object {
                                       "backgroundColor": "#333333",
@@ -6377,17 +6396,15 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                     className="route-name"
                                   >
                                     <strong
-                                      style={Object {}}
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "alignContent": "center",
-                                            "display": "flex",
-                                            "justifyContent": "center",
-                                            "whiteSpace": "nowrap",
-                                          }
+                                      style={
+                                        Object {
+                                          "fontSize": "32px",
                                         }
+                                      }
+                                    >
+                                      <span
+                                        className="route-name-container"
+                                        title="20"
                                       >
                                         <DefaultRouteRenderer
                                           leg={
@@ -6416,9 +6433,11 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                             </span>
                                           </styled.span>
                                         </DefaultRouteRenderer>
-                                      </div>
+                                      </span>
                                     </strong>
-                                    <span>
+                                    <span
+                                      title="Gresham TC"
+                                    >
                                       Gresham TC
                                     </span>
                                   </div>
@@ -6516,27 +6535,24 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="thursday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.thursday"
-                                              >
-                                                common.daysOfWeek.thursday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="wednesday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.wednesday"
+                                                  >
+                                                    common.daysOfWeek.wednesday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -6662,27 +6678,24 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="thursday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.thursday"
-                                              >
-                                                common.daysOfWeek.thursday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="wednesday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.wednesday"
+                                                  >
+                                                    common.daysOfWeek.wednesday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -6808,27 +6821,24 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="thursday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.thursday"
-                                              >
-                                                common.daysOfWeek.thursday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="wednesday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.wednesday"
+                                                  >
+                                                    common.daysOfWeek.wednesday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -7171,7 +7181,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                 "nearbyRadius": 250,
                                 "numberOfDepartures": 3,
                                 "showBlockIds": false,
-                                "timeRange": 345600,
+                                "timeRange": 172800,
                               }
                             }
                             transitOperators={Array []}
@@ -8374,7 +8384,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                 "nearbyRadius": 250,
                 "numberOfDepartures": 3,
                 "showBlockIds": false,
-                "timeRange": 345600,
+                "timeRange": 172800,
               }
             }
             toggleAutoRefresh={[Function]}
@@ -8885,7 +8895,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                   tabIndex={0}
                 >
                   <div
-                    className="sc-bQdRvg hGmYyp"
+                    className="sc-fXoxaI gHFXNE"
                     tabIndex={0}
                   >
                     <injectIntl(LiveStopTimes)
@@ -9323,7 +9333,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                           "nearbyRadius": 250,
                           "numberOfDepartures": 3,
                           "showBlockIds": false,
-                          "timeRange": 345600,
+                          "timeRange": 172800,
                         }
                       }
                       toggleAutoRefresh={[Function]}
@@ -9805,7 +9815,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                             "nearbyRadius": 250,
                             "numberOfDepartures": 3,
                             "showBlockIds": false,
-                            "timeRange": 345600,
+                            "timeRange": 172800,
                           }
                         }
                         toggleAutoRefresh={[Function]}
@@ -9819,9 +9829,22 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                         <ul
                           className="route-row-container"
                         >
+                          <p
+                            aria-hidden={true}
+                            className="day-label"
+                          >
+                            <FormattedDayOfWeek
+                              day="monday"
+                            >
+                              <FormattedMessage
+                                id="common.daysOfWeek.monday"
+                              >
+                                common.daysOfWeek.monday
+                              </FormattedMessage>
+                            </FormattedDayOfWeek>
+                          </p>
                           <injectIntl(PatternRow)
                             homeTimezone="America/Los_Angeles"
-                            key="TriMet:20-Gresham TC"
                             pattern={
                               Object {
                                 "desc": "20 to Gresham Transit Center (TriMet:8199) from Beaverton Transit Center (TriMet:9978) express",
@@ -9863,6 +9886,24 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                 },
                                 Object {
                                   "arrivalDelay": 0,
+                                  "blockId": "2046",
+                                  "departureDelay": 0,
+                                  "headsign": "Gresham TC",
+                                  "realtime": false,
+                                  "realtimeArrival": 65759,
+                                  "realtimeDeparture": 65759,
+                                  "realtimeState": "SCHEDULED",
+                                  "scheduledArrival": 65759,
+                                  "scheduledDeparture": 65759,
+                                  "serviceDay": 1564988400,
+                                  "stopCount": 132,
+                                  "stopId": "TriMet:715",
+                                  "stopIndex": 42,
+                                  "timepoint": false,
+                                  "tripId": "TriMet:9230359",
+                                },
+                                Object {
+                                  "arrivalDelay": 0,
                                   "blockId": "2047",
                                   "departureDelay": 0,
                                   "headsign": "Gresham TC",
@@ -9896,24 +9937,6 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   "stopIndex": 42,
                                   "timepoint": false,
                                   "tripId": "TriMet:9230361",
-                                },
-                                Object {
-                                  "arrivalDelay": 0,
-                                  "blockId": "2046",
-                                  "departureDelay": 0,
-                                  "headsign": "Gresham TC",
-                                  "realtime": false,
-                                  "realtimeArrival": 65759,
-                                  "realtimeDeparture": 65759,
-                                  "realtimeState": "SCHEDULED",
-                                  "scheduledArrival": 65759,
-                                  "scheduledDeparture": 65759,
-                                  "serviceDay": 1564988400,
-                                  "stopCount": 132,
-                                  "stopId": "TriMet:715",
-                                  "stopIndex": 42,
-                                  "timepoint": false,
-                                  "tripId": "TriMet:9230359",
                                 },
                                 Object {
                                   "arrivalDelay": 0,
@@ -9958,7 +9981,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                 "nearbyRadius": 250,
                                 "numberOfDepartures": 3,
                                 "showBlockIds": false,
-                                "timeRange": 345600,
+                                "timeRange": 172800,
                               }
                             }
                           >
@@ -10041,6 +10064,24 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   },
                                   Object {
                                     "arrivalDelay": 0,
+                                    "blockId": "2046",
+                                    "departureDelay": 0,
+                                    "headsign": "Gresham TC",
+                                    "realtime": false,
+                                    "realtimeArrival": 65759,
+                                    "realtimeDeparture": 65759,
+                                    "realtimeState": "SCHEDULED",
+                                    "scheduledArrival": 65759,
+                                    "scheduledDeparture": 65759,
+                                    "serviceDay": 1564988400,
+                                    "stopCount": 132,
+                                    "stopId": "TriMet:715",
+                                    "stopIndex": 42,
+                                    "timepoint": false,
+                                    "tripId": "TriMet:9230359",
+                                  },
+                                  Object {
+                                    "arrivalDelay": 0,
                                     "blockId": "2047",
                                     "departureDelay": 0,
                                     "headsign": "Gresham TC",
@@ -10074,24 +10115,6 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     "stopIndex": 42,
                                     "timepoint": false,
                                     "tripId": "TriMet:9230361",
-                                  },
-                                  Object {
-                                    "arrivalDelay": 0,
-                                    "blockId": "2046",
-                                    "departureDelay": 0,
-                                    "headsign": "Gresham TC",
-                                    "realtime": false,
-                                    "realtimeArrival": 65759,
-                                    "realtimeDeparture": 65759,
-                                    "realtimeState": "SCHEDULED",
-                                    "scheduledArrival": 65759,
-                                    "scheduledDeparture": 65759,
-                                    "serviceDay": 1564988400,
-                                    "stopCount": 132,
-                                    "stopId": "TriMet:715",
-                                    "stopIndex": 42,
-                                    "timepoint": false,
-                                    "tripId": "TriMet:9230359",
                                   },
                                   Object {
                                     "arrivalDelay": 0,
@@ -10136,7 +10159,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   "nearbyRadius": 250,
                                   "numberOfDepartures": 3,
                                   "showBlockIds": false,
-                                  "timeRange": 345600,
+                                  "timeRange": 172800,
                                 }
                               }
                             >
@@ -10144,7 +10167,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                 className="route-row"
                               >
                                 <div
-                                  className="header"
+                                  className="header stop-view"
                                   style={
                                     Object {
                                       "backgroundColor": "#333333",
@@ -10156,17 +10179,15 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     className="route-name"
                                   >
                                     <strong
-                                      style={Object {}}
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "alignContent": "center",
-                                            "display": "flex",
-                                            "justifyContent": "center",
-                                            "whiteSpace": "nowrap",
-                                          }
+                                      style={
+                                        Object {
+                                          "fontSize": "32px",
                                         }
+                                      }
+                                    >
+                                      <span
+                                        className="route-name-container"
+                                        title="20"
                                       >
                                         <DefaultRouteRenderer
                                           leg={
@@ -10195,9 +10216,11 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                             </span>
                                           </styled.span>
                                         </DefaultRouteRenderer>
-                                      </div>
+                                      </span>
                                     </strong>
-                                    <span>
+                                    <span
+                                      title="Gresham TC"
+                                    >
                                       Gresham TC
                                     </span>
                                   </div>
@@ -10295,27 +10318,24 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="monday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.monday"
-                                              >
-                                                common.daysOfWeek.monday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="monday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.monday"
+                                                  >
+                                                    common.daysOfWeek.monday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -10441,27 +10461,24 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="monday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.monday"
-                                              >
-                                                common.daysOfWeek.monday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="monday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.monday"
+                                                  >
+                                                    common.daysOfWeek.monday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -10587,27 +10604,24 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="monday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.monday"
-                                              >
-                                                common.daysOfWeek.monday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="monday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.monday"
+                                                  >
+                                                    common.daysOfWeek.monday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -10647,9 +10661,22 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                               </li>
                             </PatternRow>
                           </injectIntl(PatternRow)>
+                          <p
+                            aria-hidden={true}
+                            className="day-label"
+                          >
+                            <FormattedDayOfWeek
+                              day="tuesday"
+                            >
+                              <FormattedMessage
+                                id="common.daysOfWeek.tuesday"
+                              >
+                                common.daysOfWeek.tuesday
+                              </FormattedMessage>
+                            </FormattedDayOfWeek>
+                          </p>
                           <injectIntl(PatternRow)
                             homeTimezone="America/Los_Angeles"
-                            key="TriMet:94-Sherwood"
                             pattern={
                               Object {
                                 "desc": "94 to SW Railroad & Washington (TriMet:3670) from W Burnside & SW 8th (TriMet:715)",
@@ -10709,24 +10736,6 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                 },
                                 Object {
                                   "arrivalDelay": 0,
-                                  "blockId": "9474",
-                                  "departureDelay": 0,
-                                  "headsign": "Sherwood",
-                                  "realtime": false,
-                                  "realtimeArrival": 56880,
-                                  "realtimeDeparture": 56880,
-                                  "realtimeState": "SCHEDULED",
-                                  "scheduledArrival": 56880,
-                                  "scheduledDeparture": 56880,
-                                  "serviceDay": 1565074800,
-                                  "stopCount": 40,
-                                  "stopId": "TriMet:715",
-                                  "stopIndex": 0,
-                                  "timepoint": true,
-                                  "tripId": "TriMet:9238194",
-                                },
-                                Object {
-                                  "arrivalDelay": 0,
                                   "blockId": "9470",
                                   "departureDelay": 0,
                                   "headsign": "Sherwood",
@@ -10742,6 +10751,24 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   "stopIndex": 0,
                                   "timepoint": true,
                                   "tripId": "TriMet:9238190",
+                                },
+                                Object {
+                                  "arrivalDelay": 0,
+                                  "blockId": "9474",
+                                  "departureDelay": 0,
+                                  "headsign": "Sherwood",
+                                  "realtime": false,
+                                  "realtimeArrival": 56880,
+                                  "realtimeDeparture": 56880,
+                                  "realtimeState": "SCHEDULED",
+                                  "scheduledArrival": 56880,
+                                  "scheduledDeparture": 56880,
+                                  "serviceDay": 1565074800,
+                                  "stopCount": 40,
+                                  "stopId": "TriMet:715",
+                                  "stopIndex": 0,
+                                  "timepoint": true,
+                                  "tripId": "TriMet:9238194",
                                 },
                                 Object {
                                   "arrivalDelay": 0,
@@ -10786,7 +10813,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                 "nearbyRadius": 250,
                                 "numberOfDepartures": 3,
                                 "showBlockIds": false,
-                                "timeRange": 345600,
+                                "timeRange": 172800,
                               }
                             }
                           >
@@ -10887,24 +10914,6 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   },
                                   Object {
                                     "arrivalDelay": 0,
-                                    "blockId": "9474",
-                                    "departureDelay": 0,
-                                    "headsign": "Sherwood",
-                                    "realtime": false,
-                                    "realtimeArrival": 56880,
-                                    "realtimeDeparture": 56880,
-                                    "realtimeState": "SCHEDULED",
-                                    "scheduledArrival": 56880,
-                                    "scheduledDeparture": 56880,
-                                    "serviceDay": 1565074800,
-                                    "stopCount": 40,
-                                    "stopId": "TriMet:715",
-                                    "stopIndex": 0,
-                                    "timepoint": true,
-                                    "tripId": "TriMet:9238194",
-                                  },
-                                  Object {
-                                    "arrivalDelay": 0,
                                     "blockId": "9470",
                                     "departureDelay": 0,
                                     "headsign": "Sherwood",
@@ -10920,6 +10929,24 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     "stopIndex": 0,
                                     "timepoint": true,
                                     "tripId": "TriMet:9238190",
+                                  },
+                                  Object {
+                                    "arrivalDelay": 0,
+                                    "blockId": "9474",
+                                    "departureDelay": 0,
+                                    "headsign": "Sherwood",
+                                    "realtime": false,
+                                    "realtimeArrival": 56880,
+                                    "realtimeDeparture": 56880,
+                                    "realtimeState": "SCHEDULED",
+                                    "scheduledArrival": 56880,
+                                    "scheduledDeparture": 56880,
+                                    "serviceDay": 1565074800,
+                                    "stopCount": 40,
+                                    "stopId": "TriMet:715",
+                                    "stopIndex": 0,
+                                    "timepoint": true,
+                                    "tripId": "TriMet:9238194",
                                   },
                                   Object {
                                     "arrivalDelay": 0,
@@ -10964,7 +10991,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   "nearbyRadius": 250,
                                   "numberOfDepartures": 3,
                                   "showBlockIds": false,
-                                  "timeRange": 345600,
+                                  "timeRange": 172800,
                                 }
                               }
                             >
@@ -10972,7 +10999,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                 className="route-row"
                               >
                                 <div
-                                  className="header"
+                                  className="header stop-view"
                                   style={
                                     Object {
                                       "backgroundColor": "#333333",
@@ -10984,17 +11011,15 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     className="route-name"
                                   >
                                     <strong
-                                      style={Object {}}
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "alignContent": "center",
-                                            "display": "flex",
-                                            "justifyContent": "center",
-                                            "whiteSpace": "nowrap",
-                                          }
+                                      style={
+                                        Object {
+                                          "fontSize": "32px",
                                         }
+                                      }
+                                    >
+                                      <span
+                                        className="route-name-container"
+                                        title="94"
                                       >
                                         <DefaultRouteRenderer
                                           leg={
@@ -11023,9 +11048,11 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                             </span>
                                           </styled.span>
                                         </DefaultRouteRenderer>
-                                      </div>
+                                      </span>
                                     </strong>
-                                    <span>
+                                    <span
+                                      title="Sherwood"
+                                    >
                                       Sherwood
                                     </span>
                                   </div>
@@ -11123,27 +11150,24 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="tuesday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.tuesday"
-                                              >
-                                                common.daysOfWeek.tuesday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="tuesday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.tuesday"
+                                                  >
+                                                    common.daysOfWeek.tuesday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -11269,27 +11293,24 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="tuesday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.tuesday"
-                                              >
-                                                common.daysOfWeek.tuesday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="tuesday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.tuesday"
+                                                  >
+                                                    common.daysOfWeek.tuesday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -11415,27 +11436,24 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="tuesday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.tuesday"
-                                              >
-                                                common.daysOfWeek.tuesday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="tuesday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.tuesday"
+                                                  >
+                                                    common.daysOfWeek.tuesday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -11477,7 +11495,6 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                           </injectIntl(PatternRow)>
                           <injectIntl(PatternRow)
                             homeTimezone="America/Los_Angeles"
-                            key="TriMet:94-King City"
                             pattern={
                               Object {
                                 "desc": "94 to SW Pacific Hwy & Durham (TriMet:8644) from W Burnside & SW 8th (TriMet:715)",
@@ -11560,7 +11577,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                 "nearbyRadius": 250,
                                 "numberOfDepartures": 3,
                                 "showBlockIds": false,
-                                "timeRange": 345600,
+                                "timeRange": 172800,
                               }
                             }
                           >
@@ -11684,7 +11701,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   "nearbyRadius": 250,
                                   "numberOfDepartures": 3,
                                   "showBlockIds": false,
-                                  "timeRange": 345600,
+                                  "timeRange": 172800,
                                 }
                               }
                             >
@@ -11692,7 +11709,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                 className="route-row"
                               >
                                 <div
-                                  className="header"
+                                  className="header stop-view"
                                   style={
                                     Object {
                                       "backgroundColor": "#333333",
@@ -11704,17 +11721,15 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     className="route-name"
                                   >
                                     <strong
-                                      style={Object {}}
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "alignContent": "center",
-                                            "display": "flex",
-                                            "justifyContent": "center",
-                                            "whiteSpace": "nowrap",
-                                          }
+                                      style={
+                                        Object {
+                                          "fontSize": "32px",
                                         }
+                                      }
+                                    >
+                                      <span
+                                        className="route-name-container"
+                                        title="94"
                                       >
                                         <DefaultRouteRenderer
                                           leg={
@@ -11743,9 +11758,11 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                             </span>
                                           </styled.span>
                                         </DefaultRouteRenderer>
-                                      </div>
+                                      </span>
                                     </strong>
-                                    <span>
+                                    <span
+                                      title="King City"
+                                    >
                                       King City
                                     </span>
                                   </div>
@@ -11843,27 +11860,24 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="tuesday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.tuesday"
-                                              >
-                                                common.daysOfWeek.tuesday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="tuesday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.tuesday"
+                                                  >
+                                                    common.daysOfWeek.tuesday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -11989,27 +12003,24 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="wednesday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.wednesday"
-                                              >
-                                                common.daysOfWeek.wednesday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="wednesday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.wednesday"
+                                                  >
+                                                    common.daysOfWeek.wednesday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -12135,27 +12146,24 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="thursday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.thursday"
-                                              >
-                                                common.daysOfWeek.thursday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="thursday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.thursday"
+                                                  >
+                                                    common.daysOfWeek.thursday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -12197,7 +12205,6 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                           </injectIntl(PatternRow)>
                           <injectIntl(PatternRow)
                             homeTimezone="America/Los_Angeles"
-                            key="TriMet:36-Tualatin Park & Ride"
                             pattern={
                               Object {
                                 "desc": "36 to Tualatin Park & Ride (TriMet:7879) from W Burnside & SW 8th (TriMet:715)",
@@ -12280,7 +12287,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                 "nearbyRadius": 250,
                                 "numberOfDepartures": 3,
                                 "showBlockIds": false,
-                                "timeRange": 345600,
+                                "timeRange": 172800,
                               }
                             }
                           >
@@ -12404,7 +12411,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                   "nearbyRadius": 250,
                                   "numberOfDepartures": 3,
                                   "showBlockIds": false,
-                                  "timeRange": 345600,
+                                  "timeRange": 172800,
                                 }
                               }
                             >
@@ -12412,7 +12419,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                 className="route-row"
                               >
                                 <div
-                                  className="header"
+                                  className="header stop-view"
                                   style={
                                     Object {
                                       "backgroundColor": "#333333",
@@ -12424,17 +12431,15 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                     className="route-name"
                                   >
                                     <strong
-                                      style={Object {}}
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "alignContent": "center",
-                                            "display": "flex",
-                                            "justifyContent": "center",
-                                            "whiteSpace": "nowrap",
-                                          }
+                                      style={
+                                        Object {
+                                          "fontSize": "32px",
                                         }
+                                      }
+                                    >
+                                      <span
+                                        className="route-name-container"
+                                        title="36"
                                       >
                                         <DefaultRouteRenderer
                                           leg={
@@ -12463,9 +12468,11 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                             </span>
                                           </styled.span>
                                         </DefaultRouteRenderer>
-                                      </div>
+                                      </span>
                                     </strong>
-                                    <span>
+                                    <span
+                                      title="Tualatin Park & Ride"
+                                    >
                                       Tualatin Park & Ride
                                     </span>
                                   </div>
@@ -12563,27 +12570,24 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="tuesday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.tuesday"
-                                              >
-                                                common.daysOfWeek.tuesday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="tuesday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.tuesday"
+                                                  >
+                                                    common.daysOfWeek.tuesday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -12709,27 +12713,24 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="tuesday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.tuesday"
-                                              >
-                                                common.daysOfWeek.tuesday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="tuesday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.tuesday"
+                                                  >
+                                                    common.daysOfWeek.tuesday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -12855,27 +12856,24 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="wednesday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.wednesday"
-                                              >
-                                                common.daysOfWeek.wednesday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="wednesday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.wednesday"
+                                                  >
+                                                    common.daysOfWeek.wednesday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -13476,7 +13474,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                 "nearbyRadius": 250,
                                 "numberOfDepartures": 3,
                                 "showBlockIds": false,
-                                "timeRange": 345600,
+                                "timeRange": 172800,
                               }
                             }
                             transitOperators={Array []}
@@ -15448,7 +15446,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                 "nearbyRadius": 250,
                 "numberOfDepartures": 3,
                 "showBlockIds": false,
-                "timeRange": 345600,
+                "timeRange": 172800,
               }
             }
             toggleAutoRefresh={[Function]}
@@ -15959,7 +15957,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                   tabIndex={0}
                 >
                   <div
-                    className="sc-bQdRvg hGmYyp"
+                    className="sc-fXoxaI gHFXNE"
                     tabIndex={0}
                   >
                     <injectIntl(LiveStopTimes)
@@ -16392,7 +16390,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                           "nearbyRadius": 250,
                           "numberOfDepartures": 3,
                           "showBlockIds": false,
-                          "timeRange": 345600,
+                          "timeRange": 172800,
                         }
                       }
                       toggleAutoRefresh={[Function]}
@@ -16869,7 +16867,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                             "nearbyRadius": 250,
                             "numberOfDepartures": 3,
                             "showBlockIds": false,
-                            "timeRange": 345600,
+                            "timeRange": 172800,
                           }
                         }
                         toggleAutoRefresh={[Function]}
@@ -16883,9 +16881,22 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                         <ul
                           className="route-row-container"
                         >
+                          <p
+                            aria-hidden={true}
+                            className="day-label"
+                          >
+                            <FormattedDayOfWeek
+                              day="monday"
+                            >
+                              <FormattedMessage
+                                id="common.daysOfWeek.monday"
+                              >
+                                common.daysOfWeek.monday
+                              </FormattedMessage>
+                            </FormattedDayOfWeek>
+                          </p>
                           <injectIntl(PatternRow)
                             homeTimezone="America/Los_Angeles"
-                            key="TriMet:20-Gresham TC"
                             pattern={
                               Object {
                                 "desc": "20 to Gresham Transit Center (TriMet:8199) from Beaverton Transit Center (TriMet:9978) express",
@@ -16947,24 +16958,6 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                 },
                                 Object {
                                   "arrivalDelay": 0,
-                                  "blockId": "2047",
-                                  "departureDelay": 0,
-                                  "headsign": "Gresham TC",
-                                  "realtime": false,
-                                  "realtimeArrival": 66668,
-                                  "realtimeDeparture": 66668,
-                                  "realtimeState": "SCHEDULED",
-                                  "scheduledArrival": 66668,
-                                  "scheduledDeparture": 66668,
-                                  "serviceDay": 1564988400,
-                                  "stopCount": 132,
-                                  "stopId": "TriMet:715",
-                                  "stopIndex": 42,
-                                  "timepoint": false,
-                                  "tripId": "TriMet:9230360",
-                                },
-                                Object {
-                                  "arrivalDelay": 0,
                                   "blockId": "2046",
                                   "departureDelay": 0,
                                   "headsign": "Gresham TC",
@@ -16980,6 +16973,24 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                   "stopIndex": 42,
                                   "timepoint": false,
                                   "tripId": "TriMet:9230359",
+                                },
+                                Object {
+                                  "arrivalDelay": 0,
+                                  "blockId": "2047",
+                                  "departureDelay": 0,
+                                  "headsign": "Gresham TC",
+                                  "realtime": false,
+                                  "realtimeArrival": 66668,
+                                  "realtimeDeparture": 66668,
+                                  "realtimeState": "SCHEDULED",
+                                  "scheduledArrival": 66668,
+                                  "scheduledDeparture": 66668,
+                                  "serviceDay": 1564988400,
+                                  "stopCount": 132,
+                                  "stopId": "TriMet:715",
+                                  "stopIndex": 42,
+                                  "timepoint": false,
+                                  "tripId": "TriMet:9230360",
                                 },
                                 Object {
                                   "arrivalDelay": 0,
@@ -17024,7 +17035,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                 "nearbyRadius": 250,
                                 "numberOfDepartures": 3,
                                 "showBlockIds": false,
-                                "timeRange": 345600,
+                                "timeRange": 172800,
                               }
                             }
                           >
@@ -17127,24 +17138,6 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                   },
                                   Object {
                                     "arrivalDelay": 0,
-                                    "blockId": "2047",
-                                    "departureDelay": 0,
-                                    "headsign": "Gresham TC",
-                                    "realtime": false,
-                                    "realtimeArrival": 66668,
-                                    "realtimeDeparture": 66668,
-                                    "realtimeState": "SCHEDULED",
-                                    "scheduledArrival": 66668,
-                                    "scheduledDeparture": 66668,
-                                    "serviceDay": 1564988400,
-                                    "stopCount": 132,
-                                    "stopId": "TriMet:715",
-                                    "stopIndex": 42,
-                                    "timepoint": false,
-                                    "tripId": "TriMet:9230360",
-                                  },
-                                  Object {
-                                    "arrivalDelay": 0,
                                     "blockId": "2046",
                                     "departureDelay": 0,
                                     "headsign": "Gresham TC",
@@ -17160,6 +17153,24 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                     "stopIndex": 42,
                                     "timepoint": false,
                                     "tripId": "TriMet:9230359",
+                                  },
+                                  Object {
+                                    "arrivalDelay": 0,
+                                    "blockId": "2047",
+                                    "departureDelay": 0,
+                                    "headsign": "Gresham TC",
+                                    "realtime": false,
+                                    "realtimeArrival": 66668,
+                                    "realtimeDeparture": 66668,
+                                    "realtimeState": "SCHEDULED",
+                                    "scheduledArrival": 66668,
+                                    "scheduledDeparture": 66668,
+                                    "serviceDay": 1564988400,
+                                    "stopCount": 132,
+                                    "stopId": "TriMet:715",
+                                    "stopIndex": 42,
+                                    "timepoint": false,
+                                    "tripId": "TriMet:9230360",
                                   },
                                   Object {
                                     "arrivalDelay": 0,
@@ -17204,7 +17215,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                   "nearbyRadius": 250,
                                   "numberOfDepartures": 3,
                                   "showBlockIds": false,
-                                  "timeRange": 345600,
+                                  "timeRange": 172800,
                                 }
                               }
                             >
@@ -17212,7 +17223,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                 className="route-row"
                               >
                                 <div
-                                  className="header"
+                                  className="header stop-view"
                                   style={
                                     Object {
                                       "backgroundColor": "#333333",
@@ -17224,17 +17235,15 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                     className="route-name"
                                   >
                                     <strong
-                                      style={Object {}}
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "alignContent": "center",
-                                            "display": "flex",
-                                            "justifyContent": "center",
-                                            "whiteSpace": "nowrap",
-                                          }
+                                      style={
+                                        Object {
+                                          "fontSize": "32px",
                                         }
+                                      }
+                                    >
+                                      <span
+                                        className="route-name-container"
+                                        title="20"
                                       >
                                         <DefaultRouteRenderer
                                           leg={
@@ -17263,9 +17272,11 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                             </span>
                                           </styled.span>
                                         </DefaultRouteRenderer>
-                                      </div>
+                                      </span>
                                     </strong>
-                                    <span>
+                                    <span
+                                      title="Gresham TC"
+                                    >
                                       Gresham TC
                                     </span>
                                   </div>
@@ -17363,27 +17374,24 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="monday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.monday"
-                                              >
-                                                common.daysOfWeek.monday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="monday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.monday"
+                                                  >
+                                                    common.daysOfWeek.monday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -17509,27 +17517,24 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="monday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.monday"
-                                              >
-                                                common.daysOfWeek.monday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="monday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.monday"
+                                                  >
+                                                    common.daysOfWeek.monday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -17655,27 +17660,24 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                           </Styled(styled.span)>
                                           <span
                                             className="percy-hide"
-                                            style={
-                                              Object {
-                                                "marginBottom": -4,
-                                              }
-                                            }
-                                          >
-                                            <FormattedDayOfWeek
-                                              day="monday"
-                                            >
-                                              <FormattedMessage
-                                                id="common.daysOfWeek.monday"
-                                              >
-                                                common.daysOfWeek.monday
-                                              </FormattedMessage>
-                                            </FormattedDayOfWeek>
-                                             
-                                          </span>
-                                          <span
-                                            className="percy-hide"
                                             title="components.RealtimeStatusLabel.scheduled"
                                           >
+                                            <styled.span>
+                                              <span
+                                                className="sc-hzMMVR bVLqNV"
+                                              >
+                                                <FormattedDayOfWeek
+                                                  day="monday"
+                                                >
+                                                  <FormattedMessage
+                                                    id="common.daysOfWeek.monday"
+                                                  >
+                                                    common.daysOfWeek.monday
+                                                  </FormattedMessage>
+                                                </FormattedDayOfWeek>
+                                                 
+                                              </span>
+                                            </styled.span>
                                             <DepartureTime
                                               realTime={true}
                                               stopTime={
@@ -18271,7 +18273,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                 "nearbyRadius": 250,
                                 "numberOfDepartures": 3,
                                 "showBlockIds": false,
-                                "timeRange": 345600,
+                                "timeRange": 172800,
                               }
                             }
                             transitOperators={Array []}
@@ -19810,7 +19812,7 @@ exports[`components > viewers > stop viewer should render with initial stop id a
                 "nearbyRadius": 250,
                 "numberOfDepartures": 3,
                 "showBlockIds": false,
-                "timeRange": 345600,
+                "timeRange": 172800,
               }
             }
             toggleAutoRefresh={[Function]}

--- a/__tests__/reducers/__snapshots__/create-otp-reducer.js.snap
+++ b/__tests__/reducers/__snapshots__/create-otp-reducer.js.snap
@@ -21,7 +21,7 @@ Object {
       "nearbyRadius": 250,
       "numberOfDepartures": 3,
       "showBlockIds": false,
-      "timeRange": 345600,
+      "timeRange": 172800,
     },
     "transitOperators": Array [],
   },

--- a/example-config.yml
+++ b/example-config.yml
@@ -552,8 +552,8 @@ itinerary:
 #   # so that, for example, if it is Friday and a route does
 #   # not begin service again until Monday, we are showing its next
 #   # departure and it is not entirely excluded from display
-#   # (defaults to 4 days/345600s if unspecified).
-#   timeRange: 345600
+#   # (defaults to 2 days/172800s if unspecified).
+#   timeRange: 172800
 # routeViewer:
 #   # Whether to render routes within flex zones of a route's patterns. If set to true,
 #   # routes will not be rendered within flex zones.

--- a/lib/components/viewers/next-arrival-for-pattern.tsx
+++ b/lib/components/viewers/next-arrival-for-pattern.tsx
@@ -7,6 +7,7 @@ import { ComponentContext } from '../../util/contexts'
 import {
   extractHeadsignFromPattern,
   generateFakeLegForRouteRenderer,
+  routeNameFontSize,
   stopTimeComparator
 } from '../../util/viewer'
 import DefaultRouteRenderer from '../narrative/metro/default-route-renderer'
@@ -72,7 +73,6 @@ function NextArrivalForPattern({
     { id: 'common.routing.routeToHeadsign' },
     { headsign }
   )
-  const title = `${routeName} ${toHeadsign}`
 
   return (
     <li
@@ -83,15 +83,20 @@ function NextArrivalForPattern({
       }}
     >
       {/* route name */}
-      <div className="next-arrival-label overflow-ellipsis" title={title}>
-        <span className="route-name">
+      <div className="next-arrival-label">
+        <span
+          className="route-name"
+          style={{ fontSize: routeNameFontSize(routeName) }}
+        >
           <RouteRenderer
             isOnColoredBackground={route.operator?.colorMode?.includes('gtfs')}
             // All GTFS bg colors look strange with the top border
             leg={generateFakeLegForRouteRenderer(route, true)}
           />
         </span>
-        {toHeadsign}
+        <span className="overflow-ellipsis" title={toHeadsign}>
+          {toHeadsign}
+        </span>
       </div>
       {/* next departure preview */}
       {hasStopTimes && (

--- a/lib/components/viewers/pattern-row.tsx
+++ b/lib/components/viewers/pattern-row.tsx
@@ -7,7 +7,7 @@ import { ComponentContext } from '../../util/contexts'
 import {
   generateFakeLegForRouteRenderer,
   getRouteColorBasedOnSettings,
-  stopTimeComparator
+  routeNameFontSize
 } from '../../util/viewer'
 import { Pattern, Time } from '../util/types'
 import DefaultRouteRenderer from '../narrative/metro/default-route-renderer'
@@ -59,12 +59,9 @@ class PatternRow extends Component<Props, State> {
     const hasStopTimes = stopTimes && stopTimes.length > 0
     if (hasStopTimes) {
       sortedStopTimes = stopTimes
-        .concat()
-        .sort(stopTimeComparator)
         // We request only x departures per pattern, but the patterns are merged
         // according to shared headsigns, so we need to slice the stop times
         // here as well to ensure only x times are shown per route/headsign combo.
-        // This is applied after the sort, so we're keeping the soonest departures.
         .slice(0, stopViewerConfig.numberOfDepartures)
     } else {
       // Do not render pattern row if it has no stop times.
@@ -78,7 +75,7 @@ class PatternRow extends Component<Props, State> {
       <li className="route-row">
         {/* header row */}
         <div
-          className="header"
+          className="header stop-view"
           style={{
             backgroundColor: routeColor,
             color: getMostReadableTextColor(routeColor, route?.textColor)
@@ -86,19 +83,8 @@ class PatternRow extends Component<Props, State> {
         >
           {/* route name */}
           <div className="route-name">
-            <strong
-              style={
-                routeName && routeName?.length >= 4 ? { fontSize: '50%' } : {}
-              }
-            >
-              <div
-                style={{
-                  alignContent: 'center',
-                  display: 'flex',
-                  justifyContent: 'center',
-                  whiteSpace: 'nowrap'
-                }}
-              >
+            <strong style={{ fontSize: routeNameFontSize(routeName) }}>
+              <span className="route-name-container" title={routeName}>
                 {showOperatorLogo && (
                   <OperatorLogo operator={route?.operator} />
                 )}
@@ -109,9 +95,9 @@ class PatternRow extends Component<Props, State> {
                   )}
                   leg={generateFakeLegForRouteRenderer(route, true)}
                 />
-              </div>
+              </span>
             </strong>
-            <span>{pattern.headsign}</span>
+            <span title={pattern.headsign}>{pattern.headsign}</span>
           </div>
           {/* next departure preview */}
           {hasStopTimes && (

--- a/lib/components/viewers/stop-time-cell.tsx
+++ b/lib/components/viewers/stop-time-cell.tsx
@@ -18,10 +18,10 @@ import getRealtimeStatusLabel, {
 import type { Time } from '../util/types'
 
 import DepartureTime from './departure-time'
+import InvisibleA11yLabel from '../util/invisible-a11y-label'
 
 const { getUserTimezone } = coreUtils.time
 const ONE_HOUR_IN_SECONDS = 3600
-const ONE_DAY_IN_SECONDS = 86400
 
 const PulsingRss = styled(Rss)`
   animation: pulse-opacity 2s ease-in-out infinite;
@@ -63,22 +63,6 @@ const StopTimeCell = ({
       </div>
     )
   }
-  const departureTime = stopTime.realtimeDeparture
-  const now = utcToZonedTime(Date.now(), homeTimezone)
-  const serviceDay = utcToZonedTime(
-    new Date(stopTime.serviceDay * 1000),
-    homeTimezone
-  )
-
-  // Determine if arrival occurs on different day, making sure to account for
-  // any extra days added to the service day if it arrives after midnight. Note:
-  // this can handle the rare (and non-existent?) case where an arrival occurs
-  // 48:00 hours (or more) from the start of the service day.
-  const departureTimeRemainder = departureTime % ONE_DAY_IN_SECONDS
-  const daysAfterServiceDay =
-    (departureTime - departureTimeRemainder) / ONE_DAY_IN_SECONDS
-  const departureDay = addDays(serviceDay, daysAfterServiceDay)
-  const vehicleDepartsToday = isSameDay(now, departureDay)
 
   // Determine whether to show departure as countdown (e.g. "5 min") or as HH:mm
   // time, using realtime updates if available.
@@ -94,11 +78,7 @@ const StopTimeCell = ({
   // Whether to display "Due" or a countdown (used in conjunction with showCountdown).
   const isDue = secondsUntilDeparture < 60
 
-  // We only want to show the day of the week if the arrival is on a
-  // different day and we're not showing the countdown string. This avoids
-  // cases such as when it's Wednesday at 11:55pm and an arrival occurs at
-  // Thursday 12:19am. We don't want the time to read: 'Thursday, 24 minutes'.
-  const showDayOfWeek = !vehicleDepartsToday && !showCountdown
+  const formattedDay = utcToZonedTime(stopTime.serviceDay * 1000, homeTimezone)
 
   const realtime = stopTime.realtimeState === 'UPDATED'
   const realtimeLabel = realtime
@@ -121,17 +101,6 @@ const StopTimeCell = ({
         {realtime ? <PulsingRss /> : <Clock />}
       </StyledIconWrapperTextAlign>
 
-      {showDayOfWeek && (
-        <span className="percy-hide" style={{ marginBottom: -4 }}>
-          <FormattedDayOfWeek
-            // 'iiii' returns the long ISO day of the week (independent of browser locale).
-            // See https://date-fns.org/v2.28.0/docs/format
-            day={format(departureDay, 'iiii', {
-              timeZone: homeTimezone
-            }).toLowerCase()}
-          />{' '}
-        </span>
-      )}
       <span
         className="percy-hide"
         title={getRealtimeStatusLabel({
@@ -151,7 +120,20 @@ const StopTimeCell = ({
             />
           )
         ) : (
-          <DepartureTime realTime stopTime={stopTime} />
+          <>
+            {!isSameDay(new Date(), formattedDay) && (
+              <InvisibleA11yLabel>
+                <FormattedDayOfWeek
+                  // 'iiii' returns the long ISO day of the week (independent of browser locale).
+                  // See https://date-fns.org/v2.28.0/docs/format
+                  day={format(formattedDay, 'iiii', {
+                    timeZone: homeTimezone
+                  }).toLowerCase()}
+                />{' '}
+              </InvisibleA11yLabel>
+            )}
+            <DepartureTime realTime stopTime={stopTime} />
+          </>
         )}
       </span>
     </div>

--- a/lib/components/viewers/viewers.css
+++ b/lib/components/viewers/viewers.css
@@ -102,15 +102,35 @@
 
 /* stop viewer styles */
 
-.otp .stop-viewer .route-row {
+.otp .stop-viewer .route-row-container,
+.related-panel-container {
+  list-style-type: none;
+  padding-left: 0;
 }
 .otp .stop-viewer .route-row-container,
 .related-panel-container {
   border-radius: 10px;
-  box-shadow: 2px 2px 5px 1px rgba(0, 0, 0, 0.1);
-  list-style-type: none;
-  padding-left: 0;
+  box-shadow: 2px 2px 5px 1px rgb(0 0 0 / 10%);
 }
+
+.otp .stop-viewer .route-row-container li .header.stop-view {
+  border-radius: 0;
+}
+
+.otp .stop-viewer p.day-label {
+  font-weight: 500;
+  margin: 15px 10px;
+}
+
+.otp .stop-viewer .route-row-container li:first-of-type .header.stop-view {
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+}
+.otp .stop-viewer .route-row-container li:last-of-type .header.stop-view {
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
+}
+
 .otp .stop-viewer .route-row:first-of-type {
   margin-top: 10px;
 }
@@ -119,31 +139,40 @@
   align-items: center;
   display: grid;
   grid-template-columns: 2fr 1fr;
-  width: 100%;
+  overflow: hidden;
 }
 .otp .stop-viewer .route-row .header .route-name {
   align-items: center;
-  display: grid;
-  font-size: 42px;
-  gap: 5px;
-  grid-template-columns: 4ch 2fr;
+  display: flex;
+  gap: 10px;
 }
 .otp .stop-viewer .route-row .header .route-name span {
+  display: -webkit-box;
   font-size: 15px;
+  line-clamp: 3;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
 }
 .otp .stop-viewer .route-row .header .route-name strong span {
-  font-size: 32px;
+  display: block;
+  font-size: inherit;
+  padding-left: 10px;
+  text-align: center;
+  width: 85px;
+}
+
+.otp .stop-viewer .route-row .header .route-name span.route-name-container {
+  padding-left: 0;
 }
 
 .otp .stop-viewer .route-row .header .next-trip-preview {
   display: grid;
   grid-template-rows: fit-content(8ch);
-  justify-self: end;
   list-style-type: none;
   padding: 15px;
   text-align: right;
   white-space: nowrap;
-  width: 100%;
 }
 
 .otp .stop-viewer .route-row .header .next-trip-preview li:first-of-type {
@@ -174,6 +203,20 @@
   outline: 0px;
 }
 
+@media (max-width: 450px) {
+  .otp .stop-viewer .route-row .header .next-trip-preview {
+    padding: 15px 10px;
+  }
+
+  .otp .stop-viewer .route-row .header .route-name strong span {
+    min-width: auto;
+  }
+
+  .otp .stop-viewer .route-row .header .next-trip-preview li:first-of-type {
+    font-size: 18px;
+  }
+}
+
 /* child stop details */
 
 .otp .stop-viewer .stop-viewer-body .stop-label {
@@ -197,6 +240,7 @@
 }
 .otp .stop-viewer .stop-viewer-body .related-panel-container {
   background: #fffffff8;
+  border-radius: 10px;
   color: #333;
   padding: 0.5rem;
   margin: 1.5rem 0;
@@ -234,9 +278,11 @@
   -webkit-font-smoothing: antialiased;
   align-items: center;
   border-radius: 10px;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(65%, 90%) 90px;
   justify-content: space-between;
   margin-bottom: 5px;
+  min-height: 50px;
   width: 100%;
 }
 .otp .stop-viewer .stop-viewer-body .next-arrival-row:last-of-type {
@@ -246,13 +292,12 @@
 .otp .stop-viewer .stop-viewer-body .next-arrival-row .next-arrival-label {
   align-items: center;
   display: flex;
-  max-width: 250px;
+  gap: 7px;
+  margin-left: 10px;
 }
 
 .otp .stop-viewer .stop-viewer-body .next-arrival-row .route-name {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.25em;
+  justify-self: center;
   font-size: 22px;
   font-weight: 700;
 }
@@ -261,9 +306,10 @@
 }
 
 .otp .stop-viewer .stop-viewer-body .next-arrival-row .next-arrival-time {
-  flex-shrink: 0;
   font-weight: 700;
-  width: 90px;
+  margin-right: 8px;
+  text-align: right;
+  white-space: nowrap;
 }
 
 .otp .stop-viewer .stop-viewer-body .related-item .child-stop-icon {
@@ -284,7 +330,6 @@
   font-size: 12px;
   color: #000080;
 }
-
 /* end of child-stop-details */
 
 /*.otp .stop-viewer .trip-table {

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -81,10 +81,10 @@ export function getInitialState(userDefinedConfig) {
       numberOfDepartures: 3, // per pattern
       // Hide block ids unless explicitly enabled in config.
       showBlockIds: false,
-      // This is set to 345600 (four days) so that, for example, if it is Friday and
-      // a route does not begin service again until Monday, we are showing its next
-      // departure and it is not entirely excluded from display.
-      timeRange: 345600 // four days in seconds
+      // Window to display upcoming departures in stop viewer departures pane.
+      // Can be set in config, but defaults to showing departures up to two
+      // days in the future.
+      timeRange: 172800 // two days in seconds
     },
     transitOperators: []
   }

--- a/lib/util/viewer.js
+++ b/lib/util/viewer.js
@@ -289,6 +289,18 @@ export const REALTIME_STATUS = {
   SCHEDULED: 'SCHEDULED'
 }
 
+export const routeNameFontSize = (routeName) => {
+  let fontSize = '32px'
+  if (routeName) {
+    if (routeName?.length >= 4 && routeName?.length <= 6) {
+      fontSize = '20px'
+    } else if (routeName?.length > 7) {
+      fontSize = '16px'
+    }
+  }
+  return fontSize
+}
+
 /**
  * Get one of the realtime states (on-time, late...) if a leg/stoptime is
  * registering realtime info and given a delay value in seconds.


### PR DESCRIPTION
Separates upcoming stop times by service day and tweaks flexbox/grid elements to avoid clipping and overflow at smaller screen sizes.

The stop viewer will only show departures within the next 2 days unless otherwise specified in the configurations file.

For a full discussion on this PR, see #780 (closed due to fraught merge)


Before                                 |  After
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/115499534/217345613-4d9d0c46-9d19-4708-a4f3-b7be9015df2f.png) | ![image](https://user-images.githubusercontent.com/115499534/217345509-2a0a03f2-18bd-4660-bf38-22219ae8b4fe.png)
