### PR TITLE
Locale selector ID refs

### DIFF
--- a/lib/components/util/dropdown.tsx
+++ b/lib/components/util/dropdown.tsx
@@ -158,7 +158,9 @@ const Dropdown = ({
       style={{ float: pullRight ? 'right' : 'left' }}
     >
       <DropdownButton
-        aria-controls={id}
+        // Only set aria-controls when the dropdown is open
+        // (otherwise, assistive technologies may not announce the dropdown correctly).
+        aria-controls={open ? id : undefined}
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-label={label}
@@ -175,7 +177,7 @@ const Dropdown = ({
       {open && (
         <DropdownMenu
           aria-label={listLabel}
-          aria-labelledby={listLabel ? '' : `${id}-label`}
+          aria-labelledby={listLabel ? undefined : `${id}-label`}
           id={id}
           onClick={toggleOpen}
           role="list"

--- a/lib/components/util/dropdown.tsx
+++ b/lib/components/util/dropdown.tsx
@@ -1,6 +1,7 @@
 import React, {
   HTMLAttributes,
   KeyboardEvent,
+  useCallback,
   useEffect,
   useRef,
   useState
@@ -8,6 +9,7 @@ import React, {
 import styled from 'styled-components'
 
 interface Props extends HTMLAttributes<HTMLElement> {
+  id: string
   label?: string
   listLabel?: string
   name: JSX.Element
@@ -71,6 +73,25 @@ const DropdownMenu = styled.ul`
 const DropdownContainer = styled.li``
 
 /**
+ * Helper method to find the element within dropdown menu at the given offset
+ * (e.g. previous or next) relative to the specified element.
+ * The query is limited to the dropdown so that arrow navigation is contained within
+ * (tab navigation is not restricted).
+ */
+function getEntryRelativeTo(
+  id: string,
+  element: EventTarget,
+  offset: 1 | -1
+): HTMLElement {
+  const entries = Array.from(
+    document.querySelectorAll(`#${id} button, #${id}-label`)
+  )
+  const elementIndex = entries.indexOf(element as HTMLElement)
+
+  return entries[elementIndex + offset] as HTMLElement
+}
+
+/**
  * Renders a dropdown menu. By default, only a passed "name" is rendered. If clicked,
  * a floating div is rendered below the "name" with list contents inside. Clicking anywhere
  * outside the floating div will close the dropdown.
@@ -87,7 +108,7 @@ const Dropdown = ({
   const [open, setOpen] = useState(false)
   const containerRef = useRef<HTMLLIElement>(null)
 
-  const toggleOpen = () => setOpen(!open)
+  const toggleOpen = useCallback(() => setOpen(!open), [open, setOpen])
 
   // Adding document event listeners allows us to close the dropdown
   // when the user interacts with any part of the page that isn't the dropdown
@@ -107,48 +128,33 @@ const Dropdown = ({
     }
   }, [containerRef])
 
-  const _handleKeyDown = (e: KeyboardEvent): void => {
-    const element = e.target as HTMLElement
-    switch (e.key) {
-      case 'ArrowUp':
-        e.preventDefault()
-        getEntryRelativeTo(element, -1)?.focus()
-        break
-      case 'ArrowDown':
-        e.preventDefault()
-        getEntryRelativeTo(element, 1)?.focus()
-        break
-      case 'Escape':
-        setOpen(false)
-        break
-      case ' ':
-      case 'Enter':
-        element.click()
-        if (element.id === `${id}-label` || element.id === `${id}-wrapper`) {
-          toggleOpen()
-        }
-        break
-      default:
-    }
-  }
-
-  /**
-   * Helper method to find the element within dropdown menu at the given offset
-   * (e.g. previous or next) relative to the specified element.
-   * The query is limited to the dropdown so that arrow navigation is contained within
-   * (tab navigation is not restricted).
-   */
-  function getEntryRelativeTo(
-    element: EventTarget,
-    offset: 1 | -1
-  ): HTMLElement {
-    const entries = Array.from(
-      document.querySelectorAll(`#${id} button, #${id}-label`)
-    )
-    const elementIndex = entries.indexOf(element as HTMLElement)
-
-    return entries[elementIndex + offset] as HTMLElement
-  }
+  const _handleKeyDown = useCallback(
+    (e: KeyboardEvent): void => {
+      const element = e.target as HTMLElement
+      switch (e.key) {
+        case 'ArrowUp':
+          e.preventDefault()
+          getEntryRelativeTo(id, element, -1)?.focus()
+          break
+        case 'ArrowDown':
+          e.preventDefault()
+          getEntryRelativeTo(id, element, 1)?.focus()
+          break
+        case 'Escape':
+          setOpen(false)
+          break
+        case ' ':
+        case 'Enter':
+          element.click()
+          if (element.id === `${id}-label` || element.id === `${id}-wrapper`) {
+            toggleOpen()
+          }
+          break
+        default:
+      }
+    },
+    [id, toggleOpen]
+  )
 
   return (
     <DropdownContainer


### PR DESCRIPTION
## Description

This PR improves the locale selector accessibility by only setting the `aria-controls` attribute when the selector dropdown is open.

## PR Checklist
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [na] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?
