### PR TITLE
Adjust font size for longer route short names

### DIFF
--- a/lib/util/viewer.js
+++ b/lib/util/viewer.js
@@ -297,11 +297,14 @@ export const REALTIME_STATUS = {
   SCHEDULED: 'SCHEDULED'
 }
 
+// Adjust the font size to avoid clipping of larger routeShortNames
 export const routeNameFontSize = (routeName) => {
   let fontSize = '32px'
   if (routeName) {
     if (routeName?.length >= 4 && routeName?.length <= 6) {
       fontSize = '20px'
+    } else if (routeName?.split(' ').some((x) => x.length > 8)) {
+      fontSize = '12px'
     } else if (routeName?.length > 7) {
       fontSize = '16px'
     }


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
Adds a check for long words inside `routeShortName`s, and adjust the font size accordingly, to avoid clipping.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?

| Before | After |
|--------|-------|
|![image](https://user-images.githubusercontent.com/115499534/233146335-7d0d98e4-1d19-44a7-a677-b949dcd9a786.png)|![image](https://user-images.githubusercontent.com/115499534/233146474-654cda59-2389-4d6a-82d9-6c38511f9a4c.png)|

