### PR TITLE
fix(route-viewer): always fetch route type

### DIFF
--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -641,6 +641,7 @@ export function findRoutes() {
             longName
             shortName
             mode
+            type
             color
           }
         }
@@ -662,7 +663,10 @@ export function findRoutes() {
             // To initialize the route viewer,
             // convert the routes array to a dictionary indexed by route ids.
             return routes.reduce(
-              (result, { agency, color, id, longName, mode, shortName }) => {
+              (
+                result,
+                { agency, color, id, longName, mode, shortName, type }
+              ) => {
                 result[id] = {
                   agencyId: agency.id,
                   agencyName: agency.name,
@@ -674,6 +678,7 @@ export function findRoutes() {
                     config?.routeModeOverrides
                   ),
                   shortName,
+                  type,
                   v2: true
                 }
                 return result


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

This PR fixes the bug where routes would jump around on hover. The issue is the routing sort included `type` which wasn't initially fetched. As it's very inexpensive to fetch this extra field, this is done in the initial route call, which both improves the sort and ensures that there is no jumping around on hover

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

