### PR TITLE
Repair a11y Itinerary Regressions

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -265,7 +265,7 @@ components:
   DefaultItinerary:
     clickDetails: Click to view details
     multiModeSummary: "{accessMode} + {transitMode}"
-    nonTransit: Without Transit
+    nonTransit: Alternative options
   DeleteUser:
     deleteMyAccount: Delete my account
   EnhancedStopMarker:

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -265,6 +265,7 @@ components:
   DefaultItinerary:
     clickDetails: Click to view details
     multiModeSummary: "{accessMode} + {transitMode}"
+    nonTransit: Without Transit
   DeleteUser:
     deleteMyAccount: Delete my account
   EnhancedStopMarker:

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -439,20 +439,23 @@ class NarrativeItineraries extends Component {
                 </ListContainer>
               )}
               {this._renderLoadingDivs()}
-              {groupItineraries && !itineraryIsExpanded && (
-                <S.ModeResultContainer>
-                  <h2>
-                    <FormattedMessage id="otpUi.LocationField.other" />
-                  </h2>
-                  <S.SingleModeRowContainer>
-                    {Object.keys(groupedMergedItineraries.single).map((mode) =>
-                      groupedMergedItineraries.single[mode].map((itin) =>
-                        this._renderItineraryRow(itin, true)
-                      )
-                    )}
-                  </S.SingleModeRowContainer>
-                </S.ModeResultContainer>
-              )}
+              {groupItineraries &&
+                !itineraryIsExpanded &&
+                Object.keys(groupedMergedItineraries.single).length > 0 && (
+                  <S.ModeResultContainer>
+                    <h2>
+                      <FormattedMessage id="components.DefaultItinerary.nonTransit" />
+                    </h2>
+                    <S.SingleModeRowContainer>
+                      {Object.keys(groupedMergedItineraries.single).map(
+                        (mode) =>
+                          groupedMergedItineraries.single[mode].map((itin) =>
+                            this._renderItineraryRow(itin, true)
+                          )
+                      )}
+                    </S.SingleModeRowContainer>
+                  </S.ModeResultContainer>
+                )}
             </>
           )}
         </div>

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -31,6 +31,7 @@ import PageTitle from '../util/page-title'
 
 import * as S from './styled'
 import { getItineraryDescription } from './default/itinerary-description'
+import InvisibleA11yLabel from '../util/invisible-a11y-label'
 import Loading from './loading'
 import NarrativeItinerariesErrors from './narrative-itineraries-errors'
 import NarrativeItinerariesHeader from './narrative-itineraries-header'
@@ -443,9 +444,11 @@ class NarrativeItineraries extends Component {
                 !itineraryIsExpanded &&
                 Object.keys(groupedMergedItineraries.single).length > 0 && (
                   <S.ModeResultContainer>
-                    <h2>
-                      <FormattedMessage id="components.DefaultItinerary.nonTransit" />
-                    </h2>
+                    <InvisibleA11yLabel>
+                      <h2>
+                        <FormattedMessage id="components.DefaultItinerary.nonTransit" />
+                      </h2>
+                    </InvisibleA11yLabel>
                     <S.SingleModeRowContainer>
                       {Object.keys(groupedMergedItineraries.single).map(
                         (mode) =>


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

The "other" category always showed up, whether or not single-mode itineraries were present. This PR repairs this, as well as adjusts the string used.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [X] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [X] Are all languages supported (Internationalization/Localization)?
- [X] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

