### PR TITLE
Reduce "missing translation" error messages

### DIFF
--- a/lib/components/app/app-menu.tsx
+++ b/lib/components/app/app-menu.tsx
@@ -121,7 +121,11 @@ class AppMenu extends Component<
         } = menuItem
         const { intl } = this.props
         const localizationId = `config.menuItems.${id}`
-        const localizedLabel = intl.formatMessage({ id: localizationId })
+        const localizedLabel = intl.formatMessage({
+          // Add the string id as the default message to limit error messages.
+          defaultMessage: localizationId,
+          id: localizationId
+        })
         // Override the config label if a localized label exists
         const label =
           localizedLabel === localizationId ? configLabel : localizedLabel

--- a/lib/util/i18n.js
+++ b/lib/util/i18n.js
@@ -1,5 +1,6 @@
 import clone from 'clone'
 import flatten from 'flat'
+import memoize from 'lodash.memoize'
 
 // deepmerge must be imported via `require`: see https://github.com/TehShrike/deepmerge#include
 const merge = require('deepmerge')
@@ -63,7 +64,7 @@ export function getConfigLocales(configLanguages) {
  * @param {*} configLanguages The configured languages.
  * @returns An array of the supported locale ids if 2 or more are configured, null otherwise.
  */
-export function getLanguageOptions(configLanguages) {
+export const getLanguageOptions = memoize((configLanguages) => {
   const filteredKeys =
     (configLanguages &&
       Object.keys(configLanguages).filter(
@@ -77,7 +78,7 @@ export function getLanguageOptions(configLanguages) {
     filteredLanguages[key] = configLanguages[key]
   })
   return filteredLanguages
-}
+})
 
 /**
  * Loads in all localized strings from @opentripplanner packages.


### PR DESCRIPTION
## Description

Many "missing translation" error messages are currently shown. This PR alleviates that by preventing unnecessary re-renderings of the language selectors (in the app menu or the header bar), and by using an explicit fallback message for configured app menu items that don't come with translations, such as links to brands.

## PR Checklist
- [na] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [na] Are all languages supported (Internationalization/Localization)?
- [na] Are appropriate Typescript types implemented?
