### PR TITLE
chore(deps): Upgrade @opentripplanner/trip-details to 3.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@opentripplanner/stops-overlay": "^5.0.7",
     "@opentripplanner/transit-vehicle-overlay": "^4.0.2",
     "@opentripplanner/transitive-overlay": "^3.0.11",
-    "@opentripplanner/trip-details": "^3.0.5",
+    "@opentripplanner/trip-details": "^3.0.6",
     "@opentripplanner/trip-form": "^3.0.6",
     "@opentripplanner/trip-viewer-overlay": "^2.0.4",
     "@opentripplanner/vehicle-rental-overlay": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2548,10 +2548,10 @@
     "@turf/midpoint" "^6.5.0"
     lodash.isequal "^4.5.0"
 
-"@opentripplanner/trip-details@^3.0.5":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/trip-details/-/trip-details-3.0.5.tgz#9c7c9d5066e575da7a4c10e94c8f7ef91b3c73a0"
-  integrity sha512-qFKqP527BgKxzwTcTx5tg2uX9ZGje/h3zL/Dh3ZzNnm1MqDg1Czr4DD3+qcITrYVeHX9Qj6JEjYakV21jLwxBg==
+"@opentripplanner/trip-details@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/trip-details/-/trip-details-3.0.6.tgz#5b81bf73e6b3a2eb0061d30bf9103cbf36dad4e2"
+  integrity sha512-VhLAKESpdrKzmkgQnci1sVwO3v901BDAmct93gMW+oUu9/KjNrS8xCa6l2BiyoLYR1ahRggG6IGiiZ7lJX0xOg==
   dependencies:
     "@opentripplanner/core-utils" "^8.1.1"
     "@styled-icons/fa-solid" "^10.34.0"


### PR DESCRIPTION
## Description

This PR updates OTP-UI trip-details to use the updated CO₂ spelling.

## PR Checklist
- [na] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [na] Are appropriate Typescript types implemented?
