### PR TITLE
Add Column Context to stop schedule for AT

### DIFF
--- a/lib/components/viewers/stop-schedule-table.tsx
+++ b/lib/components/viewers/stop-schedule-table.tsx
@@ -112,17 +112,17 @@ class StopScheduleTable extends Component<{
         <thead>
           <tr>
             {showBlockIds && (
-              <th>
+              <th scope="col">
                 <FormattedMessage id="components.StopScheduleTable.block" />
               </th>
             )}
-            <th>
+            <th scope="col">
               <FormattedMessage id="components.StopScheduleTable.route" />
             </th>
-            <th>
+            <th scope="col">
               <FormattedMessage id="components.StopScheduleTable.destination" />
             </th>
-            <th>
+            <th scope="col">
               <FormattedMessage id="components.StopScheduleTable.departure" />
             </th>
           </tr>


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
Adds `scope="col"` to column headers in stop viewer so that they are navigable by screen readers and other ATs 

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [n/a] Are all languages supported (Internationalization/Localization)?
- [n/a] Are appropriate Typescript types implemented?


