### PR TITLE
Sort i18n yamls. Remove zero-transfer rendering from i18n files.

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -106,7 +106,7 @@ common:
     noTransitFareProvided: No fare info
     relativeCo2: |
       {co2} {isMore, select, true {more} other {less} } CO₂ than driving alone
-    transfers: "{transfers, plural, =0 {} one {# transfer} other {# transfers}}"
+    transfers: "{transfers, plural, one {# transfer} other {# transfers}}"
   modes:
     bicycle_rent: Bikeshare
     bike: Bike

--- a/i18n/es.yml
+++ b/i18n/es.yml
@@ -1,603 +1,71 @@
 _id: es
 _name: Spanish
-
-# This file contains localized strings (a.k.a. messages) for the language indicated above:
-#   - Messages are organized in various categories and sub-categories.
-#   - A component or JS module can use messages from one or more categories.
-#   - In the code, messages are retrieved using an ID that is simply the path to the message.
-#     Use the dot '.' to separate categories and sub-categories in the path.
-#     For instance, for the message defined in YML below:
-#         common
-#           modes
-#             subway: Metro#
-#     then use the snippet below with the corresponding message id:
-#         <FormattedMessage id='common.modes.subway' /> // renders "Metro".
-#
-# It is important that message ids in the code be consistent with
-# the categories in this file. Below are some general guidelines:
-#   - For starters, there are an 'actions', 'components' and 'common'
-#     categories. Additional categories may be added as needed.
-#   - Each sub-category under 'components' denotes a component and
-#     should contain messages that are used only by that component (e.g. button captions).
-#   - In contrast, some strings are common to multiple components,
-#     so it makes sense to group them by theme (e.g. accessModes) under the 'common' category.
-
-# Messages that are generated from actions
 actions:
+  callTaker:
+    callQuerySaveError: "Error al almacenar consultas de llamadas: {err}"
+    callSaveError: "No se pudo guardar la llamada: {err}"
+    checkSessionError: "Error al establecer la sesión de autorización: {err}"
+    couldNotFindCallError: >-
+      No se pudo encontrar la llamada. Estamos cancelando la solicitud de
+      guardar consultas.
+    fetchCallsError: "Error al obtener llamadas: {err}"
+    queryFetchError: "Error al obtener consultas: {err}"
   fieldTrip:
-    addNoteError: 'Error al agregar la nota de campo:'
-    confirmOverwriteItineraries: "Esta acción anulará un itinerario {outbound, select,\n\
-      \  true {saliente}\n  other {entrante}\n  } previamente planificado para esta\
-      \ solicitud. ¿Deseas continuar?\n"
-    deleteItinerariesError: 'Error al eliminar el plan de viaje:'
-    deleteNoteError: 'Error al eliminar nota de viaje:'
-    fetchFieldTripError: 'Error al obtener el viaje: {err}'
-    fetchFieldTripsError: 'Error al obtener viajes: {err}'
-    fetchTripsForDateError: 'Error al obtener viajes para la fecha de viaje: {err}'
-    incompatibleTripDateError: La fecha de viaje planificada ({tripDate}) no es el
-      día de viaje solicitado ({requestDate})
-    itineraryCapacityError: 'No se puede guardar el plan: este plan no se pudo guardar
-      debido a la falta de capacidad en uno o más vehículos. Por favor, vuelva a planificar
-      su viaje.'
-    maxTripRequestsExceeded: Número de solicitudes de viaje superadas sin resultados
-      válidos
-    saveItinerariesError: 'No se pudieron guardar los itinerarios: {err}'
-    editSubmitterNotesError: 'Error al editar las notas del remitente:'
-    setRequestStatusError: 'Error al establecer el estado de la solicitud:'
-    setDateError: 'Error al establecer la fecha:'
-    setGroupSizeError: 'No se pudo establecer el tamaño del grupo:'
-    setPaymentError: 'Error al configurar la información de pago:'
-  user:
-    accountDeleted: El ({email}) de su cuenta de usuario ha sido eliminado.
-    authTokenError: Error al obtener un token de autorización.
-    confirmDeleteMonitoredTrip: ¿Desea eliminar este viaje?
-    confirmDeletePlace: ¿Quiere eliminar este lugar?
-    emailVerificationResent: El mensaje de verificación de correo electrónico ha sido
-      reenviado.
-    genericError: 'Se ha encontrado un error: {err}'
-    itineraryExistenceCheckFailed: Comprobación de errores para ver si el viaje seleccionado
-      es posible.
-    preferencesSaved: Sus preferencias se han guardado.
-    smsInvalidCode: El código introducido no es válido. Por favor, inténtelo de nuevo.
-    smsResendThrottled: Se ha enviado un SMS de verificación al número de teléfono
-      indicado hace menos de un minuto. Por favor, inténtelo de nuevo en unos momentos.
-    smsVerificationFailed: Su teléfono no ha podido ser verificado. Quizás el código
-      que has introducido ha caducado. Solicita un nuevo código e inténtalo de nuevo.
+    addNoteError: "Error al agregar la nota de campo:"
+    confirmOverwriteItineraries: |
+      Esta acción anulará un itinerario {outbound, select,
+        true {saliente}
+        other {entrante}
+        } previamente planificado para esta solicitud. ¿Deseas continuar?
+    deleteItinerariesError: "Error al eliminar el plan de viaje:"
+    deleteNoteError: "Error al eliminar nota de viaje:"
+    editSubmitterNotesError: "Error al editar las notas del remitente:"
+    fetchFieldTripError: "Error al obtener el viaje: {err}"
+    fetchFieldTripsError: "Error al obtener viajes: {err}"
+    fetchTripsForDateError: "Error al obtener viajes para la fecha de viaje: {err}"
+    incompatibleTripDateError: >-
+      La fecha de viaje planificada ({tripDate}) no es el día de viaje
+      solicitado ({requestDate})
+    itineraryCapacityError: >-
+      No se puede guardar el plan: este plan no se pudo guardar debido a la
+      falta de capacidad en uno o más vehículos. Por favor, vuelva a planificar
+      su viaje.
+    maxTripRequestsExceeded: Número de solicitudes de viaje superadas sin resultados válidos
+    saveItinerariesError: "No se pudieron guardar los itinerarios: {err}"
+    setDateError: "Error al establecer la fecha:"
+    setGroupSizeError: "No se pudo establecer el tamaño del grupo:"
+    setPaymentError: "Error al configurar la información de pago:"
+    setRequestStatusError: "Error al establecer el estado de la solicitud:"
   location:
     geolocationNotSupportedError: Su navegador no admite la geolocalización
     unknownPositionError: Error desconocido al obtener la posición
   map:
     currentLocation: (Ubicación actual)
-  callTaker:
-    callQuerySaveError: 'Error al almacenar consultas de llamadas: {err}'
-    callSaveError: 'No se pudo guardar la llamada: {err}'
-    checkSessionError: 'Error al establecer la sesión de autorización: {err}'
-    couldNotFindCallError: No se pudo encontrar la llamada. Estamos cancelando la
-      solicitud de guardar consultas.
-    fetchCallsError: 'Error al obtener llamadas: {err}'
-    queryFetchError: 'Error al obtener consultas: {err}'
-components:
-  BatchResultsScreen:
-    expandMap: Ampliar el mapa
-    showResults: Mostrar resultados
-  BatchRoutingPanel:
-    shortTitle: Planificar viaje
-  BatchSearchScreen:
-    header: Planifique su viaje
-  BatchSettings:
-    planTripTooltip: Planificar viaje
-    validationMessage: 'Por favor, defina los siguientes campos para planificar un
-      viaje: {issues}'
-    destination: destino
-    origin: origen
-    settings: Preferencias de viaje
-    modeSelector: Selector de modos
-  BeforeSignInScreen:
-    mainTitle: Iniciando sesión
-    message: "Para acceder a esta página deberá iniciar sesión. Por favor, espere\
-      \ mientras le redirigimos a la página de inicio de sesión…\n"
-  DateTimeOptions:
-    now: Ahora
-    arriveBy: Llegada por
-    departAt: Salida a las
-  DateTimePreview:
-    arriveAt: Llegada {arriveTime, time, short}
-    dayLastWeek: El {formattedDayOfWeek} pasado
-    departAt: Salida {departTime, time, short}
-    editDepartOrArrival: Editar la hora de salida o de llegada
-    leaveNow: Salir ahora
-    range: '{startTime, time, short} a {endTime, time, short}'
-  ErrorMessage:
-    warning: Advertencia
-    header: No se pudo planificar el viaje
-  ExistingAccountDisplay:
-    a11y: Accesibilidad
-    mainTitle: Mis ajustes
-    notifications: Notificaciones
-    places: Lugares favoritos
-    terms: Términos
-  ItinerarySummary:
-    itineraryDetails: Detalles del itinerario
-    minMaxFare: "{minTotalFare} - {maxTotalFare}"
-  MapLayers:
-    bike-rental: '{companies} Bicicleta Compartida'
-    car-rental: Ubicaciones de los coches de alquiler
-    micromobility-rental: '{companies} Scooters eléctrico'
-    park-and-ride: Ubicaciones de Park & Ride
-    satellite: Satélite
-    shared-vehicles: "Vehículos compartidos"
-    stops: Paradas de tránsito
-    streets: Calles
-  ModeDropdown:
-    exclusiveMode: Solo {mode}
-  NarrativeItinerariesHeader:
-    changeSortDir: Cambiar la dirección de clasificación
-    itinerariesAndIssues: '{itinerariesFound} y {numIssues}'
-    itinerariesFound: '{itineraryNum, plural, one {# itinerario encontrado} other
-      {# itinerarios encontrados}}'
-    numIssues: '{issueNum, plural, one {# problema} other {# problemas}}'
-    searching: Encontrando sus opciones…
-    selectArrivalTime: Hora de llegada
-    selectBest: La mejor opción
-    selectCost: Costo
-    selectDepartureTime: Hora de salida
-    selectDuration: Duración
-    selectWalkTime: Tiempo de caminata
-    sortBy: Ordenar por
-    viewAll: Ver todas las opciones
-  NewAccountWizard:
-    finish: ¡Configuración de la cuenta completa!
-    notifications: Preferencias de notificación
-    places: Añade tus ubicaciones
-    terms: Crear una nueva cuenta
-    verify: Verifique su dirección de correo electrónico
-  NotFound:
-    description: El contenido que ha solicitado no está disponible.
-    header: No se encontró el contenido
-  NotificationPrefsPane:
-    description: Puede recibir notificaciones sobre los viajes que realiza con frecuencia.
-    noneSelect: No enviar notificaciones
-    notificationChannelPrompt: ¿Cómo desea recibir las notificaciones?
-    notificationEmailDetail: 'Los correos electrónicos de notificación se enviarán
-      a:'
-  PhoneNumberEditor:
-    changeNumber: Cambiar número de teléfono
-    invalidCode: Introduzca 6 dígitos para el código de validación.
-    invalidPhone: Por favor, introduzca un número de teléfono válido.
-    pending: Pendiente
-    placeholder: Introduzca su número de teléfono
-    prompt: 'Introduzca su número de teléfono para las notificaciones por mensaje
-      de texto:'
-    requestNewCode: Solicitar un nuevo código
-    sendVerificationText: Enviar texto de verificación
-    smsDetail: 'Las notificaciones por mensaje de texto se enviarán a:'
-    verificationCode: 'Código de verificación:'
-    verificationInstructions: "Por favor, compruebe en la aplicación de mensajería\
-      \ de texto de su teléfono móvil si hay un mensaje de texto con un código de\
-      \ verificación, e introduzca el código que aparece a continuación. El código\
-      \ caduca a los 10 minutos.\n"
-    verified: Verificado
-    verify: Verificar
-    phoneNumberSubmitted: El número de teléfono {phoneNumber} se ha enviado correctamente.
-    phoneNumberVerified: El número de teléfono {phoneNumber} se ha verificado correctamente.
-  Place:
-    deleteThisPlace: Borrar este lugar
-    enterAlert: "Introduzca el origen/destino en el formulario (o establezca mediante\
-      \ un clic en el mapa) y haga clic en el marcador resultante para establecerlo\
-      \ como lugar de {placeType}.\n"
-    viewStop: Ver parada
-  PlanFirstLastButtons:
-    first: Primero
-    last: Último
-    next: Próximo
-    previous: Anterior
-  PlanTripButton:
-    planTrip: Planificar viaje
-  PrintLayout:
-    itinerary: Itinerario
-    toggleMap: Alternar el mapa
-  RealtimeAnnotation:
-    serviceUpdate: Actualización del servicio
-    delaysShownInResults: "Los resultados de su viaje se han ajustado en base a información\
-      \ en tiempo real. En condiciones normales, este viaje duraría {normalDuration}\
-      \ utilizando las siguientes rutas: {routes}.\n"
-  RealtimeStatusLabel:
-    early: '{minutes} antes'
-    late: '{minutes} de retraso'
-    onTime: a tiempo
-    scheduled: programado
-  RelatedPanel:
-    hideExtraStops: Ocultar las paradas adicionales
-    showExtraStops: Mostrar {count} paradas adicionales
-  RelatedStopsPanel:
-    noArrivalFound: No se ha encontrado ninguna llegada
-    relatedStops: Paradas relacionadas
-    viewDetails: Ver detalles
-  RouteDetails:
-    moreDetails: Más detalles
-    operatedBy: Servicio operado por {agencyName}
-    selectADirection: Seleccione una dirección…
-    stopsTo: Hacia
-  RouteViewer:
-    agencyFilter: Filtro de agencia
-    allAgencies: Todas las agencias
-    allModes: Todos los modos
-    details: ' '
-    findARoute: Buscar una ruta
-    header: Visor de rutas
-    modeFilter: Filtro de modo
-    noFilteredRoutesFound: ¡No hay rutas que coincidan con tu filtro!
-    shortTitle: Ver rutas
-    title: Visor de rutas
-    stopsInDirectionOfTravel: 'Paradas en este sentido de la marcha:'
-    toggleRouteOnMap: Cambiar la ruta en el mapa
-    openPatternViewer: Ver los detalles de la ruta
-  SavedTripEditor:
-    editSavedTrip: Editar el viaje guardado
-    saveNewTrip: Guardar un nuevo viaje
-    tripNotifications: Notificaciones de viaje
-    tripInformation: Información sobre el viaje
-    tripNotFound: No se encontró el viaje
-    tripNotFoundDescription: Lo sentimos, no se encontró el viaje solicitado.
-  SavedTripList:
-    fromTo: 'De {from} al {to}'
-    myTrips: Mis viajes
-    noSavedTrips: No tiene viajes guardados
-    noSavedTripsInstructions: Realice primero una búsqueda de viajes desde el mapa.
-    pause: Pausa
-    resume: Reanudar
-  SavedTripScreen:
-    tooManyTrips: "Ya ha alcanzado el máximo de cinco viajes guardados. Por favor,\
-      \ elimine los viajes no utilizados de sus viajes guardados e inténtelo de nuevo.\n"
-    tripNameAlreadyUsed: Otro viaje guardado ya utiliza este nombre. Por favor, elija
-      un nombre diferente.
-    tripNameRequired: Por favor, introduzca el nombre del viaje.
-  SaveTripButton:
-    cantSaveText: No se puede guardar
-    cantSaveTooltip: Sólo se pueden controlar los itinerarios que incluyan ride hailing
-      y no los alquileres o los viajes en coche.
-    saveTripText: Salvar el viaje
-    signInTooltip: Por favor, inicie sesión para guardar un viaje.
-    signInText: Iniciar sesión para guardar el viaje
-  SettingsPreview:
-    defaultPreviewText: "Opciones\ny Preferencias del viaje"
-  StopViewer:
-    displayStopId: '<strong>Parada n°</strong>{stopId}'
-    flexStop: Esta es una parada flexible. Los vehículos dejarán y recogerán a los
-      pasajeros en esta zona flexible previa solicitud. Es posible que tenga que llamar
-      con antelación para el servicio en esta zona.
-    header: Visor de paradas
-    loadingText: Cargando la parada...
-    noStopsFound: No se han encontrado tiempos de parada para la fecha.
-    operatorLogoAriaLabel: "Parada de {operatorName}:"
-    timezoneWarning: Las horas de salida se indican en <strong>{timezoneCode}</strong>.
-    titleBarStopId: Parada {stopId}
-    viewNextArrivals: Ver próximas llegadas
-    viewSchedule: Ver horario
-    zoomToStop: Acercar vista a la parada
-    schedule: Horario
-    nextArrivals: Próximas llegadas
-    findSchedule: Buscar horario por fecha
-  TransitVehicleOverlay:
-    in_transit_to: 'Próxima parada: {stop}'
-    incoming_at: 'Acercándose a: {stop}'
-    stopped_at: Puertas abiertas en la {stop}
-    travelingAt: Viajando a {milesPerHour}
-    vehicleName: 'Vehículo {vehicleNumber}'
-  TripBasicsPane:
-    checkingItineraryExistence: Comprobación de la existencia de itinerarios para
-      cada día de la semana…
-    selectAtLeastOneDay: Por favor, seleccione al menos un día para el seguimiento.
-    tripDaysPrompt: ¿Qué días hace este viaje?
-    tripIsAvailableOnDaysIndicated: Su viaje está disponible en los días de la semana
-      indicados anteriormente.
-    tripNamePrompt: 'Por favor, indique un nombre para este viaje:'
-    tripNotAvailableOnDay: El viaje no está disponible el {repeatedDay}
-    unsavedChangesExistingTrip: Todavía no ha guardado su viaje. Si abandona la página,
-      los cambios se perderán.
-    unsavedChangesNewTrip: Todavía no ha guardado su nuevo viaje. Si abandona la página,
-      se perderá.
-  TripNotificationsPane:
-    advancedSettings: Configuración avanzada
-    altRouteRecommended: Se recomienda una ruta alternativa o un punto de transferencia
-    delaysAboveThreshold: Hay retrasos o interrupciones de más de
-    howToReceiveAlerts: "Para recibir alertas de tus viajes guardados, activa las\
-      \ notificaciones en la configuración de tu cuenta e intenta guardar un viaje\
-      \ de nuevo.\n"
-    monitorThisTrip: 'Supervise este viaje antes de que comience:'
-    notificationsTurnedOff: Las notificaciones están desactivadas para su cuenta.
-    notifyViaChannelWhen: 'Notifíqueme por {channel} cuando:'
-    oneHour: 1 hora
-    realtimeAlertFlagged: Hay una alerta en tiempo real marcada en mi viaje
-    timeBefore: '{time} antes'
-  TripStatus:
-    alerts: '{alerts, plural, one {# alerta!} other {# alertas!}}'
-    deleteTrip: Borrar el viaje
-    planNewTrip: Planificar un nuevo viaje
-  TripStatusRenderers:
-    active:
-      delayedHeading: La hora de inicio del viaje se retrasa {formattedDuration}!
-      description: El viaje debe comenzar a las {arrivalTime, time, short}.
-      onTimeHeading: El viaje está en curso y está más o menos a tiempo.
-      earlyHeading: ¡El viaje está en marcha y llega {formattedDuration} antes de
-        lo previsto!
-      noDataHeading: El viaje está en curso (no hay actualizaciones disponibles en
-        tiempo real).
-    base:
-      lastCheckedDefaultText: Hora de la última comprobación desconocida
-      lastCheckedText: 'Últimos comprobados: Hace {formattedDuration}'
-      togglePause: Pausa
-      tripIsNotSnoozed: Pausar para el resto del día
-      tripIsSnoozed: Reactivar el análisis de los viajes
-      unknownState: Estado de viaje desconocido
-      untogglePause: Reanudar
-    nextTripNotPossible:
-      description: "El planificador de viajes no ha podido encontrar su viaje hoy.\
-        \ Intente volver a planificar su itinerario para encontrar una ruta alternativa.\n"
-      heading: El viaje no es posible hoy
-    snoozed:
-      heading: El seguimiento del viaje se ha suspendido por hoy
-      description: Reactivar la supervisión del viaje para ver el estado actualizado.
-    upcoming:
-      tripBegins: El viaje debe comenzar a las {tripStart, time, short}. (El seguimiento
-        en tiempo real comenzará a las {monitoringStart, time, short}.)
-      tripStartsSoonNoUpdates: El viaje comienza pronto (no hay actualizaciones disponibles
-        en tiempo real).
-      tripStartsSoonOnTime: El viaje comienza pronto y es más o menos puntual.
-      nextTripBegins: El próximo viaje comienza el {tripDatetime, date, ::eeeee yyyyMMdd}
-        a las {tripDatetime, time, short}.
-      tripStartIsDelayed: ¡La hora de inicio del viaje se retrasa ${duration}!
-      tripStartIsEarly: ¡La hora de inicio del viaje se produce ${duration} antes
-        de lo previsto!
-    inactive:
-      description: Reanudar la supervisión del viaje para ver el estado actualizado
-      heading: La supervisión del viaje está en pausa
-    notCalculated:
-      awaiting: Esperando el cálculo…
-      description: Por favor, espere un poco para calcular el viaje.
-      heading: Viaje aún no calculado
-    noLongerPossible:
-      description: "El planificador de viajes no pudo encontrar su viaje en ninguno\
-        \ de los días seleccionados de la semana. Intente volver a planificar su itinerario\
-        \ para encontrar una ruta alternativa.\n"
-      heading: El viaje ya no es posible
-  TripSummaryPane:
-    notifications: 'Notificaciones: <strong>{leadTimeInMinutes} minutos antes de la
-      salida programada</strong>'
-    happensOnDays: 'Ocurre en: <strong>{days}</strong>'
-    notificationsDisabled: 'Notificaciones: <strong>Disabled</strong>'
-  TripTools:
-    copyLink: Copiar enlace
-    linkCopied: Copiado
-    reportEmailSubject: Informar un problema con OpenTripPlanner
-    reportEmailTemplate: "*** INSTRUCCIONES PARA EL USUARIO ***\nEste correo electrónico\
-      \ informará de su problema a los administradores de esta página.\nComplete los\
-      \ detalles a continuación, luego envíe un correo electrónico desde su software\
-      \ de correo electrónico habitual.\n\n*** POR FAVOR COMPLETE MAS ABAJO ***\n\n\
-      Problema encontrado:\n\nTipo de viaje buscado (por ejemplo, a pie + transporte,\
-      \ bicicleta + transporte, coche + transporte):\n\n*** DETALLES TÉCNICOS ***\n"
-    reportIssue: Reportar un problema
-  TripViewer:
-    accessible: Accesible
-    bicyclesAllowed: Permitido
-    header: Visor de viajes
-    routeHeader: 'Ruta: <strong>{routeShortName}</strong> {routeLongName}'
-    viewStop: Ver
-    endOfTrip: El viaje acaba aquí
-    startOfTrip: Aquí comienza el viaje
-    tripDescription: Embarque en {boardAtStop} y desembarque en {disembarkAtStop}
-    listOfRouteStops: Lista de paradas en esta ruta
-  UserAccountScreen:
-    confirmDelete: ¿Está seguro de que desea eliminar su cuenta de usuario? Una vez
-      que lo haga, no se podrá recuperar.
-  UserSettings:
-    confirmDeletion: Tiene almacenadas búsquedas o lugares recientes. Si desactiva
-      el almacenamiento de lugares o búsquedas recientes, eliminará estos elementos.
-      ¿Continuar?
-    favoriteStops: Paradas favoritas
-    myPreferences: Mis preferencias
-    mySavedPlaces: Mis lugares guardados (<manageLink>Administrar</manageLink>)
-    noFavoriteStops: No hay paradas favoritas
-    recentPlaces: Lugares recientes
-    recentSearches: Búsquedas recientes
-    recentSearchSummary: '{mode} de {from} al {to}'
-    rememberSearches: ¿Recordar las búsquedas/lugares recientes?
-    stopId: 'ID de Parada: {stopId}'
-    storageDisclaimer: "Cualquier preferencia, lugar o configuración que opte por\
-      \ guardar se guardará en el almacenamiento local de su navegador. No tendremos\
-      \ acceso al conocimiento de su casa, trabajo o cualquier otra ubicación. En\
-      \ cualquier momento puedes optar por desactivar el recuerdo de lugares o búsquedas\
-      \ recientes y borrar las ubicaciones de casa o del trabajo y las paradas favoritas\
-      \ guardadas.\n"
-  UserTripSettings:
-    forgetOptions: Olvidar mis opciones
-    rememberOptions: Recordar las opciones de viaje
-    restoreDefaults: Restaurar los valores predeterminados
-    restoreMyDefaults: Restaurar mis valores predeterminados
-  VerifyEmailPane:
-    emailIsVerified: ¡Mi correo electrónico está verificado!
-    instructions1: "Por favor compruebe el buzón de su correo electrónico y siga el\
-      \ enlace del mensaje para verificar su dirección de correo electrónico antes\
-      \ de finalizar la configuración de su cuenta.\n"
-    instructions2: Una vez verificado, haga clic en el botón de abajo para continuar.
-    resendVerification: Reenviar el correo electrónico de verificación
-  A11yPrefs:
-    accessibilityRoutingByDefault: Prefiera los viajes accesibles por defecto
-  AmenitiesPanel:
-    bikesAtStation: "{companyLength, plural,\n =0 {Bicicletas en la {name}}\n other\
-      \ {Bicicletas de {company} en la{name}}\n }\n"
-    bikesAvailable: "{count, plural,\n =0 {No hay bicicletas disponibles}\n one {#\
-      \ bicicleta disponible}\n other {# bicicletas disponibles}\n }\n"
-    bikesNearby: "{count, plural,\n =0 {No hay bicicletas de {company} cerca}\n one\
-      \ {# bicicleta de {company} cerca}\n other {#bicicletas de {company} cerca}\n\
-      \ }\n"
-    nearbyAmenities: Servicios cercanos
-    noNearbyScooters: No se encontraron alquileres de micromovilidad cerca.
-    noPRLotsFound: No hay Park-and-Ride cerca.
-    noNearbyBikes: No se ha encontrado ningún alquiler de bicicletas cercano.
-    scootersNearby: "{count, plural,\n =0 {No hay e-scooters de {company} cerca}\n\
-      \ one {# e-scooter de {company} cerca}\n other {# e-scooters de {company} cerca}\n\
-      \ }\n"
-    spacesAvailable: "{count, plural,\n =0 {No hay plazas de aparcamiento disponibles}\n\
-      \ one {# plaza de aparcamiento disponible}\n other {# plazas de aparcamiento\
-      \ disponibles}\n }\n"
-  AppMenu:
-    callHistory: Historial de llamadas
-    closeMenu: Cerrar Menú
-    fieldTrip: Título del viaje
-    mailables: Lista para publicar
-    openMenu: Abrir Menú
-    skipNavigation: Saltar navegación
-  BackToTripPlanner:
-    backToTripPlanner: Volver al planificador de viajes
-  CallTakerPanel:
-    advancedOptions: Opciones avanzadas
-    intermediateDestination: Introducir destino intermedio
-    groupSize: 'Tamaño del grupo:'
-  EnhancedStopMarker:
-    stopViewer: Visor de paradas
-    stopID: 'Parada:'
-  FavoritePlaceList:
-    addAnotherPlace: Agregue otro lugar
-    description: 'Agregue los lugares que frecuenta a menudo para ahorrar tiempo en
-      la planificación de los viajes:'
-    editThisPlace: Editar este lugar
-    setAddressForPlaceType: Establezca su dirección de {placeType}
-  FavoritePlaceScreen:
-    addNewPlace: Agregar un nuevo lugar
-    editPlace: Editar {placeName}
-    editPlaceGeneric: Editar lugar
-    invalidAddress: Por favor, establezca una ubicación para este lugar.
-    invalidName: Por favor, introduzca un nombre para este lugar.
-    nameAlreadyUsed: Ya está utilizando este nombre para otro lugar. Por favor, introduzca
-      un nombre diferente.
-    placeNotFound: No se encontró el lugar
-    placeNotFoundDescription: Lo sentimos, no se encontró el lugar solicitado.
-  FormNavigationButtons:
-    ariaLabel: Navegar por los formularios
-  LiveStopTimes:
-    autoRefresh: ¿Actualizar automáticamente las llegadas?
-    refresh: Actualizar las horas de llegada
-  LocationSearch:
-    enterLocation: Introduzca la ubicación
-    setDestination: Establecer el destino
-    setOrigin: Establecer el origen
-  MetroUI:
-    arriveAtTime: Llegar a {time}
-    fromStop: de {stop}
-    itineraryDescription: '{time} itinerario en {routes}'
-    leaveAt: Su salida
-    multipleOptions: Múltiples Opciones
-    orAlternatives: u otras rutas en la misma dirección
-    timeWalking: '{time} caminando'
-    originallyScheduledTime: (originalmente {originalTime})
-    arriveAt: Llegaste
-    singleModeItineraryDescription: Viaja {time} {mode}
-  MobileOptions:
-    header: Configurar las opciones de búsqueda
-  NavLoginButton:
-    help: Ayuda
-    myAccount: Mi cuenta
-    signIn: Acceder
-    signOut: Firmar la salida
-  PlaceEditor:
-    genericLocationPlaceholder: Buscar ubicación
-    locationPlaceholder: Buscar la ubicación de {placeName}
-    addressPrompt: 'Dirección:'
-    locationTypePrompt: 'Tipo de ubicación:'
-    namePrompt: 'Nombre del lugar:'
-    nameExample: Mi cafetería
-  ResultsError:
-    backToSearch: Volver a la búsqueda
-  ResultsHeader:
-    noTripFound: No se encontró ningún viaje
-    tripsFound: Encontramos {count, plural, one {# opción} other {# opciones}}
-    waiting: Espera...
-  SimpleRealtimeAnnotation:
-    usingRealtimeInfo: Este viaje utiliza información de tráfico y retrasos en tiempo
-      real
-  StackedPaneDisplay:
-    savePreferences: Guardar preferencias
-  StopScheduleTable:
-    block: Bloquear
-    departure: Salida
-    destination: A
-    route: 'Ruta'
-  StopTimeCell:
-    realtime: Datos basados en el tiempo real
-    scheduled: Basado en los datos del programa
-    imminentArrival: Vencido
-  SubNav:
-    languages: "Idiomas"
-    languageSelector: Seleccionar idioma
-    myAccount: Mi cuenta
-    selectALanguage: Seleccionar un idioma
-    settings: Ajustes
-    trips: Viajes
-    userMenu: Opciones de perfil
-  SwitchButton:
-    switchLocations: Cambiar de ubicación
-    defaultContent: Cambiar
-  TripSummary:
-    arriveAt: "Llegue a las "
-    leaveAt: "Salida a las "
-  ViewSwitcher:
-    switcher: Botón de cambio
-  WelcomeScreen:
-    prompt: ¿A donde quiere ir?
-  TermsOfUsePane:
-    confirmDeletionPrompt: "Eliminar su consentimiento para el almacenamiento de viajes\
-      \ históricos hará que se elimine su historial de viajes. ¿Está seguro que desea\
-      \ continuar?\n"
-    termsOfServiceStatement: "Confirmo que tengo al menos 18 años y que he leído y\
-      \ acepto los <termsOfUseLink>Términos de servicio</termsOfUseLink> para usar\
-      \ el Planificador de viajes.\n"
-    termsOfStorageStatement: "Opcional: Doy mi consentimiento para que Trip Planner\
-      \ almacene mis viajes planificados históricos para mejorar los servicios de\
-      \ tránsito en mi área. <termsOfStorageLink>Más información...</termsOfStorageLink>\n"
-    mustAgreeToTerms: Debe aceptar los términos de servicio para continuar.
-  AccountSetupFinishPane:
-    message: Ya está listo para empezar a planificar sus viajes.
-  AddPlaceButton:
-    addPlace: Añadir lugar
-    needOriginDestination: Definir el origen o el destino para añadir lugares intermedios
-    tooManyPlaces: Se alcanzó el máximo de lugares intermedios
-  AdvancedOptions:
-    bannedRoutes: Seleccionar rutas prohibidas…
-    maxBike: Máx de bicicleta {unitsString}
-    maxWalk: Máx caminando {unitsString}
-    preferredRoutes: Seleccionar rutas preferidas…
-    walkReluctance: Evasión de caminata
-  AfterSignInScreen:
-    mainTitle: Redirigiendo…
-    message: Si la página no se carga después de unos segundos, <redirectLink>haga
-      clic aquí</redirectLink>.
-  DateTimeScreen:
-    header: Fijar fecha/hora
-  DefaultItinerary:
-    clickDetails: Haga clic para ver los detalles
-    multiModeSummary: '{accessMode} + {transitMode}'
-    nonTransit: Alternativas
-  DeleteUser:
-    deleteMyAccount: Eliminar mi cuenta
-  SessionTimeout:
-    body: Su sesión expirará en un minuto. Pulse 'Continuar sesión' para mantener
-      su búsqueda.
-    header: ¡La sesión está a punto de terminar!
-    keepSession: Continuar sesión
-  PointPopup:
-    zoomToLocation: Acercar vista a la ubicación
-  MapillaryFrame:
-    title: Imágenes de la calle
+  user:
+    accountDeleted: El ({email}) de su cuenta de usuario ha sido eliminado.
+    authTokenError: Error al obtener un token de autorización.
+    confirmDeleteMonitoredTrip: ¿Desea eliminar este viaje?
+    confirmDeletePlace: ¿Quiere eliminar este lugar?
+    emailVerificationResent: El mensaje de verificación de correo electrónico ha sido reenviado.
+    genericError: "Se ha encontrado un error: {err}"
+    itineraryExistenceCheckFailed: Comprobación de errores para ver si el viaje seleccionado es posible.
+    preferencesSaved: Sus preferencias se han guardado.
+    smsInvalidCode: El código introducido no es válido. Por favor, inténtelo de nuevo.
+    smsResendThrottled: >-
+      Se ha enviado un SMS de verificación al número de teléfono indicado hace
+      menos de un minuto. Por favor, inténtelo de nuevo en unos momentos.
+    smsVerificationFailed: >-
+      Su teléfono no ha podido ser verificado. Quizás el código que has
+      introducido ha caducado. Solicita un nuevo código e inténtalo de nuevo.
 common:
-  coordinates: '{lat}; {lon}'
+  coordinates: "{lat}; {lon}"
   dateExpressions:
     today: Hoy
     tomorrow: Mañana
     yesterday: Ayer
   daysOfWeek:
-    monday: Lunes
     friday: Viernes
+    monday: Lunes
     saturday: Sábado
     sunday: Domingo
     thursday: Jueves
@@ -605,43 +73,44 @@ common:
     wednesday: Miércoles
   daysOfWeekCompact:
     friday: Vie.
+    monday: Lun.
     saturday: Sáb.
     sunday: Dom.
-    monday: Lun.
     thursday: Jue.
     tuesday: Mar.
     wednesday: Mié.
   daysOfWeekPlural:
     friday: Viernes
+    monday: Lunes
     saturday: Sábados
     sunday: Domingos
-    monday: Lunes
     thursday: Jueves
     tuesday: Martes
     wednesday: Miércoles
   forms:
-    finish: Finalizar
-    next: Siguiente
-    no: No
-    print: Imprimir
-    save: Guardar
-    yes: Sí
     back: Atrás
     cancel: Cancelar
     close: Cerrar
-    defaultValue: '{value} (por defecto)'
+    defaultValue: "{value} (por defecto)"
     delete: Borrar
     edit: Editar
     error: ¡error!
+    finish: Finalizar
+    next: Siguiente
+    "no": "No"
+    print: Imprimir
+    save: Guardar
     startOver: Comenzar de nuevo
     submitting: Enviando…
+    "yes": Sí
   itineraryDescriptions:
-    calories: '{calories, number} kcal'
+    calories: "{calories, number} kcal"
     noItineraryToDisplay: No hay itinerario que mostrar.
     noTransitFareProvided: Sin información sobre las tarifas
-    transfers: '{transfers, plural, =0 {} one {# transferencia} other {# transferencias}}'
     relativeCo2: >
-      {co2} de CO₂ en {isMore, select, true {más} other {menos} } que conducir solo
+      {co2} de CO₂ en {isMore, select, true {más} other {menos} } que conducir
+      solo
+    transfers: "{transfers, plural, one {# transferencia} other {# transferencias}}"
   modes:
     bicycle_rent: Compartir bicicleta
     bike: Bicicleta
@@ -665,6 +134,11 @@ common:
   notifications:
     email: correo electrónico
     sms: Mensaje de texto
+  places:
+    custom: personalizado
+    dining: restaurante
+    home: residencia
+    work: trabajo
   routing:
     routeAndNumber: Ruta {routeId}
     routeToHeadsign: A {headsign}
@@ -674,47 +148,615 @@ common:
     enterStartLocation: Introduzca la ubicación de inicio o {mapAction} en el mapa…
     tap: toque
   time:
-    departureArrivalTimes: '{startTime, time, short}—{endTime, time, short}'
+    departureArrivalTimes: "{startTime, time, short}—{endTime, time, short}"
     duration:
       aFewSeconds: unos segundos
       nDays: "{days, plural, =1 {un día} other {# días}}"
       nHours: "{hours, plural, =1 {una hora} other {# horas}}"
       nMinutes: "{minutes, plural, =1 {un minuto} other {# minutos}}"
-    durationAgo: "hace {duration}"
-    tripDurationFormat: "{hours, plural, =0 {} other {# h }}{minutes} min { seconds,\
-      \ plural, =0 {} other {# s}}"
-  places:
-    custom: personalizado
-    dining: restaurante
-    home: residencia
-    work: trabajo
+    durationAgo: hace {duration}
+    tripDurationFormat: >-
+      {hours, plural, =0 {} other {# h }}{minutes} min { seconds, plural, =0 {}
+      other {# s}}
+components:
+  A11yPrefs:
+    accessibilityRoutingByDefault: Prefiera los viajes accesibles por defecto
+  AccountSetupFinishPane:
+    message: Ya está listo para empezar a planificar sus viajes.
+  AddPlaceButton:
+    addPlace: Añadir lugar
+    needOriginDestination: Definir el origen o el destino para añadir lugares intermedios
+    tooManyPlaces: Se alcanzó el máximo de lugares intermedios
+  AdvancedOptions:
+    bannedRoutes: Seleccionar rutas prohibidas…
+    maxBike: Máx de bicicleta {unitsString}
+    maxWalk: Máx caminando {unitsString}
+    preferredRoutes: Seleccionar rutas preferidas…
+    walkReluctance: Evasión de caminata
+  AfterSignInScreen:
+    mainTitle: Redirigiendo…
+    message: >-
+      Si la página no se carga después de unos segundos, <redirectLink>haga clic
+      aquí</redirectLink>.
+  AmenitiesPanel:
+    bikesAtStation: |
+      {companyLength, plural,
+       =0 {Bicicletas en la {name}}
+       other {Bicicletas de {company} en la{name}}
+       }
+    bikesAvailable: |
+      {count, plural,
+       =0 {No hay bicicletas disponibles}
+       one {# bicicleta disponible}
+       other {# bicicletas disponibles}
+       }
+    bikesNearby: |
+      {count, plural,
+       =0 {No hay bicicletas de {company} cerca}
+       one {# bicicleta de {company} cerca}
+       other {#bicicletas de {company} cerca}
+       }
+    nearbyAmenities: Servicios cercanos
+    noNearbyBikes: No se ha encontrado ningún alquiler de bicicletas cercano.
+    noNearbyScooters: No se encontraron alquileres de micromovilidad cerca.
+    noPRLotsFound: No hay Park-and-Ride cerca.
+    scootersNearby: |
+      {count, plural,
+       =0 {No hay e-scooters de {company} cerca}
+       one {# e-scooter de {company} cerca}
+       other {# e-scooters de {company} cerca}
+       }
+    spacesAvailable: |
+      {count, plural,
+       =0 {No hay plazas de aparcamiento disponibles}
+       one {# plaza de aparcamiento disponible}
+       other {# plazas de aparcamiento disponibles}
+       }
+  AppMenu:
+    callHistory: Historial de llamadas
+    closeMenu: Cerrar Menú
+    fieldTrip: Título del viaje
+    mailables: Lista para publicar
+    openMenu: Abrir Menú
+    skipNavigation: Saltar navegación
+  BackToTripPlanner:
+    backToTripPlanner: Volver al planificador de viajes
+  BatchResultsScreen:
+    expandMap: Ampliar el mapa
+    showResults: Mostrar resultados
+  BatchRoutingPanel:
+    shortTitle: Planificar viaje
+  BatchSearchScreen:
+    header: Planifique su viaje
+  BatchSettings:
+    destination: destino
+    modeSelector: Selector de modos
+    origin: origen
+    planTripTooltip: Planificar viaje
+    settings: Preferencias de viaje
+    validationMessage: "Por favor, defina los siguientes campos para planificar un viaje: {issues}"
+  BeforeSignInScreen:
+    mainTitle: Iniciando sesión
+    message: >
+      Para acceder a esta página deberá iniciar sesión. Por favor, espere
+      mientras le redirigimos a la página de inicio de sesión…
+  CallTakerPanel:
+    advancedOptions: Opciones avanzadas
+    groupSize: "Tamaño del grupo:"
+    intermediateDestination: Introducir destino intermedio
+  DateTimeOptions:
+    arriveBy: Llegada por
+    departAt: Salida a las
+    now: Ahora
+  DateTimePreview:
+    arriveAt: Llegada {arriveTime, time, short}
+    dayLastWeek: El {formattedDayOfWeek} pasado
+    departAt: Salida {departTime, time, short}
+    editDepartOrArrival: Editar la hora de salida o de llegada
+    leaveNow: Salir ahora
+    range: "{startTime, time, short} a {endTime, time, short}"
+  DateTimeScreen:
+    header: Fijar fecha/hora
+  DefaultItinerary:
+    clickDetails: Haga clic para ver los detalles
+    multiModeSummary: "{accessMode} + {transitMode}"
+    nonTransit: Alternativas
+  DeleteUser:
+    deleteMyAccount: Eliminar mi cuenta
+  EnhancedStopMarker:
+    stopID: "Parada:"
+    stopViewer: Visor de paradas
+  ErrorMessage:
+    header: No se pudo planificar el viaje
+    warning: Advertencia
+  ExistingAccountDisplay:
+    a11y: Accesibilidad
+    mainTitle: Mis ajustes
+    notifications: Notificaciones
+    places: Lugares favoritos
+    terms: Términos
+  FavoritePlaceList:
+    addAnotherPlace: Agregue otro lugar
+    description: >-
+      Agregue los lugares que frecuenta a menudo para ahorrar tiempo en la
+      planificación de los viajes:
+    editThisPlace: Editar este lugar
+    setAddressForPlaceType: Establezca su dirección de {placeType}
+  FavoritePlaceScreen:
+    addNewPlace: Agregar un nuevo lugar
+    editPlace: Editar {placeName}
+    editPlaceGeneric: Editar lugar
+    invalidAddress: Por favor, establezca una ubicación para este lugar.
+    invalidName: Por favor, introduzca un nombre para este lugar.
+    nameAlreadyUsed: >-
+      Ya está utilizando este nombre para otro lugar. Por favor, introduzca un
+      nombre diferente.
+    placeNotFound: No se encontró el lugar
+    placeNotFoundDescription: Lo sentimos, no se encontró el lugar solicitado.
+  FormNavigationButtons:
+    ariaLabel: Navegar por los formularios
+  ItinerarySummary:
+    itineraryDetails: Detalles del itinerario
+    minMaxFare: "{minTotalFare} - {maxTotalFare}"
+  LiveStopTimes:
+    autoRefresh: ¿Actualizar automáticamente las llegadas?
+    refresh: Actualizar las horas de llegada
+  LocationSearch:
+    enterLocation: Introduzca la ubicación
+    setDestination: Establecer el destino
+    setOrigin: Establecer el origen
+  MapLayers:
+    bike-rental: "{companies} Bicicleta Compartida"
+    car-rental: Ubicaciones de los coches de alquiler
+    micromobility-rental: "{companies} Scooters eléctrico"
+    park-and-ride: Ubicaciones de Park & Ride
+    satellite: Satélite
+    shared-vehicles: Vehículos compartidos
+    stops: Paradas de tránsito
+    streets: Calles
+  MapillaryFrame:
+    title: Imágenes de la calle
+  MetroUI:
+    arriveAt: Llegaste
+    arriveAtTime: Llegar a {time}
+    fromStop: de {stop}
+    itineraryDescription: "{time} itinerario en {routes}"
+    leaveAt: Su salida
+    multipleOptions: Múltiples Opciones
+    orAlternatives: u otras rutas en la misma dirección
+    originallyScheduledTime: (originalmente {originalTime})
+    singleModeItineraryDescription: Viaja {time} {mode}
+    timeWalking: "{time} caminando"
+  MobileOptions:
+    header: Configurar las opciones de búsqueda
+  ModeDropdown:
+    exclusiveMode: Solo {mode}
+  NarrativeItinerariesHeader:
+    changeSortDir: Cambiar la dirección de clasificación
+    itinerariesAndIssues: "{itinerariesFound} y {numIssues}"
+    itinerariesFound: >-
+      {itineraryNum, plural, one {# itinerario encontrado} other {# itinerarios
+      encontrados}}
+    numIssues: "{issueNum, plural, one {# problema} other {# problemas}}"
+    searching: Encontrando sus opciones…
+    selectArrivalTime: Hora de llegada
+    selectBest: La mejor opción
+    selectCost: Costo
+    selectDepartureTime: Hora de salida
+    selectDuration: Duración
+    selectWalkTime: Tiempo de caminata
+    sortBy: Ordenar por
+    viewAll: Ver todas las opciones
+  NavLoginButton:
+    help: Ayuda
+    myAccount: Mi cuenta
+    signIn: Acceder
+    signOut: Firmar la salida
+  NewAccountWizard:
+    finish: ¡Configuración de la cuenta completa!
+    notifications: Preferencias de notificación
+    places: Añade tus ubicaciones
+    terms: Crear una nueva cuenta
+    verify: Verifique su dirección de correo electrónico
+  NotFound:
+    description: El contenido que ha solicitado no está disponible.
+    header: No se encontró el contenido
+  NotificationPrefsPane:
+    description: Puede recibir notificaciones sobre los viajes que realiza con frecuencia.
+    noneSelect: No enviar notificaciones
+    notificationChannelPrompt: ¿Cómo desea recibir las notificaciones?
+    notificationEmailDetail: "Los correos electrónicos de notificación se enviarán a:"
+  PhoneNumberEditor:
+    changeNumber: Cambiar número de teléfono
+    invalidCode: Introduzca 6 dígitos para el código de validación.
+    invalidPhone: Por favor, introduzca un número de teléfono válido.
+    pending: Pendiente
+    phoneNumberSubmitted: El número de teléfono {phoneNumber} se ha enviado correctamente.
+    phoneNumberVerified: El número de teléfono {phoneNumber} se ha verificado correctamente.
+    placeholder: Introduzca su número de teléfono
+    prompt: >-
+      Introduzca su número de teléfono para las notificaciones por mensaje de
+      texto:
+    requestNewCode: Solicitar un nuevo código
+    sendVerificationText: Enviar texto de verificación
+    smsDetail: "Las notificaciones por mensaje de texto se enviarán a:"
+    verificationCode: "Código de verificación:"
+    verificationInstructions: >
+      Por favor, compruebe en la aplicación de mensajería de texto de su
+      teléfono móvil si hay un mensaje de texto con un código de verificación, e
+      introduzca el código que aparece a continuación. El código caduca a los 10
+      minutos.
+    verified: Verificado
+    verify: Verificar
+  Place:
+    deleteThisPlace: Borrar este lugar
+    enterAlert: >
+      Introduzca el origen/destino en el formulario (o establezca mediante un
+      clic en el mapa) y haga clic en el marcador resultante para establecerlo
+      como lugar de {placeType}.
+    viewStop: Ver parada
+  PlaceEditor:
+    addressPrompt: "Dirección:"
+    genericLocationPlaceholder: Buscar ubicación
+    locationPlaceholder: Buscar la ubicación de {placeName}
+    locationTypePrompt: "Tipo de ubicación:"
+    nameExample: Mi cafetería
+    namePrompt: "Nombre del lugar:"
+  PlanFirstLastButtons:
+    first: Primero
+    last: Último
+    next: Próximo
+    previous: Anterior
+  PlanTripButton:
+    planTrip: Planificar viaje
+  PointPopup:
+    zoomToLocation: Acercar vista a la ubicación
+  PrintLayout:
+    itinerary: Itinerario
+    toggleMap: Alternar el mapa
+  RealtimeAnnotation:
+    delaysShownInResults: >
+      Los resultados de su viaje se han ajustado en base a información en tiempo
+      real. En condiciones normales, este viaje duraría {normalDuration}
+      utilizando las siguientes rutas: {routes}.
+    serviceUpdate: Actualización del servicio
+  RealtimeStatusLabel:
+    early: "{minutes} antes"
+    late: "{minutes} de retraso"
+    onTime: a tiempo
+    scheduled: programado
+  RelatedPanel:
+    hideExtraStops: Ocultar las paradas adicionales
+    showExtraStops: Mostrar {count} paradas adicionales
+  RelatedStopsPanel:
+    noArrivalFound: No se ha encontrado ninguna llegada
+    relatedStops: Paradas relacionadas
+    viewDetails: Ver detalles
+  ResultsError:
+    backToSearch: Volver a la búsqueda
+  ResultsHeader:
+    noTripFound: No se encontró ningún viaje
+    tripsFound: Encontramos {count, plural, one {# opción} other {# opciones}}
+    waiting: Espera...
+  RouteDetails:
+    moreDetails: Más detalles
+    operatedBy: Servicio operado por {agencyName}
+    selectADirection: Seleccione una dirección…
+    stopsTo: Hacia
+  RouteViewer:
+    agencyFilter: Filtro de agencia
+    allAgencies: Todas las agencias
+    allModes: Todos los modos
+    details: " "
+    findARoute: Buscar una ruta
+    header: Visor de rutas
+    modeFilter: Filtro de modo
+    noFilteredRoutesFound: ¡No hay rutas que coincidan con tu filtro!
+    openPatternViewer: Ver los detalles de la ruta
+    shortTitle: Ver rutas
+    stopsInDirectionOfTravel: "Paradas en este sentido de la marcha:"
+    title: Visor de rutas
+    toggleRouteOnMap: Cambiar la ruta en el mapa
+  SaveTripButton:
+    cantSaveText: No se puede guardar
+    cantSaveTooltip: >-
+      Sólo se pueden controlar los itinerarios que incluyan ride hailing y no
+      los alquileres o los viajes en coche.
+    saveTripText: Salvar el viaje
+    signInText: Iniciar sesión para guardar el viaje
+    signInTooltip: Por favor, inicie sesión para guardar un viaje.
+  SavedTripEditor:
+    editSavedTrip: Editar el viaje guardado
+    saveNewTrip: Guardar un nuevo viaje
+    tripInformation: Información sobre el viaje
+    tripNotFound: No se encontró el viaje
+    tripNotFoundDescription: Lo sentimos, no se encontró el viaje solicitado.
+    tripNotifications: Notificaciones de viaje
+  SavedTripList:
+    fromTo: De {from} al {to}
+    myTrips: Mis viajes
+    noSavedTrips: No tiene viajes guardados
+    noSavedTripsInstructions: Realice primero una búsqueda de viajes desde el mapa.
+    pause: Pausa
+    resume: Reanudar
+  SavedTripScreen:
+    tooManyTrips: >
+      Ya ha alcanzado el máximo de cinco viajes guardados. Por favor, elimine
+      los viajes no utilizados de sus viajes guardados e inténtelo de nuevo.
+    tripNameAlreadyUsed: >-
+      Otro viaje guardado ya utiliza este nombre. Por favor, elija un nombre
+      diferente.
+    tripNameRequired: Por favor, introduzca el nombre del viaje.
+  SessionTimeout:
+    body: >-
+      Su sesión expirará en un minuto. Pulse 'Continuar sesión' para mantener su
+      búsqueda.
+    header: ¡La sesión está a punto de terminar!
+    keepSession: Continuar sesión
+  SettingsPreview:
+    defaultPreviewText: |-
+      Opciones
+      y Preferencias del viaje
+  SimpleRealtimeAnnotation:
+    usingRealtimeInfo: Este viaje utiliza información de tráfico y retrasos en tiempo real
+  StackedPaneDisplay:
+    savePreferences: Guardar preferencias
+  StopScheduleTable:
+    block: Bloquear
+    departure: Salida
+    destination: A
+    route: Ruta
+  StopTimeCell:
+    imminentArrival: Vencido
+    realtime: Datos basados en el tiempo real
+    scheduled: Basado en los datos del programa
+  StopViewer:
+    displayStopId: <strong>Parada n°</strong>{stopId}
+    findSchedule: Buscar horario por fecha
+    flexStop: >-
+      Esta es una parada flexible. Los vehículos dejarán y recogerán a los
+      pasajeros en esta zona flexible previa solicitud. Es posible que tenga que
+      llamar con antelación para el servicio en esta zona.
+    header: Visor de paradas
+    loadingText: Cargando la parada...
+    nextArrivals: Próximas llegadas
+    noStopsFound: No se han encontrado tiempos de parada para la fecha.
+    operatorLogoAriaLabel: "Parada de {operatorName}:"
+    schedule: Horario
+    timezoneWarning: Las horas de salida se indican en <strong>{timezoneCode}</strong>.
+    titleBarStopId: Parada {stopId}
+    viewNextArrivals: Ver próximas llegadas
+    viewSchedule: Ver horario
+    zoomToStop: Acercar vista a la parada
+  SubNav:
+    languageSelector: Seleccionar idioma
+    languages: Idiomas
+    myAccount: Mi cuenta
+    selectALanguage: Seleccionar un idioma
+    settings: Ajustes
+    trips: Viajes
+    userMenu: Opciones de perfil
+  SwitchButton:
+    defaultContent: Cambiar
+    switchLocations: Cambiar de ubicación
+  TermsOfUsePane:
+    confirmDeletionPrompt: >
+      Eliminar su consentimiento para el almacenamiento de viajes históricos
+      hará que se elimine su historial de viajes. ¿Está seguro que desea
+      continuar?
+    mustAgreeToTerms: Debe aceptar los términos de servicio para continuar.
+    termsOfServiceStatement: >
+      Confirmo que tengo al menos 18 años y que he leído y acepto los
+      <termsOfUseLink>Términos de servicio</termsOfUseLink> para usar el
+      Planificador de viajes.
+    termsOfStorageStatement: >
+      Opcional: Doy mi consentimiento para que Trip Planner almacene mis viajes
+      planificados históricos para mejorar los servicios de tránsito en mi área.
+      <termsOfStorageLink>Más información...</termsOfStorageLink>
+  TransitVehicleOverlay:
+    in_transit_to: "Próxima parada: {stop}"
+    incoming_at: "Acercándose a: {stop}"
+    stopped_at: Puertas abiertas en la {stop}
+    travelingAt: Viajando a {milesPerHour}
+    vehicleName: Vehículo {vehicleNumber}
+  TripBasicsPane:
+    checkingItineraryExistence: Comprobación de la existencia de itinerarios para cada día de la semana…
+    selectAtLeastOneDay: Por favor, seleccione al menos un día para el seguimiento.
+    tripDaysPrompt: ¿Qué días hace este viaje?
+    tripIsAvailableOnDaysIndicated: Su viaje está disponible en los días de la semana indicados anteriormente.
+    tripNamePrompt: "Por favor, indique un nombre para este viaje:"
+    tripNotAvailableOnDay: El viaje no está disponible el {repeatedDay}
+    unsavedChangesExistingTrip: >-
+      Todavía no ha guardado su viaje. Si abandona la página, los cambios se
+      perderán.
+    unsavedChangesNewTrip: Todavía no ha guardado su nuevo viaje. Si abandona la página, se perderá.
+  TripNotificationsPane:
+    advancedSettings: Configuración avanzada
+    altRouteRecommended: Se recomienda una ruta alternativa o un punto de transferencia
+    delaysAboveThreshold: Hay retrasos o interrupciones de más de
+    howToReceiveAlerts: >
+      Para recibir alertas de tus viajes guardados, activa las notificaciones en
+      la configuración de tu cuenta e intenta guardar un viaje de nuevo.
+    monitorThisTrip: "Supervise este viaje antes de que comience:"
+    notificationsTurnedOff: Las notificaciones están desactivadas para su cuenta.
+    notifyViaChannelWhen: "Notifíqueme por {channel} cuando:"
+    oneHour: 1 hora
+    realtimeAlertFlagged: Hay una alerta en tiempo real marcada en mi viaje
+    timeBefore: "{time} antes"
+  TripStatus:
+    alerts: "{alerts, plural, one {# alerta!} other {# alertas!}}"
+    deleteTrip: Borrar el viaje
+    planNewTrip: Planificar un nuevo viaje
+  TripStatusRenderers:
+    active:
+      delayedHeading: La hora de inicio del viaje se retrasa {formattedDuration}!
+      description: El viaje debe comenzar a las {arrivalTime, time, short}.
+      earlyHeading: >-
+        ¡El viaje está en marcha y llega {formattedDuration} antes de lo
+        previsto!
+      noDataHeading: >-
+        El viaje está en curso (no hay actualizaciones disponibles en tiempo
+        real).
+      onTimeHeading: El viaje está en curso y está más o menos a tiempo.
+    base:
+      lastCheckedDefaultText: Hora de la última comprobación desconocida
+      lastCheckedText: "Últimos comprobados: Hace {formattedDuration}"
+      togglePause: Pausa
+      tripIsNotSnoozed: Pausar para el resto del día
+      tripIsSnoozed: Reactivar el análisis de los viajes
+      unknownState: Estado de viaje desconocido
+      untogglePause: Reanudar
+    inactive:
+      description: Reanudar la supervisión del viaje para ver el estado actualizado
+      heading: La supervisión del viaje está en pausa
+    nextTripNotPossible:
+      description: >
+        El planificador de viajes no ha podido encontrar su viaje hoy. Intente
+        volver a planificar su itinerario para encontrar una ruta alternativa.
+      heading: El viaje no es posible hoy
+    noLongerPossible:
+      description: >
+        El planificador de viajes no pudo encontrar su viaje en ninguno de los
+        días seleccionados de la semana. Intente volver a planificar su
+        itinerario para encontrar una ruta alternativa.
+      heading: El viaje ya no es posible
+    notCalculated:
+      awaiting: Esperando el cálculo…
+      description: Por favor, espere un poco para calcular el viaje.
+      heading: Viaje aún no calculado
+    snoozed:
+      description: Reactivar la supervisión del viaje para ver el estado actualizado.
+      heading: El seguimiento del viaje se ha suspendido por hoy
+    upcoming:
+      nextTripBegins: >-
+        El próximo viaje comienza el {tripDatetime, date, ::eeeee yyyyMMdd} a
+        las {tripDatetime, time, short}.
+      tripBegins: >-
+        El viaje debe comenzar a las {tripStart, time, short}. (El seguimiento
+        en tiempo real comenzará a las {monitoringStart, time, short}.)
+      tripStartIsDelayed: ¡La hora de inicio del viaje se retrasa ${duration}!
+      tripStartIsEarly: >-
+        ¡La hora de inicio del viaje se produce ${duration} antes de lo
+        previsto!
+      tripStartsSoonNoUpdates: >-
+        El viaje comienza pronto (no hay actualizaciones disponibles en tiempo
+        real).
+      tripStartsSoonOnTime: El viaje comienza pronto y es más o menos puntual.
+  TripSummary:
+    arriveAt: "Llegue a las "
+    leaveAt: "Salida a las "
+  TripSummaryPane:
+    happensOnDays: "Ocurre en: <strong>{days}</strong>"
+    notifications: >-
+      Notificaciones: <strong>{leadTimeInMinutes} minutos antes de la salida
+      programada</strong>
+    notificationsDisabled: "Notificaciones: <strong>Disabled</strong>"
+  TripTools:
+    copyLink: Copiar enlace
+    linkCopied: Copiado
+    reportEmailSubject: Informar un problema con OpenTripPlanner
+    reportEmailTemplate: >
+      *** INSTRUCCIONES PARA EL USUARIO ***
+
+      Este correo electrónico informará de su problema a los administradores de
+      esta página.
+
+      Complete los detalles a continuación, luego envíe un correo electrónico
+      desde su software de correo electrónico habitual.
+
+
+      *** POR FAVOR COMPLETE MAS ABAJO ***
+
+
+      Problema encontrado:
+
+
+      Tipo de viaje buscado (por ejemplo, a pie + transporte, bicicleta +
+      transporte, coche + transporte):
+
+
+      *** DETALLES TÉCNICOS ***
+    reportIssue: Reportar un problema
+  TripViewer:
+    accessible: Accesible
+    bicyclesAllowed: Permitido
+    endOfTrip: El viaje acaba aquí
+    header: Visor de viajes
+    listOfRouteStops: Lista de paradas en esta ruta
+    routeHeader: "Ruta: <strong>{routeShortName}</strong> {routeLongName}"
+    startOfTrip: Aquí comienza el viaje
+    tripDescription: Embarque en {boardAtStop} y desembarque en {disembarkAtStop}
+    viewStop: Ver
+  UserAccountScreen:
+    confirmDelete: >-
+      ¿Está seguro de que desea eliminar su cuenta de usuario? Una vez que lo
+      haga, no se podrá recuperar.
+  UserSettings:
+    confirmDeletion: >-
+      Tiene almacenadas búsquedas o lugares recientes. Si desactiva el
+      almacenamiento de lugares o búsquedas recientes, eliminará estos
+      elementos. ¿Continuar?
+    favoriteStops: Paradas favoritas
+    myPreferences: Mis preferencias
+    mySavedPlaces: Mis lugares guardados (<manageLink>Administrar</manageLink>)
+    noFavoriteStops: No hay paradas favoritas
+    recentPlaces: Lugares recientes
+    recentSearchSummary: "{mode} de {from} al {to}"
+    recentSearches: Búsquedas recientes
+    rememberSearches: ¿Recordar las búsquedas/lugares recientes?
+    stopId: "ID de Parada: {stopId}"
+    storageDisclaimer: >
+      Cualquier preferencia, lugar o configuración que opte por guardar se
+      guardará en el almacenamiento local de su navegador. No tendremos acceso
+      al conocimiento de su casa, trabajo o cualquier otra ubicación. En
+      cualquier momento puedes optar por desactivar el recuerdo de lugares o
+      búsquedas recientes y borrar las ubicaciones de casa o del trabajo y las
+      paradas favoritas guardadas.
+  UserTripSettings:
+    forgetOptions: Olvidar mis opciones
+    rememberOptions: Recordar las opciones de viaje
+    restoreDefaults: Restaurar los valores predeterminados
+    restoreMyDefaults: Restaurar mis valores predeterminados
+  VerifyEmailPane:
+    emailIsVerified: ¡Mi correo electrónico está verificado!
+    instructions1: >
+      Por favor compruebe el buzón de su correo electrónico y siga el enlace del
+      mensaje para verificar su dirección de correo electrónico antes de
+      finalizar la configuración de su cuenta.
+    instructions2: Una vez verificado, haga clic en el botón de abajo para continuar.
+    resendVerification: Reenviar el correo electrónico de verificación
+  ViewSwitcher:
+    switcher: Botón de cambio
+  WelcomeScreen:
+    prompt: ¿A donde quiere ir?
+config:
+  accessModes:
+    bicycle: Tránsito + Bicicleta Personal
+    bicycle_rent: Tránsito + Compartir Bicicleta
+    car_hail: VTC
+    car_park: Aparcamiento disuasorio
+    micromobility: Tránsito + Scooter Personal
+    micromobility_rent: Tránsito + Alquiler de scooter eléctrico
+  bicycleModes:
+    bicycle: Bicicleta propia
+    bicycle_rent: Compartir bicicleta
+  flex:
+    both: Ver detalles al final del itinerario
+    call-ahead: Llame para reservar
+    continuous-dropoff: Comunicar al operador sobre la parada
+    flex-service: Servicio Flex
+    flex-service-colon: "Servicio Flex:"
+  micromobilityModes:
+    micromobility: Mi E-Scooter
+    micromobility_rent: Alquiler de scooter eléctrico
 util:
   state:
     errorPlanningTrip: Se ha producido un error al planificar un viaje.
     networkUnavailable: La red {network} no está disponible en este momento.
     noTripFound: No se encontró ningún viaje.
     noTripFoundForMode: No se encontró ningún viaje para {modes}.
-    noTripFoundReason: Es posible que no haya servicio de tránsito dentro de la distancia
-      máxima especificada o en el momento especificado, o es posible que su punto
-      de inicio o final no sea accesible de manera segura.
-    noTripFoundWithReason: '{noTripFound} {reason}'
-config:
-  accessModes:
-    bicycle: Tránsito + Bicicleta Personal
-    bicycle_rent: Tránsito + Compartir Bicicleta
-    micromobility: Tránsito + Scooter Personal
-    car_hail: VTC
-    car_park: Aparcamiento disuasorio
-    micromobility_rent: Tránsito + Alquiler de scooter eléctrico
-  flex:
-    flex-service: Servicio Flex
-    flex-service-colon: 'Servicio Flex:'
-    both: Ver detalles al final del itinerario
-    call-ahead: Llame para reservar
-    continuous-dropoff: Comunicar al operador sobre la parada
-  bicycleModes:
-    bicycle_rent: Compartir bicicleta
-    bicycle: Bicicleta propia
-  micromobilityModes:
-    micromobility: Mi E-Scooter
-    micromobility_rent: Alquiler de scooter eléctrico
+    noTripFoundReason: >-
+      Es posible que no haya servicio de tránsito dentro de la distancia máxima
+      especificada o en el momento especificado, o es posible que su punto de
+      inicio o final no sea accesible de manera segura.
+    noTripFoundWithReason: "{noTripFound} {reason}"

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -1,47 +1,36 @@
 _id: fr
 _name: Exemple de traduction pour OTP-react-redux en français
-
-# Noteworthy items for translating into French:
-# - trip, itinerary, journey => trajet
-# - trip monitoring => suivi de trajet
-# - place => lieu (destination)
-# - disable, deactivate => désactiver
-# - email => 'e-mail' or 'mail' is widely used in France, although courriel is more common in Canada.
-# - Instruction text is generally less cheerful in French than English (e.g. fewer uses of exclamation marks)
-#   and tends to rely on infinitive tense.
-#
-
-# Messages that are generated from actions
 actions:
   callTaker:
-    callQuerySaveError: "Erreur lors de l'enregistrement des requêtes pour l'appel\
-      \ : {err}"
+    callQuerySaveError: "Erreur lors de l'enregistrement des requêtes pour l'appel : {err}"
     callSaveError: "Impossible d'enregistrer l'appel : {err}"
     checkSessionError: "Erreur durant la session d'authentification : {err}"
-    couldNotFindCallError: Impossible de trouver l'appel. Tentative de sauvegarde
-      des requêtes annulée.
+    couldNotFindCallError: >-
+      Impossible de trouver l'appel. Tentative de sauvegarde des requêtes
+      annulée.
     fetchCallsError: "Erreur lors du chargement des appels : {err}"
     queryFetchError: "Erreur lors du chargement des requêtes : {err}"
   fieldTrip:
     addNoteError: "Erreur lors de l'ajout d'une note sur le groupe :"
-    confirmOverwriteItineraries: >
+    confirmOverwriteItineraries: |
       Cette action replacera un trajet {outbound, select,
         true {aller}
         other {retour}
       } planifié préalablement pour cette demande. Voulez-vous continuer ?
-    deleteItinerariesError: "Erreur lors de la suppression du trajet pour le groupe\
-      \ :"
+    deleteItinerariesError: "Erreur lors de la suppression du trajet pour le groupe :"
     deleteNoteError: "Erreur lors de la suppression d'une note sur le groupe :"
-    editSubmitterNotesError: "Erreur lors de la modification des notes du demandeur\
-      \ :"
+    editSubmitterNotesError: "Erreur lors de la modification des notes du demandeur :"
     fetchFieldTripError: "Erreur de chargement du groupe scolaire : {err}"
     fetchFieldTripsError: "Erreur lors du chargement des groupes scolaires : {err}"
-    fetchTripsForDateError: "Erreur lors du chargement des trajets du groupe pour\
-      \ les dates de sorties : {err}"
-    incompatibleTripDateError: La date du trajet planifié ({tripDate}) ne correspond
-      pas à la date demandée ({requestDate}).
-    itineraryCapacityError: "Impossible d'enregistrer les trajets : Capacité insuffisante\
-      \ dans un ou plusieurs véhicules. Veuillez réorganiser votre trajet."
+    fetchTripsForDateError: >-
+      Erreur lors du chargement des trajets du groupe pour les dates de sorties
+      : {err}
+    incompatibleTripDateError: >-
+      La date du trajet planifié ({tripDate}) ne correspond pas à la date
+      demandée ({requestDate}).
+    itineraryCapacityError: >-
+      Impossible d'enregistrer les trajets : Capacité insuffisante dans un ou
+      plusieurs véhicules. Veuillez réorganiser votre trajet.
     maxTripRequestsExceeded: Le nombre de requêtes sans résultats valables a été dépassé.
     saveItinerariesError: "Erreur lors de l'enregistrement des trajets : {err}"
     setDateError: "Erreur sur la date :"
@@ -49,8 +38,7 @@ actions:
     setPaymentError: "Erreur sur les coordonnées de paiement :"
     setRequestStatusError: "Erreur sur l'état de la requête :"
   location:
-    geolocationNotSupportedError: La géolocalisation n'est pas prise en charge par
-      votre navigateur.
+    geolocationNotSupportedError: La géolocalisation n'est pas prise en charge par votre navigateur.
     unknownPositionError: Erreur inconnue lors de la détection de votre emplacement.
   map:
     currentLocation: (Emplacement actuel)
@@ -59,22 +47,120 @@ actions:
     authTokenError: Erreur lors de l'obtention d'un jeton d'authentification.
     confirmDeleteMonitoredTrip: Voulez-vous supprimer ce trajet ?
     confirmDeletePlace: Voulez-vous supprimer ce lieu ?
-    emailVerificationResent: Le message de vérification de votre adresse e-mail a
-      été envoyé de nouveau.
+    emailVerificationResent: >-
+      Le message de vérification de votre adresse e-mail a été envoyé de
+      nouveau.
     genericError: "Une erreur s'est produite : {err}"
-    itineraryExistenceCheckFailed: Erreur lors de la vérification de la validité du
-      trajet choisi.
+    itineraryExistenceCheckFailed: Erreur lors de la vérification de la validité du trajet choisi.
     preferencesSaved: Vos préférences ont été enregistrées.
     smsInvalidCode: Le code saisi est incorrect. Veuillez réessayer.
-    smsResendThrottled: Un SMS de vérification a été envoyé au numéro de téléphone
-      indiqué il y a moins d'une minute. Patientez quelques moments avant de réessayer.
-    smsVerificationFailed: Votre numéro de téléphone n'a pas pu être vérifié. Le code
-      que vous avez entré a peut-être expiré. Veuillez demander un nouveau code, puis
+    smsResendThrottled: >-
+      Un SMS de vérification a été envoyé au numéro de téléphone indiqué il y a
+      moins d'une minute. Patientez quelques moments avant de réessayer.
+    smsVerificationFailed: >-
+      Votre numéro de téléphone n'a pas pu être vérifié. Le code que vous avez
+      entré a peut-être expiré. Veuillez demander un nouveau code, puis
       réessayez.
-
-
-# Component-specific messages (e.g. button captions)
-# are defined for each component under the 'components' category.
+common:
+  coordinates: "{lat}; {lon}"
+  dateExpressions:
+    today: Aujourd'hui
+    tomorrow: Demain
+    yesterday: Hier
+  daysOfWeek:
+    friday: vendredi
+    monday: lundi
+    saturday: samedi
+    sunday: dimanche
+    thursday: jeudi
+    tuesday: mardi
+    wednesday: mercredi
+  daysOfWeekCompact:
+    friday: ven.
+    monday: lun.
+    saturday: sam.
+    sunday: dim.
+    thursday: jeu.
+    tuesday: mar.
+    wednesday: mer.
+  daysOfWeekPlural:
+    friday: vendredis
+    monday: lundis
+    saturday: samedis
+    sunday: dimanches
+    thursday: jeudis
+    tuesday: mardis
+    wednesday: mercredis
+  forms:
+    back: Retour
+    cancel: Annuler
+    close: Fermer
+    defaultValue: "{value} (défaut)"
+    delete: Supprimer
+    edit: Modifier
+    error: erreur !
+    finish: Terminer
+    next: Suivant
+    "no": Non
+    print: Imprimer
+    save: Enregistrer
+    startOver: Recommencer
+    submitting: Envoi en cours…
+    "yes": Oui
+  itineraryDescriptions:
+    calories: "{calories, number} kcal"
+    noItineraryToDisplay: Aucun trajet à afficher.
+    noTransitFareProvided: Tarif inconnu
+    relativeCo2: |
+      {co2} de CO₂ en {isMore, select, true {plus} other {moins} } qu'en voiture
+    transfers: "{transfers, plural, one {# correspondance} other {# correspondances}}"
+  modes:
+    bicycle_rent: En vélo en libre-service
+    bike: Vélo
+    bus: Bus
+    cable_car: Tram tiré par câble
+    car: Voiture
+    car_park: Parc relais
+    drive: Voiture
+    ferry: Ferry
+    flex: Service Flex
+    funicular: Funiculaire
+    gondola: Téléphérique
+    micromobility: En trottinette électrique
+    micromobility_rent: En trottinette
+    rail: Train
+    rent: Location de véhicules
+    subway: Métro
+    tram: Tram
+    transit: En transports
+    walk: À pied
+  notifications:
+    email: e-mail
+    sms: SMS
+  places:
+    custom: divers
+    dining: restaurant
+    home: domicile
+    work: lieu de travail
+  routing:
+    routeAndNumber: Ligne {routeId}
+    routeToHeadsign: Direction {headsign}
+  searchForms:
+    click: cliquez
+    enterDestination: Entrez votre destination ou {mapAction} sur la carte…
+    enterStartLocation: Entrez votre point de départ ou {mapAction} sur la carte…
+    tap: appuyez
+  time:
+    departureArrivalTimes: "{startTime, time, short}—{endTime, time, short}"
+    duration:
+      aFewSeconds: quelques secondes
+      nDays: "{days, plural, =1 {un jour} other {# jours}}"
+      nHours: "{hours, plural, =1 {une heure} other {# heures}}"
+      nMinutes: "{minutes, plural, =1 {une minute} other {# minutes}}"
+    durationAgo: il y a {duration}
+    tripDurationFormat: >-
+      {hours, plural, =0 {} other {# h }}{minutes} min { seconds, plural, =0 {}
+      other {# s}}
 components:
   A11yPrefs:
     accessibilityRoutingByDefault: Privilégier par défaut les trajets accessibles
@@ -82,33 +168,34 @@ components:
     message: Vous pouvez maintenant commencer à planifier vos trajets.
   AddPlaceButton:
     addPlace: Ajouter un point intermédiaire
-    needOriginDestination: Choisissez le départ et l'arrivée avant d'ajouter les points
+    needOriginDestination: >-
+      Choisissez le départ et l'arrivée avant d'ajouter les points
       intermédiaires
     tooManyPlaces: Nombre max. de points intermédiaires atteint
   AdvancedOptions:
     bannedRoutes: Choisissez les lignes à éviter…
     maxBike: Dist. à vélo ({unitsString})
     maxWalk: Dist. à pied ({unitsString})
-    walkReluctance: Réticence à marcher
     preferredRoutes: Choisissez les lignes preferées
+    walkReluctance: Réticence à marcher
   AfterSignInScreen:
     mainTitle: Redirection...
-    message: "Si la page ne s'affiche pas après quelques secondes, <redirectLink>cliquez\
-      \ ici</redirectLink>."
+    message: >-
+      Si la page ne s'affiche pas après quelques secondes, <redirectLink>cliquez
+      ici</redirectLink>.
   AmenitiesPanel:
-    # Use plurals to differentiate between company variable being set or not
-    bikesAtStation: >
+    bikesAtStation: |
       {companyLength, plural,
         =0 {vélo à {name}}
         other {vélos {company} à {name}}
       }
-    bikesAvailable: >
+    bikesAvailable: |
       {count, plural,
         =0 {Aucun vélo disponible}
         one {# vélo disponible}
         other {# vélos disponibles}
       }
-    bikesNearby: >
+    bikesNearby: |
       {count, plural,
         =0 {Aucun vélo partagé {company} à proximité}
         one {# vélo partagé {company} à proximité}
@@ -118,13 +205,13 @@ components:
     noNearbyBikes: Aucun vélo en location à proximité.
     noNearbyScooters: Aucune trottinette en location à proximité.
     noPRLotsFound: Aucun parc relais à proximité.
-    scootersNearby: >
+    scootersNearby: |
       {count, plural,
         =0 {Aucune trottinette {company} à proximité}
         one {# trottinette {company} à proximité}
         other {# trottinettes {company} à proximité}
       }
-    spacesAvailable: >
+    spacesAvailable: |
       {count, plural,
         =0 {Aucun emplacement disponible}
         one {# emplacement disponible}
@@ -148,17 +235,18 @@ components:
     header: Planifiez votre trajet
   BatchSettings:
     destination: destination
+    modeSelector: Sélecteur de modes
     origin: point de départ
     planTripTooltip: Planifier le trajet
-    validationMessage: "Veuillez définir les champs suivants afin de planifier votre\
-      \ trajet : {issues}"
     settings: Préférences du trajet
-    modeSelector: Sélecteur de modes
+    validationMessage: >-
+      Veuillez définir les champs suivants afin de planifier votre trajet :
+      {issues}
   BeforeSignInScreen:
     mainTitle: Connexion en cours
     message: >
-      Pour accéder à cette page, vous devez vous connecter.
-      Veuillez patienter pendant que nous vous redirigeons vers la page de connexion...
+      Pour accéder à cette page, vous devez vous connecter. Veuillez patienter
+      pendant que nous vous redirigeons vers la page de connexion...
   CallTakerPanel:
     advancedOptions: Options avancées
     groupSize: "Taille du groupe :"
@@ -168,9 +256,9 @@ components:
     departAt: Partir à
     now: Tout de suite
   DateTimePreview:
-    arriveAt: "Arrivée {arriveTime, time, short}"
+    arriveAt: Arrivée {arriveTime, time, short}
     dayLastWeek: "{formattedDayOfWeek} dernier"
-    departAt: "Départ {departTime, time, short}"
+    departAt: Départ {departTime, time, short}
     editDepartOrArrival: Modifier l'heure de départ ou d'arrivée
     leaveNow: Tout de suite
     range: "{startTime, time, short} à {endTime, time, short}"
@@ -183,7 +271,7 @@ components:
   DeleteUser:
     deleteMyAccount: Supprimer mon compte
   EnhancedStopMarker:
-    stopID: "Arrêt nº"
+    stopID: Arrêt nº
     stopViewer: Info arrêt
   ErrorMessage:
     header: Impossible de planifier le trajet
@@ -196,9 +284,9 @@ components:
     terms: Conditions d'utilisation
   FavoritePlaceList:
     addAnotherPlace: Ajouter un autre lieu
-    description: "Ajoutez les lieux que vous fréquentez souvent pour faciliter vos\
-      \ recherches de trajets :"
-    # editThisPlace is a tooltip text.
+    description: >-
+      Ajoutez les lieux que vous fréquentez souvent pour faciliter vos
+      recherches de trajets :
     editThisPlace: Modifier ce lieu
     setAddressForPlaceType: Entrez l'adresse de votre {placeType}
   FavoritePlaceScreen:
@@ -207,8 +295,9 @@ components:
     editPlaceGeneric: Modifier le lieu
     invalidAddress: Veuillez entrer l'adresse du lieu.
     invalidName: Veuillez saisir le nom du lieu.
-    nameAlreadyUsed: Ce nom est déjà utilisé avec un autre lieu. Veuillez saisir un
-      nom différent.
+    nameAlreadyUsed: >-
+      Ce nom est déjà utilisé avec un autre lieu. Veuillez saisir un nom
+      différent.
     placeNotFound: Lieu introuvable
     placeNotFoundDescription: Le lieu recherché est introuvable.
   FormNavigationButtons:
@@ -223,28 +312,28 @@ components:
     enterLocation: Entrez le lieu
     setDestination: Choisissez la destination
     setOrigin: Choisissez le point de départ
-  MapillaryFrame:
-    title: Vue panoramique
   MapLayers:
     bike-rental: Vélos partagés {companies}
     car-rental: Voitures en location
     micromobility-rental: Trottinettes {companies}
     park-and-ride: Parcs relais
     satellite: Satellite
-    shared-vehicles: "Véhicules en partage"
+    shared-vehicles: Véhicules en partage
     stops: Arrêts et stations
     streets: Plan des rues
+  MapillaryFrame:
+    title: Vue panoramique
   MetroUI:
-    fromStop: "de {stop}"
-    itineraryDescription: "Trajet de {time} par les lignes {routes}"
+    arriveAt: Vous arrivez à
+    arriveAtTime: Arrivée à {time}
+    fromStop: de {stop}
+    itineraryDescription: Trajet de {time} par les lignes {routes}
     leaveAt: Partez à
     multipleOptions: Plusieurs options
     orAlternatives: ou autres lignes dans la même direction
-    singleModeItineraryDescription: "Trajet de {time} {mode}"
-    timeWalking: "{time} de marche"
     originallyScheduledTime: (initialement {originalTime})
-    arriveAt: Vous arrivez à
-    arriveAtTime: Arrivée à {time}
+    singleModeItineraryDescription: Trajet de {time} {mode}
+    timeWalking: "{time} de marche"
   MobileOptions:
     header: Options de recherche
   ModeDropdown:
@@ -252,11 +341,8 @@ components:
   NarrativeItinerariesHeader:
     changeSortDir: Changer l'ordre de tri
     itinerariesAndIssues: "{itinerariesFound} et {numIssues}"
-    itinerariesFound: "{itineraryNum, plural, one {# trajet trouvé} other {# trajets\
-      \ trouvés} }"
+    itinerariesFound: "{itineraryNum, plural, one {# trajet trouvé} other {# trajets trouvés} }"
     numIssues: "{issueNum, plural, one {# problème} other {# problèmes} }"
-    # Note to translator: text below is width-constrained
-    # (about half-pane width, or half-screen width in mobile views).
     searching: Recherche...
     selectArrivalTime: Heure d'arrivée
     selectBest: Meilleure option
@@ -281,11 +367,12 @@ components:
     description: Le contenu que vous avez demandé n'est pas disponible.
     header: Contenu introuvable
   NotificationPrefsPane:
-    description: Vous pouvez recevoir des notifications sur les trajets que vous effectuez
+    description: >-
+      Vous pouvez recevoir des notifications sur les trajets que vous effectuez
       fréquemment.
+    noneSelect: Ne pas me notifier
     notificationChannelPrompt: Comment voulez-vous recevoir vos notifications ?
     notificationEmailDetail: "Les courriers de notification seront envoyés à :"
-    noneSelect: Ne pas me notifier
   PhoneNumberEditor:
     changeNumber: Changer de numéro
     invalidCode: Le code de vérification doit comporter 6 chiffres.
@@ -293,25 +380,23 @@ components:
     pending: Non vérifié
     phoneNumberSubmitted: Le numéro {phoneNumber} a bien été envoyé.
     phoneNumberVerified: Le numéro {phoneNumber} a bien été vérifié.
-    # Note to translator: placeholder is width-constrained.
-    placeholder: "Entrez votre numéro"
+    placeholder: Entrez votre numéro
     prompt: "Entrez votre numéro de téléphone pour les SMS de notification :"
     requestNewCode: Envoyer un nouveau code
     sendVerificationText: Envoyer le SMS de vérification
     smsDetail: "Les SMS de notification seront envoyés au :"
-    verified: Vérifié
     verificationCode: "Code de vérification :"
     verificationInstructions: >
-      Un SMS vous a été envoyé avec un code de vérification.
-      Veuillez taper ce code ci-dessous (le code expire après 10 minutes).
+      Un SMS vous a été envoyé avec un code de vérification. Veuillez taper ce
+      code ci-dessous (le code expire après 10 minutes).
+    verified: Vérifié
     verify: Vérifier
   Place:
-    # deleteThisPlace is an aria/tooltip text.
     deleteThisPlace: Supprimer ce lieu
     enterAlert: >
-      Entrez votre point de départ/destination dans le formulaire (ou cliquez sur
-      la carte),
-      puis cliquez sur le marqueur qui apparaît afin de définir votre {placeType}.
+      Entrez votre point de départ/destination dans le formulaire (ou cliquez
+      sur la carte), puis cliquez sur le marqueur qui apparaît afin de définir
+      votre {placeType}.
     viewStop: Voir cet arrêt
   PlaceEditor:
     addressPrompt: "Adresse :"
@@ -321,40 +406,35 @@ components:
     nameExample: Mon café du coin
     namePrompt: "Nom du lieu :"
   PlanFirstLastButtons:
-    # Note to translator: these values are width-constrained.
     first: Premier
     last: Dernier
     next: Suivant
     previous: Précédent
   PlanTripButton:
-    planTrip: Planifier le trajet # or simply "Rechercher"
+    planTrip: Planifier le trajet
   PointPopup:
     zoomToLocation: Zoomer sur cet endroit
   PrintLayout:
     itinerary: Votre trajet
     toggleMap: Afficher/masquer la carte
   RealtimeAnnotation:
-    delaysShownInResults: "Vos trajets recherchés ont été mis à jour avec les conditions\
-      \ en temps réel. En temps normal, ce trajet prendrait {normalDuration} en empruntant\
-      \ les lignes : {routes}.\n"
+    delaysShownInResults: >
+      Vos trajets recherchés ont été mis à jour avec les conditions en temps
+      réel. En temps normal, ce trajet prendrait {normalDuration} en empruntant
+      les lignes : {routes}.
     serviceUpdate: Information sur le service
   RealtimeStatusLabel:
-    # Note to translator: In itinerary body, early or late is single-line
-    # and stacked above/below the delay in minutes depending on word order,
-    # e.g. "5 min\nlate".
-    # In the StopViewer, delay and status are shown in a single line.
-    # Width is constrained for all messages.
-    early: "avance de {minutes}"
-    late: "retard {minutes}"
+    early: avance de {minutes}
+    late: retard {minutes}
     onTime: à l'heure
     scheduled: horaire
   RelatedPanel:
     hideExtraStops: Masquer les arrêts à proximité
-    showExtraStops: "Afficher {count} arrêts à proximité"
+    showExtraStops: Afficher {count} arrêts à proximité
   RelatedStopsPanel:
+    noArrivalFound: Aucun passage prévu
     relatedStops: Arrêts à proximité
     viewDetails: Détails
-    noArrivalFound: Aucun passage prévu
   ResultsError:
     backToSearch: Retour à la recherche
   ResultsHeader:
@@ -362,25 +442,32 @@ components:
     tripsFound: "{count, plural, one {# trajet trouvé} other {# trajets trouvés}}"
     waiting: Patientez...
   RouteDetails:
-    operatedBy: "Exploité par {agencyName}"
-    moreDetails: "Plus d'infos"
-    stopsTo: "Direction"
-    selectADirection: "Choisissez une direction..."
-  # Used in both desktop and mobile
+    moreDetails: Plus d'infos
+    operatedBy: Exploité par {agencyName}
+    selectADirection: Choisissez une direction...
+    stopsTo: Direction
   RouteViewer:
     agencyFilter: Filtrer les transporteurs
     allAgencies: Tous transporteurs
-    allModes: Tous modes # Note to translator: This text is width-constrained.
-    details: " " # If the string is left blank, React-Intl renders the id
+    allModes: Tous modes
+    details: " "
     findARoute: Chercher une ligne
     header: Index des lignes
     modeFilter: Filtre pour les modes
     noFilteredRoutesFound: Aucune ligne ne correspond à vos critères
+    openPatternViewer: Voir les dessertes
     shortTitle: Index des lignes
     stopsInDirectionOfTravel: "Arrêts dans cette direction :"
     title: Index des lignes
-    openPatternViewer: Voir les dessertes
     toggleRouteOnMap: Afficher ou masquer cette ligne sur la carte
+  SaveTripButton:
+    cantSaveText: Impossible d'enregistrer
+    cantSaveTooltip: >-
+      Seuls les trajets en transports publics sans location de véhicules et sans
+      course en voiture peuvent être suivis.
+    saveTripText: Enregistrer
+    signInText: Connectez-vous pour enregistrer
+    signInTooltip: Veuillez vous connecter pour enregistrer ce trajet.
   SavedTripEditor:
     editSavedTrip: Modifier un trajet enregistré
     saveNewTrip: Enregistrer un nouveau trajet
@@ -389,37 +476,37 @@ components:
     tripNotFoundDescription: Le trajet recherché est introuvable.
     tripNotifications: Notifications du trajet
   SavedTripList:
-    fromTo: "De {from} à {to}"
+    fromTo: De {from} à {to}
     myTrips: Mes trajets
     noSavedTrips: Vous n'avez aucun trajet enregistré
-    noSavedTripsInstructions: Effectuez une recherche depuis la carte avant de pouvoir
-      enregistrer un nouveau trajet.
+    noSavedTripsInstructions: >-
+      Effectuez une recherche depuis la carte avant de pouvoir enregistrer un
+      nouveau trajet.
     pause: Arrêter
     resume: Reprendre
   SavedTripScreen:
     tooManyTrips: >
       Vous avez déjà atteint le nombre maximum de 5 trajets enregistrés.
-      Veuillez supprimer les trajets enregistrés qui sont inutilisés, puis réessayez.
-    tripNameAlreadyUsed: Ce nom est déjà utilisé avec un autre trajet. Veuillez choisir
-      un nom différent.
+      Veuillez supprimer les trajets enregistrés qui sont inutilisés, puis
+      réessayez.
+    tripNameAlreadyUsed: >-
+      Ce nom est déjà utilisé avec un autre trajet. Veuillez choisir un nom
+      différent.
     tripNameRequired: Veuillez entrer un nom pour ce trajet.
-  SaveTripButton:
-    cantSaveText: Impossible d'enregistrer
-    cantSaveTooltip: Seuls les trajets en transports publics sans location de véhicules
-      et sans course en voiture peuvent être suivis.
-    saveTripText: Enregistrer
-    signInText: Connectez-vous pour enregistrer
-    signInTooltip: Veuillez vous connecter pour enregistrer ce trajet.
   SessionTimeout:
-    body: Votre session va expirer d'ici une minute. Appuyez sur 'Prolonger ma session'
-      pour conserver votre recherche.
+    body: >-
+      Votre session va expirer d'ici une minute. Appuyez sur 'Prolonger ma
+      session' pour conserver votre recherche.
     header: Votre session va expirer
     keepSession: Prolonger ma session
   SettingsPreview:
-    defaultPreviewText: "Choix du mode\n& préférences"
+    defaultPreviewText: |-
+      Choix du mode
+      & préférences
   SimpleRealtimeAnnotation:
-    usingRealtimeInfo: Ce trajet utilise les informations en temps réel sur le trafic
-      et les retards
+    usingRealtimeInfo: >-
+      Ce trajet utilise les informations en temps réel sur le trafic et les
+      retards
   StackedPaneDisplay:
     savePreferences: Enregistrer mes préférences
   StopScheduleTable:
@@ -428,30 +515,29 @@ components:
     destination: Direction
     route: Ligne
   StopTimeCell:
+    imminentArrival: Imminent
     realtime: Données en temps réel
     scheduled: Selon l'horaire
-    imminentArrival: Imminent
-  # Used in both desktop and mobile
   StopViewer:
-    displayStopId: "<strong>Arrêt n°</strong>{stopId}"
-    flexStop: Cet arrêt fait partie d'une zone 'Flex' et est desservi à la demande.
-      Une réservation préalable peut être exigée pour obtenir la desserte.
+    displayStopId: <strong>Arrêt n°</strong>{stopId}
+    findSchedule: Rechercher les horaires par date
+    flexStop: >-
+      Cet arrêt fait partie d'une zone 'Flex' et est desservi à la demande. Une
+      réservation préalable peut être exigée pour obtenir la desserte.
     header: Info arrêt
     loadingText: Chargement de l'arrêt...
     nextArrivals: Prochains passages
     noStopsFound: Aucun horaire pour la date choisie.
     operatorLogoAriaLabel: "Arrêt {operatorName} :"
     schedule: Horaires
-    timezoneWarning: "Les horaires sont affichés dans le fuseau <strong>{timezoneCode}</strong>."
-    titleBarStopId: "Arrêt {stopId}"
+    timezoneWarning: Les horaires sont affichés dans le fuseau <strong>{timezoneCode}</strong>.
+    titleBarStopId: Arrêt {stopId}
     viewNextArrivals: Prochains passages
     viewSchedule: Horaires
     zoomToStop: Zoomer sur l'arrêt
-
-    findSchedule: Rechercher les horaires par date
   SubNav:
     languageSelector: Langue
-    languages: "Langues"
+    languages: Langues
     myAccount: Mon compte
     selectALanguage: Sélectionner une langue
     settings: Préférences
@@ -462,50 +548,44 @@ components:
     switchLocations: Permuter les lieux
   TermsOfUsePane:
     confirmDeletionPrompt: >
-      En révoquant votre accord sur l'enregistrement de vos recherches de trajets,
-      tout l'historique de vos de trajets sera supprimé.
-      Voulez-vous continuer ?
+      En révoquant votre accord sur l'enregistrement de vos recherches de
+      trajets, tout l'historique de vos de trajets sera supprimé. Voulez-vous
+      continuer ?
     mustAgreeToTerms: Vous devez accepter les conditions d'utilisation avant de continuer.
     termsOfServiceStatement: >
       J'atteste avoir au moins 18 ans et j'ai lu et consens aux
-      <termsOfUseLink>Conditions de service</termsOfUseLink> pour utiliser the Planificateur
-      de trajets.
-    termsOfStorageStatement: >
-      Facultatif : Je consens à ce que le Planificateur de trajets sauvegarde mes
-      recherches afin d'améliorer les transports publics dans ma region. <termsOfStorageLink>Plus
-      d'informations...</termsOfStorageLink>
+      <termsOfUseLink>Conditions de service</termsOfUseLink> pour utiliser the
+      Planificateur de trajets.
+    termsOfStorageStatement: "Facultatif\_: Je consens à ce que le Planificateur de trajets sauvegarde mes recherches afin d'améliorer les transports publics dans ma region. <termsOfStorageLink>Plus d'informations...</termsOfStorageLink>\n"
   TransitVehicleOverlay:
-    # keys designed to match API output
-    incoming_at: "Approchant {stop}"
     in_transit_to: "Prochain arrêt : {stop}"
-    stopped_at: "À quai à {stop}"
+    incoming_at: Approchant {stop}
+    stopped_at: À quai à {stop}
     travelingAt: "Vitesse : {milesPerHour}"
-    vehicleName: "Véhicule {vehicleNumber}"
+    vehicleName: Véhicule {vehicleNumber}
   TripBasicsPane:
     checkingItineraryExistence: Vérification du trajet pour chaque jour de la semaine...
     selectAtLeastOneDay: Veuillez choisir au moins un jour pour effectuer le suivi.
-    tripIsAvailableOnDaysIndicated: Votre trajet est possible les jours indiqués ci-dessus.
     tripDaysPrompt: Quels jours effectuez-vous ce trajet ?
+    tripIsAvailableOnDaysIndicated: Votre trajet est possible les jours indiqués ci-dessus.
     tripNamePrompt: "Saisissez un nom pour ce trajet :"
-    # This is shown in a tooltip.
     tripNotAvailableOnDay: Ce trajet n'est pas possible les {repeatedDay}.
-    unsavedChangesNewTrip: Vous n'avez pas encore enregistré votre nouveau trajet.
-      Si vous annulez, ce trajet sera perdu.
-    unsavedChangesExistingTrip: Vous n'avez pas encore enregistré votre trajet. Si
-      vous annulez, les changements seront perdus.
+    unsavedChangesExistingTrip: >-
+      Vous n'avez pas encore enregistré votre trajet. Si vous annulez, les
+      changements seront perdus.
+    unsavedChangesNewTrip: >-
+      Vous n'avez pas encore enregistré votre nouveau trajet. Si vous annulez,
+      ce trajet sera perdu.
   TripNotificationsPane:
     advancedSettings: Paramètres avancés
     altRouteRecommended: Un·e autre trajet ou correspondance est conseillé·e
     delaysAboveThreshold: Il y a des perturbations ou des retards de plus de
     howToReceiveAlerts: >
-      Pour recevoir les alertes pour vos trajets suivis, activez les notifications
-      dans la section Préférences de votre compte, et essayez d'enregistrer un trajet
-      à nouveau.
+      Pour recevoir les alertes pour vos trajets suivis, activez les
+      notifications dans la section Préférences de votre compte, et essayez
+      d'enregistrer un trajet à nouveau.
     monitorThisTrip: "Faire le suivi du trajet avant le départ :"
     notificationsTurnedOff: Les notifications sont désactivées pour votre compte.
-    # Note to translator: The notifyViaChannelWhen message, combined with
-    # altRouteRecommended, delaysAboveTHreshold, realtimeAlertFlagged,
-    # should read like a sentence.
     notifyViaChannelWhen: "Recevoir des notifications par {channel} lorsque :"
     oneHour: 1 heure
     realtimeAlertFlagged: Une alerte en temps réel affecte mon trajet
@@ -516,45 +596,47 @@ components:
     planNewTrip: Planifier un nouveau trajet
   TripStatusRenderers:
     active:
-      delayedHeading: "Trajet en cours, retardé de {formattedDuration}."
-      description: "Arrivée à destination prévue à {arrivalTime, time, short}."
-      earlyHeading: "Trajet en cours, en avance de {formattedDuration}."
+      delayedHeading: Trajet en cours, retardé de {formattedDuration}.
+      description: Arrivée à destination prévue à {arrivalTime, time, short}.
+      earlyHeading: Trajet en cours, en avance de {formattedDuration}.
       noDataHeading: Trajet en cours (données en temps réel non disponibles).
       onTimeHeading: Trajet en cours et prévu à l'heure.
     base:
       lastCheckedDefaultText: Dernière vérification inconnue
-      lastCheckedText: "Dernière vérification effectuée il y a {formattedDuration}"
+      lastCheckedText: Dernière vérification effectuée il y a {formattedDuration}
       togglePause: Suspendre le suivi
       tripIsNotSnoozed: Suspendre jusqu'à demain
       tripIsSnoozed: Reprendre le suivi du trajet
       unknownState: État du trajet inconnu
       untogglePause: Reprendre
     inactive:
-      description: Reprenez le suivi pour obtenir des dernières conditions de votre
-        trajet.
+      description: Reprenez le suivi pour obtenir des dernières conditions de votre trajet.
       heading: Suivi suspendu
     nextTripNotPossible:
       description: >
-        Le planificateur n'a pas pu trouver votre trajet aujourd'hui.
-        Veuillez replanifier votre trajet pour trouver une alternative.
+        Le planificateur n'a pas pu trouver votre trajet aujourd'hui. Veuillez
+        replanifier votre trajet pour trouver une alternative.
       heading: Trajet infaisable aujourd'hui
     noLongerPossible:
       description: >
-        Le planificateur n'a pas pu trouver votre trajet pour aucun des jours choisis.
-        Veuillez replanifier votre trajet pour trouver une alternative.
+        Le planificateur n'a pas pu trouver votre trajet pour aucun des jours
+        choisis. Veuillez replanifier votre trajet pour trouver une alternative.
       heading: Le trajet n'est plus possible
     notCalculated:
       awaiting: Calcul des conditions du trajet en cours...
-      description: Veuillez patienter pendant que les conditions du trajet sont déterminées.
+      description: >-
+        Veuillez patienter pendant que les conditions du trajet sont
+        déterminées.
       heading: Conditions du trajet indéterminées
     snoozed:
-      description: Reprenez le suivi pour obtenir des dernières conditions de votre
-        trajet.
+      description: Reprenez le suivi pour obtenir des dernières conditions de votre trajet.
       heading: Suivi suspendu jusqu'à demain
     upcoming:
-      nextTripBegins: "Prochain départ : {tripDatetime, date, ::eeeee yyyyMMdd} à\
-        \ {tripDatetime, time, short}."
-      tripBegins: Départ prévu à {tripStart, time, short}. (Le suivi en temps réel
+      nextTripBegins: >-
+        Prochain départ : {tripDatetime, date, ::eeeee yyyyMMdd} à
+        {tripDatetime, time, short}.
+      tripBegins: >-
+        Départ prévu à {tripStart, time, short}. (Le suivi en temps réel
         débutera à {monitoringStart, time, short}.)
       tripStartIsDelayed: Départ retardé de ${duration}.
       tripStartIsEarly: Départ avancé de ${duration} !
@@ -565,29 +647,35 @@ components:
     leaveAt: "Partez à "
   TripSummaryPane:
     happensOnDays: "Effectué : <strong>{days}</strong>"
-    notifications: "Notifications : <strong>{leadTimeInMinutes} mn avant l'heure de\
-      \ départ prévue</strong>"
+    notifications: >-
+      Notifications : <strong>{leadTimeInMinutes} mn avant l'heure de départ
+      prévue</strong>
     notificationsDisabled: "Notifications : <strong>Désactivées</strong>"
   TripTools:
-    # Note to translator: copyLink, linkCopied, print, reportIssue are width-constrained.
     copyLink: Copier le lien
-    # Text that replaces the copyLink button text after user clicks it.
     linkCopied: Copié
-    reportIssue: Un problème ? # "Signaler un problème" does not fit.
     reportEmailSubject: Signaler un problème avec OpenTripPlanner
-    reportEmailTemplate: |
+    reportEmailTemplate: >
       *** CONSIGNES POUR L'UTILISATEUR ***
+
       Cet email signalera votre problème aux administrateurs de ce site.
-      Veuillez remplir les détails ci-dessous, puis envoyez depuis votre logiciel de messagerie habituel.
+
+      Veuillez remplir les détails ci-dessous, puis envoyez depuis votre
+      logiciel de messagerie habituel.
+
 
       *** VEUILLEZ REMPLIR CI-DESSOUS ***
 
+
       Problème rencontré :
 
-      Type de trajet recherché (ex. à pied + transports, vélo + transports, voiture + transports) :
+
+      Type de trajet recherché (ex. à pied + transports, vélo + transports,
+      voiture + transports) :
+
 
       *** DÉTAILS TECHNIQUES ***
-  # Used in both desktop and mobile
+    reportIssue: Un problème ?
   TripViewer:
     accessible: Accessible
     bicyclesAllowed: Autorisés
@@ -599,27 +687,28 @@ components:
     tripDescription: Montez à {boardAtStop} et descendez à {disembarkAtStop}
     viewStop: Info
   UserAccountScreen:
-    confirmDelete: "Voulez-vous vraiment supprimer votre compte ? Cette action est\
-      \ irréversible."
+    confirmDelete: >-
+      Voulez-vous vraiment supprimer votre compte ? Cette action est
+      irréversible.
   UserSettings:
-    confirmDeletion: Vous avez des recherches et/ou lieux récemment enregistrés qui
-      vont être supprimés. Voulez-vous continuer ?
+    confirmDeletion: >-
+      Vous avez des recherches et/ou lieux récemment enregistrés qui vont être
+      supprimés. Voulez-vous continuer ?
     favoriteStops: Arrêts favoris
     myPreferences: Mes préférences
     mySavedPlaces: Mes lieux favoris (<manageLink>modifier</manageLink>)
     noFavoriteStops: Aucun arrêt favori
     recentPlaces: Lieux récents
-    recentSearches: Recherches récentes
     recentSearchSummary: "{mode} de {from} à {to}"
+    recentSearches: Recherches récentes
     rememberSearches: Enregistrer les recherches/lieux récents ?
-    stopId: "Arrêt n° {stopId}"
+    stopId: Arrêt n° {stopId}
     storageDisclaimer: >
-      En activant cette option, tous vos lieux, préférences et paramètres
-      seront enregistrés dans le cache de votre navigateur.
-      TriMet n'aura pas accès aux données concernant votre domicile, lieu de travail,
-      ou autre endroit. Vous pouvez à tout moment désactiver la collecte de vos
-      recherches/lieux récents et effacer vos domicile, lieu de travail, et arrêts
-      favoris.
+      En activant cette option, tous vos lieux, préférences et paramètres seront
+      enregistrés dans le cache de votre navigateur. TriMet n'aura pas accès aux
+      données concernant votre domicile, lieu de travail, ou autre endroit. Vous
+      pouvez à tout moment désactiver la collecte de vos recherches/lieux
+      récents et effacer vos domicile, lieu de travail, et arrêts favoris.
   UserTripSettings:
     forgetOptions: Oublier mes options
     rememberOptions: Enregistrer les options de trajet
@@ -628,147 +717,17 @@ components:
   VerifyEmailPane:
     emailIsVerified: Mon email est vérifié
     instructions1: >
-      Vous devriez recevoir un message par e-mail. Cliquez le lien dans le message
-      pour verifier votre adresse e-mail. Vous pourrez ensuite finir de créer votre
-      compte.
-    instructions2: Une fois votre adresse vérifiée, cliquez sur le bouton ci-dessous
-      pour continuer.
+      Vous devriez recevoir un message par e-mail. Cliquez le lien dans le
+      message pour verifier votre adresse e-mail. Vous pourrez ensuite finir de
+      créer votre compte.
+    instructions2: >-
+      Une fois votre adresse vérifiée, cliquez sur le bouton ci-dessous pour
+      continuer.
     resendVerification: Envoyer un nouveau message de vérification
   ViewSwitcher:
     switcher: Sélecteur de vues
   WelcomeScreen:
     prompt: Où désirez-vous aller ?
-
-common:
-  coordinates: "{lat}; {lon}"
-  dateExpressions:
-    today: Aujourd'hui
-    tomorrow: Demain
-    yesterday: Hier
-
-  daysOfWeek:
-    monday: lundi
-    tuesday: mardi
-    wednesday: mercredi
-    thursday: jeudi
-    friday: vendredi
-    saturday: samedi
-    sunday: dimanche
-  daysOfWeekCompact:
-    monday: lun.
-    tuesday: mar.
-    wednesday: mer.
-    thursday: jeu.
-    friday: ven.
-    saturday: sam.
-    sunday: dim.
-  daysOfWeekPlural:
-    monday: lundis
-    tuesday: mardis
-    wednesday: mercredis
-    thursday: jeudis
-    friday: vendredis
-    saturday: samedis
-    sunday: dimanches
-  # Common form UI messages
-  # Note to translator: these values are width-constrained.
-  forms:
-    back: Retour
-    cancel: Annuler
-    close: Fermer
-    error: erreur !
-    defaultValue: "{value} (défaut)"
-    delete: Supprimer
-    edit: Modifier
-    finish: Terminer
-    next: Suivant
-    no: Non
-    print: Imprimer
-    save: Enregistrer
-    startOver: Recommencer
-    submitting: Envoi en cours…
-    yes: Oui
-  itineraryDescriptions:
-    calories: "{calories, number} kcal" # SI unit
-    noItineraryToDisplay: Aucun trajet à afficher.
-    # Note to translator: noTransitFareProvided is width-constrained.
-    noTransitFareProvided: Tarif inconnu
-    transfers: "{transfers, plural, =0 {} one {# correspondance} other {# correspondances}}"
-    relativeCo2: >
-      {co2} de CO₂ en {isMore, select, true {plus} other {moins} } qu'en voiture
-
-  # Note to translator: some of the strings below are used in sentences such as:
-  # "No trip found for bike, walk, and transit."
-  # This set is based on OTP travel modes, in lower case, and accommodates the use
-  # of particles before/after each travel mode in some languages.
-  # In French, the above sentence could read:
-  # "Aucun trajet en vélo, à pied, et en transports publics n'a été trouvé."
-  modes:
-    bike: Vélo
-    bicycle_rent: En vélo en libre-service
-    bus: Bus
-    # The original OTP mode id is CABLE_CAR. Lowercase makes it cable_car.
-    cable_car: Tram tiré par câble
-    car: Voiture
-    car_park: Parc relais
-    drive: Voiture
-    ferry: Ferry
-    flex: Service Flex
-    funicular: Funiculaire
-    gondola: Téléphérique
-    micromobility: En trottinette électrique
-    micromobility_rent: En trottinette
-    rail: Train
-    rent: Location de véhicules
-    subway: Métro
-    tram: Tram
-    transit: En transports
-    walk: À pied
-
-  notifications:
-    email: e-mail
-    sms: SMS
-
-  # Note to translator: Places names below are used in
-  # contexts such as: "Edit home", "Set home address".
-  places:
-    custom: divers
-    dining: restaurant
-    home: domicile
-    work: lieu de travail
-
-  routing:
-    routeAndNumber: "Ligne {routeId}"
-    routeToHeadsign: "Direction {headsign}"
-
-  searchForms:
-    click: cliquez
-    enterDestination: Entrez votre destination ou {mapAction} sur la carte…
-    enterStartLocation: Entrez votre point de départ ou {mapAction} sur la carte…
-    tap: appuyez
-
-  time:
-    departureArrivalTimes: "{startTime, time, short}—{endTime, time, short}"
-    duration:
-      aFewSeconds: quelques secondes
-      nDays: "{days, plural, =1 {un jour} other {# jours}}"
-      nHours: "{hours, plural, =1 {une heure} other {# heures}}"
-      nMinutes: "{minutes, plural, =1 {une minute} other {# minutes}}"
-    durationAgo: "il y a {duration}"
-    tripDurationFormat: "{hours, plural, =0 {} other {# h }}{minutes} min { seconds,\
-      \ plural, =0 {} other {# s}}"
-
-util:
-  state:
-    errorPlanningTrip: Une erreur s'est produite lors de la planification du trajet.
-    networkUnavailable: Le système {network} n'est pas disponible pour le moment.
-    noTripFound: Aucun trajet trouvé.
-    noTripFoundForMode: Aucun trajet {modes} n'a été trouvé.
-    noTripFoundReason: Vos points de départ et d'arrivée ne sont peut-être pas desservis
-      dans le rayon spécifié ou aux heures indiquées, ou ne sont pas accessibles en
-      toute sécurité.
-    noTripFoundWithReason: "{noTripFound} {reason}"
-
 config:
   accessModes:
     bicycle: Transports + Vélo personnel
@@ -780,13 +739,23 @@ config:
   bicycleModes:
     bicycle: Vélo pers.
     bicycle_rent: Vélo partagé
-  micromobilityModes:
-    micromobility: Trottinnette pers.
-    micromobility_rent: Trottinette louée
-  # Default values for Flex Indicator (set in configuration as well)
   flex:
-    flex-service: Service Flex
-    flex-service-colon: "Service Flex :"
     both: Plus de détails au bas de l'itinéraire
     call-ahead: Appelez pour réserver
     continuous-dropoff: Demandez l'arrêt au conducteur
+    flex-service: Service Flex
+    flex-service-colon: "Service Flex :"
+  micromobilityModes:
+    micromobility: Trottinnette pers.
+    micromobility_rent: Trottinette louée
+util:
+  state:
+    errorPlanningTrip: Une erreur s'est produite lors de la planification du trajet.
+    networkUnavailable: Le système {network} n'est pas disponible pour le moment.
+    noTripFound: Aucun trajet trouvé.
+    noTripFoundForMode: Aucun trajet {modes} n'a été trouvé.
+    noTripFoundReason: >-
+      Vos points de départ et d'arrivée ne sont peut-être pas desservis dans le
+      rayon spécifié ou aux heures indiquées, ou ne sont pas accessibles en
+      toute sécurité.
+    noTripFoundWithReason: "{noTripFound} {reason}"

--- a/i18n/ko.yml
+++ b/i18n/ko.yml
@@ -1,563 +1,103 @@
 _id: ko
 _name: Korean
-
-# This file contains localized strings (a.k.a. messages) for the language indicated above:
-#   - Messages are organized in various categories and sub-categories.
-#   - A component or JS module can use messages from one or more categories.
-#   - In the code, messages are retrieved using an ID that is simply the path to the message.
-#     Use the dot '.' to separate categories and sub-categories in the path.
-#     For instance, for the message defined in YML below:
-#         common
-#           modes
-#             subway: Metro#
-#     then use the snippet below with the corresponding message id:
-#         <FormattedMessage id='common.modes.subway' /> // renders "Metro".
-#
-# It is important that message ids in the code be consistent with
-# the categories in this file. Below are some general guidelines:
-#   - For starters, there are an 'actions', 'components' and 'common'
-#     categories. Additional categories may be added as needed.
-#   - Each sub-category under 'components' denotes a component and
-#     should contain messages that are used only by that component (e.g. button captions).
-#   - In contrast, some strings are common to multiple components,
-#     so it makes sense to group them by theme (e.g. accessModes) under the 'common' category.
-
-# Messages that are generated from actions
 actions:
+  callTaker:
+    callQuerySaveError: "통화 쿼리를 저장하는 중에 오류가 발생했습니다: {err}"
+    callSaveError: "통화를 저장할 수 없습니다: {err}"
+    checkSessionError: "인증 세션을 설정하는 중에 오류가 발생했습니다: {err}"
+    couldNotFindCallError: 통화를 찾을 수 없습니다. 쿼리 저장 요청을 취소하는 중입니다.
+    fetchCallsError: "통화를 가져오는 중에 오류가 발생했습니다: {err}"
+    queryFetchError: "쿼리를 가져오는 중에 오류가 발생했습니다: {err}"
+  fieldTrip:
+    addNoteError: "트립 메모를 찾는 중에 오류가 발생했습니다:"
+    confirmOverwriteItineraries: |
+      이 작업은 이 요청에 대해 이전에 계획된 {outbound, select,
+        true {아웃바운드}
+        other {인바운드}
+        } 일정을 덮어씁니다. 계속하시겠습니까?
+    deleteItinerariesError: "트립 플랜을 삭제하는 중에 오류가 발생했습니다:"
+    deleteNoteError: "트립 메모를 삭제하는 중에 오류가 발생했습니다:"
+    editSubmitterNotesError: "제출자 메모를 수정하는 중에 오류가 발생했습니다:"
+    fetchFieldTripError: "트립을 가져오는 중에 오류가 발생했습니다: {err}"
+    fetchFieldTripsError: "트립을 가져오는 중에 오류가 발생했습니다: {err}"
+    fetchTripsForDateError: "필트 트립 날짜에 대한 트립을 가져오는 중에 오류가 발생했습니다: {err}"
+    incompatibleTripDateError: 계획한 트립 날짜({tripDate})가 요청한 트립 날짜({requestDate})가 아닙니다
+    itineraryCapacityError: "플랜을 저장할 수 없습니다: 하나 이상의 차량의 용량이 부족하여 이 플랜을 저장할 수 없습니다. 트립을 다시 계획하세요."
+    maxTripRequestsExceeded: 유효한 결과없이 초과된 트립 요청의 개수
+    saveItinerariesError: "트립을 저장하는 데 실패했습니다: {err}"
+    setDateError: "날짜를 설정하는 중에 오류가 발생했습니다:"
+    setGroupSizeError: "그룹 크기를 설정하는 중에 오류가 발생했습니다:"
+    setPaymentError: "결제 정보를 설정하는 중에 오류가 발생했습니다:"
+    setRequestStatusError: "요청 상태를 설정하는 중에 오류가 발생했습니다:"
+  location:
+    geolocationNotSupportedError: 귀하의 브라우저에서 지원되지 않는 지리적 위치
+    unknownPositionError: 위치를 가져오는 중 알 수 없는 오류가 발생했습니다
+  map:
+    currentLocation: (현재 위치)
   user:
     accountDeleted: 귀하의 사용자 계정({email})이 삭제되었습니다.
     authTokenError: 승인 토큰을 얻는 중에 오류가 발생했습니다.
     confirmDeleteMonitoredTrip: 이 트립을 제거하시겠습니까?
     confirmDeletePlace: 이 장소를 제거하시겠습니까?
     emailVerificationResent: 이메일 확인 메시지가 다시 전송되었습니다.
-    genericError: '오류가 발견되었습니다: {err}'
+    genericError: "오류가 발견되었습니다: {err}"
     itineraryExistenceCheckFailed: 선택한 트립이 가능한지 확인하는 중에 오류가 발생했습니다.
     preferencesSaved: 선호사항이 저장되었습니다.
     smsInvalidCode: 입력한 코드가 유효하지 않습니다. 다시 시도하세요.
     smsResendThrottled: 확인 SMS가 1분 미만 전에 표시된 전화번호로 전송되었습니다. 잠시 후 다시 시도하세요.
     smsVerificationFailed: 번호가 확인되지 않습니다. 입력한 코드가 만료되었을 수 있습니다. 새 코드를 요청한 후 다시 시도하세요.
-  fieldTrip:
-    addNoteError: '트립 메모를 찾는 중에 오류가 발생했습니다:'
-    confirmOverwriteItineraries: "이 작업은 이 요청에 대해 이전에 계획된 {outbound, select,\n  true\
-      \ {아웃바운드}\n  other {인바운드}\n  } 일정을 덮어씁니다. 계속하시겠습니까?\n"
-    deleteItinerariesError: '트립 플랜을 삭제하는 중에 오류가 발생했습니다:'
-    deleteNoteError: '트립 메모를 삭제하는 중에 오류가 발생했습니다:'
-    editSubmitterNotesError: '제출자 메모를 수정하는 중에 오류가 발생했습니다:'
-    fetchFieldTripError: '트립을 가져오는 중에 오류가 발생했습니다: {err}'
-    fetchFieldTripsError: '트립을 가져오는 중에 오류가 발생했습니다: {err}'
-    fetchTripsForDateError: '필트 트립 날짜에 대한 트립을 가져오는 중에 오류가 발생했습니다: {err}'
-    incompatibleTripDateError: 계획한 트립 날짜({tripDate})가 요청한 트립 날짜({requestDate})가 아닙니다
-    itineraryCapacityError: '플랜을 저장할 수 없습니다: 하나 이상의 차량의 용량이 부족하여 이 플랜을 저장할 수 없습니다.
-      트립을 다시 계획하세요.'
-    maxTripRequestsExceeded: 유효한 결과없이 초과된 트립 요청의 개수
-    saveItinerariesError: '트립을 저장하는 데 실패했습니다: {err}'
-    setDateError: '날짜를 설정하는 중에 오류가 발생했습니다:'
-    setPaymentError: '결제 정보를 설정하는 중에 오류가 발생했습니다:'
-    setGroupSizeError: '그룹 크기를 설정하는 중에 오류가 발생했습니다:'
-    setRequestStatusError: '요청 상태를 설정하는 중에 오류가 발생했습니다:'
-  location:
-    geolocationNotSupportedError: 귀하의 브라우저에서 지원되지 않는 지리적 위치
-    unknownPositionError: 위치를 가져오는 중 알 수 없는 오류가 발생했습니다
-  map:
-    currentLocation: (현재 위치)
-  callTaker:
-    callQuerySaveError: '통화 쿼리를 저장하는 중에 오류가 발생했습니다: {err}'
-    callSaveError: '통화를 저장할 수 없습니다: {err}'
-    checkSessionError: '인증 세션을 설정하는 중에 오류가 발생했습니다: {err}'
-    couldNotFindCallError: 통화를 찾을 수 없습니다. 쿼리 저장 요청을 취소하는 중입니다.
-    fetchCallsError: '통화를 가져오는 중에 오류가 발생했습니다: {err}'
-    queryFetchError: '쿼리를 가져오는 중에 오류가 발생했습니다: {err}'
-components:
-  BatchSettings:
-    destination: 목적지
-    origin: 출발지
-    planTripTooltip: 트립 계획
-    settings: 여행 설정
-    validationMessage: '트립 계획을 위해 다음 필드를 정의하세요: {issues}'
-  BeforeSignInScreen:
-    mainTitle: 로그인 중
-    message: "이 페이지에 접근하려면 로그인해야 합니다. 로그인 페이지로 리디렉션하는 동안 기다려 주세요…\n"
-  CallTakerPanel:
-    advancedOptions: 고급 옵션
-    groupSize: '그룹 크기:'
-    intermediateDestination: 중간 목적지 입력
-  DateTimeOptions:
-    arriveBy: 도착 시간
-    departAt: 출발 시간
-    now: 지금
-  ExistingAccountDisplay:
-    a11y: 접근성
-    mainTitle: 내 설정
-    notifications: 알림
-    places: 좋아하는 장소
-    terms: 약관
-  FavoritePlaceList:
-    addAnotherPlace: 다른 장소 추가
-    description: '자주 가는 장소를 추가하여 트립 플랜 시간을 절약하세요 :'
-    editThisPlace: 이 장소 수정
-    setAddressForPlaceType: '{placeType}의 주소 설정'
-  FavoritePlaceScreen:
-    addNewPlace: 새 장소 추가
-    editPlace: '{placeName} 수정'
-    editPlaceGeneric: 장소 수정
-    invalidAddress: 이 장소의 위치를 설정하세요.
-    invalidName: 이 장소의 이름을 입력하세요.
-    nameAlreadyUsed: 이 이름은 이미 다른 장소에 사용되고 있습니다. 다른 이름을 입력해 주세요.
-    placeNotFound: 장소를 찾을 수 없음
-    placeNotFoundDescription: 죄송합니다. 요청하신 장소를 찾을 수 없습니다.
-  LiveStopTimes:
-    autoRefresh: 도착을 자동으로 새로 고침?
-  MapLayers:
-    bike-rental: '{companies} 공유자전거'
-    car-rental: 렌터카 위치
-    micromobility-rental: '{companies} 전동스쿠터'
-    park-and-ride: 파크 앤 라이드 위치
-    satellite: 위성
-    shared-vehicles: 공유 차량
-    stops: 대중 교통 정류장
-    streets: 거리
-  MetroUI:
-    arriveAtTime: '{time}에 도착'
-    fromStop: '{stop}에서부터'
-    itineraryDescription: '{routes}을(를) 이용한 {time} 일정'
-    leaveAt: 출발
-    multipleOptions: 여러 옵션
-    orAlternatives: 또는 같은 방향의 다른 경로
-    timeWalking: '{time} 걷기'
-  NarrativeItinerariesHeader:
-    changeSortDir: 정렬 방향 변경
-    itinerariesAndIssues: '{itinerariesFound} 및 {numIssues}'
-    itinerariesFound: "{itineraryNum} 개의 여정을 찾았습니다"
-    numIssues: "{issueNum, plural,\n one {# 문제}\n other {# 문제}\n }"
-    searching: 옵션을 찾고 있는 중...
-    selectArrivalTime: 도착 시간
-    selectBest: 가장 좋은 옵션
-    selectCost: 비용
-    selectDepartureTime: 출발 시각
-    selectDuration: 기간
-    selectWalkTime: 도보 시간
-    sortBy: 정렬 기준
-    viewAll: 모든 옵션 보기
-  NavLoginButton:
-    help: 지원
-    myAccount: 내 계정
-    signIn: 로그인
-    signOut: 로그 아웃
-  NewAccountWizard:
-    finish: 계정 설정을 완료하셨습니다!
-    notifications: 알림 설정
-    places: 위치 추가
-    terms: 새 계정 생성
-    verify: 이메일 주소 확인
-  NotificationPrefsPane:
-    description: 자주 가는 트립에 대한 알림을 받을 수 있습니다.
-    noneSelect: 알림 거부
-    notificationChannelPrompt: 알림을 어떻게 받고 싶습니까?
-    notificationEmailDetail: '알림 이메일이 다음으로 전송됩니다:'
-  PhoneNumberEditor:
-    changeNumber: 번호 변경
-    invalidCode: 확인 코드 6 자리를 입력하세요.
-    invalidPhone: 유효한 전화번호를 입력하세요.
-    pending: 보류 중
-    placeholder: 전화번호를 입력하십시오
-    prompt: 'SMS 알림 수신을 위한 전화번호를 입력하세요:'
-    requestNewCode: 새 코드 요청
-    sendVerificationText: 확인 텍스트 전송
-    smsDetail: 'SMS 알림이 다음으로 전송됩니다:'
-    verificationCode: '확인 코드:'
-    verificationInstructions: "휴대폰의 SMS 메시지 앱에서 인증 코드를 확인하고 아래에 코드를 입력하세요(코드는 10분\
-      \ 후에 만료됩니다).\n"
-    verified: 확인됨
-    verify: 확인
-    phoneNumberVerified: 전화번호 {phoneNumber}가 성공적으로 확인되었습니다.
-  Place:
-    deleteThisPlace: 이 장소 삭제
-    enterAlert: "양식에 출발지/목적지를 입력하고(또는 지도를 클릭하여 설정), 생성된 마커를 클릭하여 {placeType} 위치로 설정하세요.\n"
-    viewStop: 정류장 보기
-  PlanTripButton:
-    planTrip: 트립 계획
-  RealtimeAnnotation:
-    delaysShownInResults: "귀하의 여행 결과는 실시간 정보를 기반으로 조정되었습니다. 정상적인 상황에서 이 여행은 다음 경로를\
-      \ 사용하여 {normalDuration} 이 소요됩니다:\n"
-    serviceUpdate: 서비스 업데이트
-  RelatedStopsPanel:
-    noArrivalFound: 도착편을 찾을 수 없음
-    viewDetails: 세부 정보 보기
-    relatedStops: 관련 정류장
-  ResultsError:
-    backToSearch: 검색으로 돌아가기
-  ResultsHeader:
-    noTripFound: 트립을 찾을 수 없음
-    tripsFound: '{count} 개의 옵션 을 찾았습니다'
-    waiting: 기다리는 중...
-  RouteDetails:
-    moreDetails: 더 자세한 내용
-    operatedBy: '{agencyName}에서 운영하는 서비스'
-    selectADirection: 방향 선택…
-    stopsTo: 방면
-  RouteViewer:
-    agencyFilter: 에이전시 필터
-    allAgencies: 모든 에이전시
-    allModes: 모든 모드
-    details: ' '
-    findARoute: 경로 찾기
-    header: 경로 뷰어
-    modeFilter: 모드 필터
-    noFilteredRoutesFound: 필터와 일치하는 경로가 없습니다!
-    shortTitle: 경로 보기
-    title: 경로 뷰어
-  SavedTripEditor:
-    editSavedTrip: 저장된 트립 수정
-    saveNewTrip: 새 트립 저장
-    tripInformation: 트립 정보
-    tripNotFound: 트립을 찾을 수 없음
-    tripNotFoundDescription: 죄송합니다. 요청된 트립을 찾을 수 없습니다.
-    tripNotifications: 트립 알림
-  SavedTripList:
-    fromTo: "{from}에서 {to}까지"
-    myTrips: 내 트립
-    noSavedTrips: 저장된 트립이 없음
-    noSavedTripsInstructions: 지도에서 먼저 트립을 검색하세요.
-    pause: 일시 정지
-    resume: 다시 시작
-  SavedTripScreen:
-    tooManyTrips: "저장된 트립의 최대 개수인 5개에 도달했습니다. 저장된 트립에서 사용하지 않는 트립을 제거한 후, 다시 시도하세요.\n"
-    tripNameRequired: 트립의 이름을 입력하세요.
-    tripNameAlreadyUsed: 저장된 다른 트립이 이 이름을 사용하고 있습니다. 다른 이름을 선택하세요.
-  SaveTripButton:
-    cantSaveText: 저장할 수 없음
-    cantSaveTooltip: 대중교통을 포함하고 렌트 또는 차량 호출을 포함하지 않는 트립 일정만 모니터링할 수 있습니다.
-    saveTripText: 트립 저장
-    signInText: 로그인하여 트립 저장
-    signInTooltip: 트립을 저장하려면 로그인하십시오.
-  StopViewer:
-    displayStopId: '<strong>정류장 ID</strong>: {stopId}'
-    flexStop: 이 정류장은 가변 정류장입니다. 이 가변 구역에서 차량은 요청이 있을 때에만 승객을 태우고 내릴 것입니다. 이 지역에서 서비스를
-      받으려면 미리 전화를 해야 할 수도 있습니다.
-    header: 정류장 뷰어
-    loadingText: 정류장 로드 중…
-    noStopsFound: 날짜에 대한 정류장 시간이 없습니다.
-    operatorLogoAriaLabel: "정류장 {operatorName}:"
-    timezoneWarning: 출발 시간은 <strong>{timezoneCode}</strong>(으)로 표시됩니다.
-    titleBarStopId: 정류장 {stopId}
-    viewNextArrivals: 다음 도착편 보기
-    viewSchedule: 스케쥴 보기
-    zoomToStop: 정류장 확대
-    findSchedule: 날짜별 일정 검색
-  SubNav:
-    languages: "언어"
-    languageSelector: 언어 선택
-    myAccount: 내 계정
-    selectALanguage: 언어 선택
-    settings: 설정
-    trips: 트립
-    userMenu: 프로필 옵션
-  SwitchButton:
-    defaultContent: 바꾸기
-    switchLocations: 위치 바꾸기
-  TermsOfUsePane:
-    termsOfServiceStatement: "본인은 만 18세 이상임을 확인하며, 트립 플래너 이용을 위한 <termsOfUseLink>이용\
-      \ 약관</termsOfUseLink>을 읽고 이에 동의합니다.\n"
-    mustAgreeToTerms: 계속하시려면 서비스 약관에 동의하셔야 합니다.
-    confirmDeletionPrompt: "트립 기록 저장에 대한 동의를 제거하면 트립 기록이 삭제됩니다. 계속하시겠습니까?\n"
-    termsOfStorageStatement: "선택 사항: 본인의 지역의 대중 교통 서비스를 개선하기 위해 내 트립 플랜 기록을 저장하는 데\
-      \ 동의합니다. <termsOfStorageLink>보다 자세한 정보...</termsOfStorageLink>\n"
-  TransitVehicleOverlay:
-    stopped_at: '{stop}에서 문이 열립니다'
-    vehicleName: '차량 {vehicleNumber}'
-    in_transit_to: '다음 정류장: {stop}'
-    incoming_at: '{stop}에 접근하는 중'
-    travelingAt: 현재 {milesPerHour} 속도로 주행 중
-  TripBasicsPane:
-    checkingItineraryExistence: 각 요일의 트립을 확인 중…
-    selectAtLeastOneDay: 모니터링하려면 최소 1일 이상을 선택하세요.
-    tripDaysPrompt: 어느 요일에 이 트립을 사용하시나요?
-    tripIsAvailableOnDaysIndicated: 트립은 위에 표시된 요일에 제공됩니다.
-    tripNamePrompt: '이 트립의 이름을 입력하세요:'
-    tripNotAvailableOnDay: '{repeatedDay}에는 트립을 이용할 수 없음'
-    unsavedChangesExistingTrip: 트립을 아직 저장하지 않았습니다. 나가시면 변경내용이 사라집니다.
-    unsavedChangesNewTrip: 새 트립을 저장하지 않았습니다. 나가시면 변경내용이 사라집니다.
-  TripNotificationsPane:
-    advancedSettings: 고급 설정
-    altRouteRecommended: 대체 경로 또는 환승 지점이 권장됩니다
-    delaysAboveThreshold: '다음 시간 이상의 지연 또는 차질이 있습니다:'
-    howToReceiveAlerts: "저장된 트립에 대한 경고를 받으려면, 계정 설정에서 알림을 활성화하고 트립을 다시 저장하세요.\n"
-    monitorThisTrip: '시작하기 전에 이 여행을 모니터링하세요:'
-    notificationsTurnedOff: 계정에 대한 알림이 꺼져 있습니다.
-    notifyViaChannelWhen: '다음의 경우, {channel}을 통해 알려주세요:'
-    oneHour: 1 시간
-    realtimeAlertFlagged: 내 트립 일정에 실시간 경고가 있습니다
-  TripStatus:
-    deleteTrip: 트립 삭제
-    planNewTrip: 새 트립 계획
-    alerts: '{alerts, plural, one {# 경고!} other {# 경고!}}'
-  TripStatusRenderers:
-    base:
-      lastCheckedDefaultText: 마지막 확인 시간 알 수 없음
-      lastCheckedText: '마지막 확인 시간: {formattedDuration} 전'
-      togglePause: 일시 정지
-      tripIsNotSnoozed: 오늘 하루 동안 스누즈하기
-      tripIsSnoozed: 트립 분석 스누즈 해제
-      unknownState: 트립 상태 알 수 없음
-      untogglePause: 다시 시작
-    notCalculated:
-      awaiting: 계산을 기다리는 중…
-      description: 트립이 계산되는 동안 잠시 기다려 주십시오.
-      heading: 트립이 아직 계산되지 않음
-    snoozed:
-      description: 트립 모니터링의 스누즈를 해제하여 상태 업데이트를 확인하세요.
-      heading: 오늘 트립 모니터링이 일시 중지되었습니다.
-    upcoming:
-      nextTripBegins: 다음 트립은 {tripDatetime, date, ::eeeee yyyyMMdd}, {tripDatetime,
-        time, short}에 시작됩니다.
-      tripStartsSoonOnTime: 트립은 곧 정시에 시작됩니다.
-      tripBegins: 트립이 {tripStart, time, short}에 시작될 것으로 예정되어 있습니다. (실시간 모니터링은 {monitoringStart,
-        time, short}에 시작됩니다.)
-      tripStartIsDelayed: 트립 시작 시간이 ${duration} 지연됩니다!
-      tripStartIsEarly: 트립이 예상보다 ${duration} 일찍 시작됩니다!
-      tripStartsSoonNoUpdates: 트립이 곧 시작됩니다 (실시간 업데이트를 사용할 수 없습니다).
-    nextTripNotPossible:
-      heading: 오늘 트립이 불가능함
-      description: "트립 플래너가 오늘 트립을 찾을 수 없습니다. 대체 경로를 찾으려면 여정을 트립 일정을 다시 계획하세요.\n"
-    noLongerPossible:
-      heading: 트립은 더 이상 불가능함
-      description: "트립 플래너는 선택된 요일에 트립을 찾을 수 없습니다. 대체 경로를 찾으려면 트립 일정을 다시 계획하세요.\n"
-    inactive:
-      description: 트립 모니터링을 다시 시작하여 상태 업데이트 확인
-      heading: 트립 모니터링이 일시 중지됨
-    active:
-      delayedHeading: 진행 중인 트립이 {formattedDuration} 지연됩니다!
-      description: '{arrivalTime, time, short}에 목적지에 도착할 예정입니다.'
-      earlyHeading: 진행 중인 트립이 예상보다 {formattedDuration} 일찍 시작됩니다!
-      noDataHeading: 트립이 진행 중입니다 (실시간 업데이트를 사용할 수 없습니다).
-      onTimeHeading: 트립이 정시에 진행 중에 있습니다.
-  TripTools:
-    copyLink: 링크 복사
-    linkCopied: 복사됨
-    reportEmailSubject: OpenTripPlanner로 문제 보고
-    reportEmailTemplate: "*** 사용자 안내 ***\n 이 기능을 사용하면 사이트 관리자에게 검토할 수 있도록 보고서를 이메일로\
-      \ 전송할 수 있습니다.\n 아래 프롬프트를 작성한 후, 귀하의 일반 이메일 프로그램을 사용하여 전송하여 주십시오.\n \n *** 다음을\
-      \ 작성해 주십시오 ***\n \n 발생한 문제:\n \n시도하려고 했던 트립의 종류 (예: 도보 + 대중 교통, 자전거 + 대중 교통,\
-      \ 자동차 + 대중 교통)::\n \n *** 기술적 문제의 세부 내용 ***\n"
-    reportIssue: 문제 보고
-  TripViewer:
-    accessible: 접근성이 있음
-    bicyclesAllowed: 허용됨
-    header: 트립 뷰어
-    viewStop: 보기
-    routeHeader: '노선: <strong>{routeShortName}</strong> {routeLongName}'
-  UserSettings:
-    confirmDeletion: 최근 검색이나 장소가 저장되어 있습니다. 최근 장소 또는 검색을 비활성화하면 이러한 항목이 제거됩니다. 계속하시겠습니까?
-    favoriteStops: 좋아하는 정류장
-    myPreferences: 내 환경설정
-    mySavedPlaces: 내 저장 장소 (<manageLink>관리</manageLink>)
-    noFavoriteStops: 좋아하지 않는 정류장
-    recentPlaces: 최근 장소
-    recentSearches: 최근 검색
-    recentSearchSummary: '{from}에서 {to}까지 {mode}'
-    rememberSearches: 최근 검색어/장소를 기억하십니까?
-    stopId: '정류장 ID: {stopId}'
-    storageDisclaimer: "저장하기로 선택한 환경설정, 장소 또는 설정은 브라우저의 로컬 저장소에 저장됩니다. TriMet은 귀하의\
-      \ 집, 직장 또는 기타 위치에 대한 정보에 접근할 수 없습니다. 언제든지 최근 장소/검색 기억을 끄고 저장된 집/직장 위치 및 즐겨찾는\
-      \ 정류장을 지우실 수 있습니다.\n"
-  UserTripSettings:
-    forgetOptions: 내 옵션 잊기
-    rememberOptions: 트립 옵션 기억하기
-    restoreDefaults: 기본 설정 복원
-    restoreMyDefaults: 내 기본 설정 복원
-  ViewSwitcher:
-    switcher: 변경
-  A11yPrefs:
-    accessibilityRoutingByDefault: 접근 가능한 트립 선호를 기본 설정으로
-  AddPlaceButton:
-    addPlace: 장소 추가
-    tooManyPlaces: 중간 경유지의 최대 수에 도달함
-    needOriginDestination: 출발지/목적지를 정의하고 중간 경유지 추가
-  AdvancedOptions:
-    bannedRoutes: 금지된 경로 선택…
-    maxBike: 최대 자전거 {unitsString}
-    maxWalk: 최대 도보 {unitsString}
-    preferredRoutes: 선호 경로 선택…
-    walkReluctance: 걷기 제외
-  AfterSignInScreen:
-    message: 몇 초 후에도 페이지가 로드되지 않는 경우, <redirectLink>여기를 클릭</redirectLink>하십시오.
-    mainTitle: 경로 재설정 중...
-  AmenitiesPanel:
-    bikesAvailable: "{count, plural,\n =0 {이용 가능한 자전거가 없습니다}\n one {# 자전거 이용 가능}\n\
-      \ other {# 자전거 이용 가능}\n }\n"
-    bikesAtStation: "{companyLength, plural,\n =0 {{name}에서 자전거}\n other {{name}에서\
-      \ {company} 자전거}\n }\n"
-    bikesNearby: "{count, plural,\n =0 {근처에 {company} 자전거가 없습니다}\n one {근처에{company}자전거\
-      \ # 대}\n other {근처에{company}자전거 # 대}\n }\n"
-    nearbyAmenities: 근처 편의시설
-    noNearbyBikes: 근처에 자전거 대여점을 찾을 수 없습니다.
-    noNearbyScooters: 근처에 마이크로 모빌리티 대여점을 찾을 수 없습니다.
-    noPRLotsFound: 근처에 파크 앤 라이드를 찾을 수 없습니다.
-    spacesAvailable: "{count, plural,\n =0 {주차 공간 없음}\n one {# 대 주차}\n other {# 대\
-      \ 주차}\n }\n"
-    scootersNearby: "{count, plural,\n =0 {근처에 {company} 전기 스쿠터 없음}\n one {근처에 {company}\
-      \ 전기 스쿠터 # 대}\n other {근처에 {company} 전기 스쿠터 # 대}\n }\n"
-  AppMenu:
-    callHistory: 통화 기록
-    closeMenu: 메뉴 닫기
-    fieldTrip: 필드 트립
-    mailables: 발송 가능
-    openMenu: 메뉴 열기
-    skipNavigation: 내비게이션 건너뛰기
-  DateTimePreview:
-    arriveAt: 도착 {arriveTime, time, short}
-    dayLastWeek: 지난 {formattedDayOfWeek}
-    departAt: 출발 {departTime, time, short}
-    editDepartOrArrival: 출발 시간 또는 도착 시간 수정
-    leaveNow: 지금 출발
-    range: '{startTime, time, short}에서 {endTime, time, short}까지'
-  DefaultItinerary:
-    multiModeSummary: '{accessMode} + {transitMode}'
-    clickDetails: 클릭하여 자세한 내용 보기
-  DeleteUser:
-    deleteMyAccount: 내 계정 삭제
-  EnhancedStopMarker:
-    stopID: '정류장 ID:'
-    stopViewer: 정류장 뷰어
-  LocationSearch:
-    setOrigin: 출발지 선택
-    enterLocation: 위치 입력
-    setDestination: 목적지 선택
-  MobileOptions:
-    header: 검색 옵션 설정
-  ModeDropdown:
-    exclusiveMode: '{mode} 전용'
-  PlaceEditor:
-    genericLocationPlaceholder: 위치 검색
-    locationPlaceholder: '{placeName} 위치 검색'
-    namePrompt: '지명:'
-    addressPrompt: '주소:'
-    nameExample: 내 커피숍
-  PlanFirstLastButtons:
-    first: 처음
-    last: 마지막
-    next: 다음
-    previous: 이전
-  StopScheduleTable:
-    block: 블록
-    departure: 출발
-    destination: 목적지
-    route: 경로
-  TripSummary:
-    arriveAt: "도착 "
-    leaveAt: "출발 "
-  TripSummaryPane:
-    happensOnDays: '발생: <strong>{days}</strong>'
-    notifications: '알림: <strong>출발 예정 시간 {leadTimeInMinutes} 분 전</strong>'
-    notificationsDisabled: '알림: <strong>비활성화됨</strong>'
-  WelcomeScreen:
-    prompt: 어디로 가고 싶으신가요?
-  AccountSetupFinishPane:
-    message: 트립 계획을 시작하실 준비가 되었습니다.
-  BackToTripPlanner:
-    backToTripPlanner: 트립 플래너로 돌아가기
-  BatchResultsScreen:
-    expandMap: 지도 확장
-    showResults: 결과 보기
-  BatchRoutingPanel:
-    shortTitle: 트립 계획
-  BatchSearchScreen:
-    header: 트립 계획
-  DateTimeScreen:
-    header: 날짜/시간 설정
-  ErrorMessage:
-    header: 트립을 계획할 수 없음
-    warning: 경고
-  FormNavigationButtons:
-    ariaLabel: 내비게이션 양식
-  NotFound:
-    description: 요청한 콘텐츠를 사용할 수 없습니다.
-    header: 콘텐츠를 찾을 수 없음
-  PrintLayout:
-    itinerary: 트립 일정
-    toggleMap: 지도 토글
-  RealtimeStatusLabel:
-    early: '{minutes} 일찍'
-    late: '{minutes} 늦게'
-    onTime: 제 시간
-    scheduled: 예정
-  RelatedPanel:
-    hideExtraStops: 여분의 정류장 숨기기
-    showExtraStops: '{count}개의 여분의 정류장 보이기'
-  SimpleRealtimeAnnotation:
-    usingRealtimeInfo: 이 트립은 실시간 교통 및 지체 정보를 사용합니다
-  StackedPaneDisplay:
-    savePreferences: 환경설정 저장
-  StopTimeCell:
-    realtime: 실시간 데이터 기반
-    scheduled: 일정 데이터 기준
-    imminentArrival: 예정
-  UserAccountScreen:
-    confirmDelete: 귀하의 사용자 계정을 삭제하시겠습니까? 한 번 그렇게 하신 경우, 복구할 수 없습니다.
-  VerifyEmailPane:
-    emailIsVerified: 내 이메일이 확인되었습니다!
-    instructions1: "귀하의 이메일의 받은 편지함을 확인한 후, 메시지의 링크를 따라 이메일 주소를 확인하여 계정 설정을 완료하세요.\n"
-    instructions2: 확인 후, 아래의 버튼을 클릭하여 계속 진행하십시오.
-    resendVerification: 확인 이메일을 다시 전송
-  SettingsPreview:
-    defaultPreviewText: 대중 교통 옵션 및 기본 설정
-  SessionTimeout:
-    header: 세션이 곧 타임아웃됩니다!
-    body: 세션이 1분 이내에 만료됩니다. 검색을 유지하려면 '세션 계속'을 누르세요.
-    keepSession: 세션 계속
-  PointPopup:
-    zoomToLocation: 이 위치로 확대
-  ItinerarySummary:
-    itineraryDetails: 여정 세부 정보
-    minMaxFare: '{minTotalFare} - {maxTotalFare}'
 common:
+  coordinates: "{lat}, {lon}"
   dateExpressions:
+    today: 오늘
     tomorrow: 내일
     yesterday: 어제
-    today: 오늘
   daysOfWeek:
+    friday: 금요일
     monday: 월요일
+    saturday: 토요일
     sunday: 일요일
+    thursday: 목요일
     tuesday: 화요일
     wednesday: 수요일
-    friday: 금요일
-    saturday: 토요일
-    thursday: 목요일
   daysOfWeekCompact:
     friday: 금.
+    monday: 월.
     saturday: 토.
     sunday: 일.
-    monday: 월.
     thursday: 목.
     tuesday: 화.
     wednesday: 수.
+  daysOfWeekPlural:
+    friday: 금요일
+    monday: 월요일
+    saturday: 토요일
+    sunday: 일요일
+    thursday: 목요일
+    tuesday: 화요일
+    wednesday: 수요일
   forms:
-    defaultValue: '{value} (기본값)'
-    error: 오류!
-    startOver: 다시 시작
-    yes: 예
     back: 뒤로
     cancel: 취소
     close: 닫기
+    defaultValue: "{value} (기본값)"
     delete: 삭제
     edit: 수정
+    error: 오류!
     finish: 마침
     next: 다음
-    no: 아니요
+    "no": 아니요
     print: 인쇄
     save: 저장
+    startOver: 다시 시작
+    "yes": 예
   itineraryDescriptions:
-    calories: '{calories, number} 칼로리'
+    calories: "{calories, number} 칼로리"
     noItineraryToDisplay: 표시할 일정이 없습니다.
     noTransitFareProvided: 운임 정보 없음
-    relativeCo2: >
-      {co2}
-      CO₂ 를 자동차보다
-      {isMore, select,
-      true {더}
-      other {덜}
-      } 사용합니다
-    transfers: '{transfers, plural, =0 {} other {# 전송}}'
+    relativeCo2: |
+      {co2} CO₂ 를 자동차보다 {isMore, select, true {더} other {덜} } 사용합니다
+    transfers: "{transfers} 전송"
   modes:
     bicycle_rent: 공유자전거
     bike: 자전거
@@ -588,57 +128,537 @@ common:
     work: 직장
   routing:
     routeAndNumber: 경로 {routeId}
-    routeToHeadsign: '{headsign} 방면'
+    routeToHeadsign: "{headsign} 방면"
   searchForms:
-    enterStartLocation: "시작 위치 또는 {mapAction}을(를) 지도에 입력하십시오…"
-    enterDestination: "목적지 또는{mapAction}을(를) 지도에 입력하십시오…"
     click: 클릭
+    enterDestination: 목적지 또는{mapAction}을(를) 지도에 입력하십시오…
+    enterStartLocation: 시작 위치 또는 {mapAction}을(를) 지도에 입력하십시오…
     tap: 클릭
-  daysOfWeekPlural:
-    friday: 금요일
-    thursday: 목요일
-    wednesday: 수요일
-    monday: 월요일
-    saturday: 토요일
-    sunday: 일요일
-    tuesday: 화요일
   time:
-    departureArrivalTimes: '{startTime, time, short}—{endTime, time, short}'
+    departureArrivalTimes: "{startTime, time, short}—{endTime, time, short}"
     duration:
       aFewSeconds: 몇 초
       nDays: "{days} 일"
       nHours: "{hours} 시간"
       nMinutes: "{minutes} 분"
     durationAgo: "{duration} 전"
-    tripDurationFormat: "{hours, plural, =0 {} other {# 시간 }}{minutes} 분 { seconds,\
-      \ plural, =0 {} other {# 초}}"
-  coordinates: '{lat}, {lon}'
+    tripDurationFormat: >-
+      {hours, plural, =0 {} other {# 시간 }}{minutes} 분 { seconds, plural, =0 {}
+      other {# 초}}
+components:
+  A11yPrefs:
+    accessibilityRoutingByDefault: 접근 가능한 트립 선호를 기본 설정으로
+  AccountSetupFinishPane:
+    message: 트립 계획을 시작하실 준비가 되었습니다.
+  AddPlaceButton:
+    addPlace: 장소 추가
+    needOriginDestination: 출발지/목적지를 정의하고 중간 경유지 추가
+    tooManyPlaces: 중간 경유지의 최대 수에 도달함
+  AdvancedOptions:
+    bannedRoutes: 금지된 경로 선택…
+    maxBike: 최대 자전거 {unitsString}
+    maxWalk: 최대 도보 {unitsString}
+    preferredRoutes: 선호 경로 선택…
+    walkReluctance: 걷기 제외
+  AfterSignInScreen:
+    mainTitle: 경로 재설정 중...
+    message: 몇 초 후에도 페이지가 로드되지 않는 경우, <redirectLink>여기를 클릭</redirectLink>하십시오.
+  AmenitiesPanel:
+    bikesAtStation: |
+      {companyLength, plural,
+       =0 {{name}에서 자전거}
+       other {{name}에서 {company} 자전거}
+       }
+    bikesAvailable: |
+      {count, plural,
+       =0 {이용 가능한 자전거가 없습니다}
+       one {# 자전거 이용 가능}
+       other {# 자전거 이용 가능}
+       }
+    bikesNearby: |
+      {count, plural,
+       =0 {근처에 {company} 자전거가 없습니다}
+       one {근처에{company}자전거 # 대}
+       other {근처에{company}자전거 # 대}
+       }
+    nearbyAmenities: 근처 편의시설
+    noNearbyBikes: 근처에 자전거 대여점을 찾을 수 없습니다.
+    noNearbyScooters: 근처에 마이크로 모빌리티 대여점을 찾을 수 없습니다.
+    noPRLotsFound: 근처에 파크 앤 라이드를 찾을 수 없습니다.
+    scootersNearby: |
+      {count, plural,
+       =0 {근처에 {company} 전기 스쿠터 없음}
+       one {근처에 {company} 전기 스쿠터 # 대}
+       other {근처에 {company} 전기 스쿠터 # 대}
+       }
+    spacesAvailable: |
+      {count, plural,
+       =0 {주차 공간 없음}
+       one {# 대 주차}
+       other {# 대 주차}
+       }
+  AppMenu:
+    callHistory: 통화 기록
+    closeMenu: 메뉴 닫기
+    fieldTrip: 필드 트립
+    mailables: 발송 가능
+    openMenu: 메뉴 열기
+    skipNavigation: 내비게이션 건너뛰기
+  BackToTripPlanner:
+    backToTripPlanner: 트립 플래너로 돌아가기
+  BatchResultsScreen:
+    expandMap: 지도 확장
+    showResults: 결과 보기
+  BatchRoutingPanel:
+    shortTitle: 트립 계획
+  BatchSearchScreen:
+    header: 트립 계획
+  BatchSettings:
+    destination: 목적지
+    origin: 출발지
+    planTripTooltip: 트립 계획
+    settings: 여행 설정
+    validationMessage: "트립 계획을 위해 다음 필드를 정의하세요: {issues}"
+  BeforeSignInScreen:
+    mainTitle: 로그인 중
+    message: |
+      이 페이지에 접근하려면 로그인해야 합니다. 로그인 페이지로 리디렉션하는 동안 기다려 주세요…
+  CallTakerPanel:
+    advancedOptions: 고급 옵션
+    groupSize: "그룹 크기:"
+    intermediateDestination: 중간 목적지 입력
+  DateTimeOptions:
+    arriveBy: 도착 시간
+    departAt: 출발 시간
+    now: 지금
+  DateTimePreview:
+    arriveAt: 도착 {arriveTime, time, short}
+    dayLastWeek: 지난 {formattedDayOfWeek}
+    departAt: 출발 {departTime, time, short}
+    editDepartOrArrival: 출발 시간 또는 도착 시간 수정
+    leaveNow: 지금 출발
+    range: "{startTime, time, short}에서 {endTime, time, short}까지"
+  DateTimeScreen:
+    header: 날짜/시간 설정
+  DefaultItinerary:
+    clickDetails: 클릭하여 자세한 내용 보기
+    multiModeSummary: "{accessMode} + {transitMode}"
+  DeleteUser:
+    deleteMyAccount: 내 계정 삭제
+  EnhancedStopMarker:
+    stopID: "정류장 ID:"
+    stopViewer: 정류장 뷰어
+  ErrorMessage:
+    header: 트립을 계획할 수 없음
+    warning: 경고
+  ExistingAccountDisplay:
+    a11y: 접근성
+    mainTitle: 내 설정
+    notifications: 알림
+    places: 좋아하는 장소
+    terms: 약관
+  FavoritePlaceList:
+    addAnotherPlace: 다른 장소 추가
+    description: "자주 가는 장소를 추가하여 트립 플랜 시간을 절약하세요 :"
+    editThisPlace: 이 장소 수정
+    setAddressForPlaceType: "{placeType}의 주소 설정"
+  FavoritePlaceScreen:
+    addNewPlace: 새 장소 추가
+    editPlace: "{placeName} 수정"
+    editPlaceGeneric: 장소 수정
+    invalidAddress: 이 장소의 위치를 설정하세요.
+    invalidName: 이 장소의 이름을 입력하세요.
+    nameAlreadyUsed: 이 이름은 이미 다른 장소에 사용되고 있습니다. 다른 이름을 입력해 주세요.
+    placeNotFound: 장소를 찾을 수 없음
+    placeNotFoundDescription: 죄송합니다. 요청하신 장소를 찾을 수 없습니다.
+  FormNavigationButtons:
+    ariaLabel: 내비게이션 양식
+  ItinerarySummary:
+    itineraryDetails: 여정 세부 정보
+    minMaxFare: "{minTotalFare} - {maxTotalFare}"
+  LiveStopTimes:
+    autoRefresh: 도착을 자동으로 새로 고침?
+  LocationSearch:
+    enterLocation: 위치 입력
+    setDestination: 목적지 선택
+    setOrigin: 출발지 선택
+  MapLayers:
+    bike-rental: "{companies} 공유자전거"
+    car-rental: 렌터카 위치
+    micromobility-rental: "{companies} 전동스쿠터"
+    park-and-ride: 파크 앤 라이드 위치
+    satellite: 위성
+    shared-vehicles: 공유 차량
+    stops: 대중 교통 정류장
+    streets: 거리
+  MetroUI:
+    arriveAtTime: "{time}에 도착"
+    fromStop: "{stop}에서부터"
+    itineraryDescription: "{routes}을(를) 이용한 {time} 일정"
+    leaveAt: 출발
+    multipleOptions: 여러 옵션
+    orAlternatives: 또는 같은 방향의 다른 경로
+    timeWalking: "{time} 걷기"
+  MobileOptions:
+    header: 검색 옵션 설정
+  ModeDropdown:
+    exclusiveMode: "{mode} 전용"
+  NarrativeItinerariesHeader:
+    changeSortDir: 정렬 방향 변경
+    itinerariesAndIssues: "{itinerariesFound} 및 {numIssues}"
+    itinerariesFound: "{itineraryNum} 개의 여정을 찾았습니다"
+    numIssues: |-
+      {issueNum, plural,
+       one {# 문제}
+       other {# 문제}
+       }
+    searching: 옵션을 찾고 있는 중...
+    selectArrivalTime: 도착 시간
+    selectBest: 가장 좋은 옵션
+    selectCost: 비용
+    selectDepartureTime: 출발 시각
+    selectDuration: 기간
+    selectWalkTime: 도보 시간
+    sortBy: 정렬 기준
+    viewAll: 모든 옵션 보기
+  NavLoginButton:
+    help: 지원
+    myAccount: 내 계정
+    signIn: 로그인
+    signOut: 로그 아웃
+  NewAccountWizard:
+    finish: 계정 설정을 완료하셨습니다!
+    notifications: 알림 설정
+    places: 위치 추가
+    terms: 새 계정 생성
+    verify: 이메일 주소 확인
+  NotFound:
+    description: 요청한 콘텐츠를 사용할 수 없습니다.
+    header: 콘텐츠를 찾을 수 없음
+  NotificationPrefsPane:
+    description: 자주 가는 트립에 대한 알림을 받을 수 있습니다.
+    noneSelect: 알림 거부
+    notificationChannelPrompt: 알림을 어떻게 받고 싶습니까?
+    notificationEmailDetail: "알림 이메일이 다음으로 전송됩니다:"
+  PhoneNumberEditor:
+    changeNumber: 번호 변경
+    invalidCode: 확인 코드 6 자리를 입력하세요.
+    invalidPhone: 유효한 전화번호를 입력하세요.
+    pending: 보류 중
+    phoneNumberVerified: 전화번호 {phoneNumber}가 성공적으로 확인되었습니다.
+    placeholder: 전화번호를 입력하십시오
+    prompt: "SMS 알림 수신을 위한 전화번호를 입력하세요:"
+    requestNewCode: 새 코드 요청
+    sendVerificationText: 확인 텍스트 전송
+    smsDetail: "SMS 알림이 다음으로 전송됩니다:"
+    verificationCode: "확인 코드:"
+    verificationInstructions: |
+      휴대폰의 SMS 메시지 앱에서 인증 코드를 확인하고 아래에 코드를 입력하세요(코드는 10분 후에 만료됩니다).
+    verified: 확인됨
+    verify: 확인
+  Place:
+    deleteThisPlace: 이 장소 삭제
+    enterAlert: |
+      양식에 출발지/목적지를 입력하고(또는 지도를 클릭하여 설정), 생성된 마커를 클릭하여 {placeType} 위치로 설정하세요.
+    viewStop: 정류장 보기
+  PlaceEditor:
+    addressPrompt: "주소:"
+    genericLocationPlaceholder: 위치 검색
+    locationPlaceholder: "{placeName} 위치 검색"
+    nameExample: 내 커피숍
+    namePrompt: "지명:"
+  PlanFirstLastButtons:
+    first: 처음
+    last: 마지막
+    next: 다음
+    previous: 이전
+  PlanTripButton:
+    planTrip: 트립 계획
+  PointPopup:
+    zoomToLocation: 이 위치로 확대
+  PrintLayout:
+    itinerary: 트립 일정
+    toggleMap: 지도 토글
+  RealtimeAnnotation:
+    delaysShownInResults: >
+      귀하의 여행 결과는 실시간 정보를 기반으로 조정되었습니다. 정상적인 상황에서 이 여행은 다음 경로를 사용하여
+      {normalDuration} 이 소요됩니다:
+    serviceUpdate: 서비스 업데이트
+  RealtimeStatusLabel:
+    early: "{minutes} 일찍"
+    late: "{minutes} 늦게"
+    onTime: 제 시간
+    scheduled: 예정
+  RelatedPanel:
+    hideExtraStops: 여분의 정류장 숨기기
+    showExtraStops: "{count}개의 여분의 정류장 보이기"
+  RelatedStopsPanel:
+    noArrivalFound: 도착편을 찾을 수 없음
+    relatedStops: 관련 정류장
+    viewDetails: 세부 정보 보기
+  ResultsError:
+    backToSearch: 검색으로 돌아가기
+  ResultsHeader:
+    noTripFound: 트립을 찾을 수 없음
+    tripsFound: "{count} 개의 옵션 을 찾았습니다"
+    waiting: 기다리는 중...
+  RouteDetails:
+    moreDetails: 더 자세한 내용
+    operatedBy: "{agencyName}에서 운영하는 서비스"
+    selectADirection: 방향 선택…
+    stopsTo: 방면
+  RouteViewer:
+    agencyFilter: 에이전시 필터
+    allAgencies: 모든 에이전시
+    allModes: 모든 모드
+    details: " "
+    findARoute: 경로 찾기
+    header: 경로 뷰어
+    modeFilter: 모드 필터
+    noFilteredRoutesFound: 필터와 일치하는 경로가 없습니다!
+    shortTitle: 경로 보기
+    title: 경로 뷰어
+  SaveTripButton:
+    cantSaveText: 저장할 수 없음
+    cantSaveTooltip: 대중교통을 포함하고 렌트 또는 차량 호출을 포함하지 않는 트립 일정만 모니터링할 수 있습니다.
+    saveTripText: 트립 저장
+    signInText: 로그인하여 트립 저장
+    signInTooltip: 트립을 저장하려면 로그인하십시오.
+  SavedTripEditor:
+    editSavedTrip: 저장된 트립 수정
+    saveNewTrip: 새 트립 저장
+    tripInformation: 트립 정보
+    tripNotFound: 트립을 찾을 수 없음
+    tripNotFoundDescription: 죄송합니다. 요청된 트립을 찾을 수 없습니다.
+    tripNotifications: 트립 알림
+  SavedTripList:
+    fromTo: "{from}에서 {to}까지"
+    myTrips: 내 트립
+    noSavedTrips: 저장된 트립이 없음
+    noSavedTripsInstructions: 지도에서 먼저 트립을 검색하세요.
+    pause: 일시 정지
+    resume: 다시 시작
+  SavedTripScreen:
+    tooManyTrips: |
+      저장된 트립의 최대 개수인 5개에 도달했습니다. 저장된 트립에서 사용하지 않는 트립을 제거한 후, 다시 시도하세요.
+    tripNameAlreadyUsed: 저장된 다른 트립이 이 이름을 사용하고 있습니다. 다른 이름을 선택하세요.
+    tripNameRequired: 트립의 이름을 입력하세요.
+  SessionTimeout:
+    body: 세션이 1분 이내에 만료됩니다. 검색을 유지하려면 '세션 계속'을 누르세요.
+    header: 세션이 곧 타임아웃됩니다!
+    keepSession: 세션 계속
+  SettingsPreview:
+    defaultPreviewText: 대중 교통 옵션 및 기본 설정
+  SimpleRealtimeAnnotation:
+    usingRealtimeInfo: 이 트립은 실시간 교통 및 지체 정보를 사용합니다
+  StackedPaneDisplay:
+    savePreferences: 환경설정 저장
+  StopScheduleTable:
+    block: 블록
+    departure: 출발
+    destination: 목적지
+    route: 경로
+  StopTimeCell:
+    imminentArrival: 예정
+    realtime: 실시간 데이터 기반
+    scheduled: 일정 데이터 기준
+  StopViewer:
+    displayStopId: "<strong>정류장 ID</strong>: {stopId}"
+    findSchedule: 날짜별 일정 검색
+    flexStop: >-
+      이 정류장은 가변 정류장입니다. 이 가변 구역에서 차량은 요청이 있을 때에만 승객을 태우고 내릴 것입니다. 이 지역에서 서비스를
+      받으려면 미리 전화를 해야 할 수도 있습니다.
+    header: 정류장 뷰어
+    loadingText: 정류장 로드 중…
+    noStopsFound: 날짜에 대한 정류장 시간이 없습니다.
+    operatorLogoAriaLabel: "정류장 {operatorName}:"
+    timezoneWarning: 출발 시간은 <strong>{timezoneCode}</strong>(으)로 표시됩니다.
+    titleBarStopId: 정류장 {stopId}
+    viewNextArrivals: 다음 도착편 보기
+    viewSchedule: 스케쥴 보기
+    zoomToStop: 정류장 확대
+  SubNav:
+    languageSelector: 언어 선택
+    languages: 언어
+    myAccount: 내 계정
+    selectALanguage: 언어 선택
+    settings: 설정
+    trips: 트립
+    userMenu: 프로필 옵션
+  SwitchButton:
+    defaultContent: 바꾸기
+    switchLocations: 위치 바꾸기
+  TermsOfUsePane:
+    confirmDeletionPrompt: |
+      트립 기록 저장에 대한 동의를 제거하면 트립 기록이 삭제됩니다. 계속하시겠습니까?
+    mustAgreeToTerms: 계속하시려면 서비스 약관에 동의하셔야 합니다.
+    termsOfServiceStatement: >
+      본인은 만 18세 이상임을 확인하며, 트립 플래너 이용을 위한 <termsOfUseLink>이용 약관</termsOfUseLink>을
+      읽고 이에 동의합니다.
+    termsOfStorageStatement: >
+      선택 사항: 본인의 지역의 대중 교통 서비스를 개선하기 위해 내 트립 플랜 기록을 저장하는 데 동의합니다.
+      <termsOfStorageLink>보다 자세한 정보...</termsOfStorageLink>
+  TransitVehicleOverlay:
+    in_transit_to: "다음 정류장: {stop}"
+    incoming_at: "{stop}에 접근하는 중"
+    stopped_at: "{stop}에서 문이 열립니다"
+    travelingAt: 현재 {milesPerHour} 속도로 주행 중
+    vehicleName: 차량 {vehicleNumber}
+  TripBasicsPane:
+    checkingItineraryExistence: 각 요일의 트립을 확인 중…
+    selectAtLeastOneDay: 모니터링하려면 최소 1일 이상을 선택하세요.
+    tripDaysPrompt: 어느 요일에 이 트립을 사용하시나요?
+    tripIsAvailableOnDaysIndicated: 트립은 위에 표시된 요일에 제공됩니다.
+    tripNamePrompt: "이 트립의 이름을 입력하세요:"
+    tripNotAvailableOnDay: "{repeatedDay}에는 트립을 이용할 수 없음"
+    unsavedChangesExistingTrip: 트립을 아직 저장하지 않았습니다. 나가시면 변경내용이 사라집니다.
+    unsavedChangesNewTrip: 새 트립을 저장하지 않았습니다. 나가시면 변경내용이 사라집니다.
+  TripNotificationsPane:
+    advancedSettings: 고급 설정
+    altRouteRecommended: 대체 경로 또는 환승 지점이 권장됩니다
+    delaysAboveThreshold: "다음 시간 이상의 지연 또는 차질이 있습니다:"
+    howToReceiveAlerts: |
+      저장된 트립에 대한 경고를 받으려면, 계정 설정에서 알림을 활성화하고 트립을 다시 저장하세요.
+    monitorThisTrip: "시작하기 전에 이 여행을 모니터링하세요:"
+    notificationsTurnedOff: 계정에 대한 알림이 꺼져 있습니다.
+    notifyViaChannelWhen: "다음의 경우, {channel}을 통해 알려주세요:"
+    oneHour: 1 시간
+    realtimeAlertFlagged: 내 트립 일정에 실시간 경고가 있습니다
+  TripStatus:
+    alerts: "{alerts, plural, one {# 경고!} other {# 경고!}}"
+    deleteTrip: 트립 삭제
+    planNewTrip: 새 트립 계획
+  TripStatusRenderers:
+    active:
+      delayedHeading: 진행 중인 트립이 {formattedDuration} 지연됩니다!
+      description: "{arrivalTime, time, short}에 목적지에 도착할 예정입니다."
+      earlyHeading: 진행 중인 트립이 예상보다 {formattedDuration} 일찍 시작됩니다!
+      noDataHeading: 트립이 진행 중입니다 (실시간 업데이트를 사용할 수 없습니다).
+      onTimeHeading: 트립이 정시에 진행 중에 있습니다.
+    base:
+      lastCheckedDefaultText: 마지막 확인 시간 알 수 없음
+      lastCheckedText: "마지막 확인 시간: {formattedDuration} 전"
+      togglePause: 일시 정지
+      tripIsNotSnoozed: 오늘 하루 동안 스누즈하기
+      tripIsSnoozed: 트립 분석 스누즈 해제
+      unknownState: 트립 상태 알 수 없음
+      untogglePause: 다시 시작
+    inactive:
+      description: 트립 모니터링을 다시 시작하여 상태 업데이트 확인
+      heading: 트립 모니터링이 일시 중지됨
+    nextTripNotPossible:
+      description: |
+        트립 플래너가 오늘 트립을 찾을 수 없습니다. 대체 경로를 찾으려면 여정을 트립 일정을 다시 계획하세요.
+      heading: 오늘 트립이 불가능함
+    noLongerPossible:
+      description: |
+        트립 플래너는 선택된 요일에 트립을 찾을 수 없습니다. 대체 경로를 찾으려면 트립 일정을 다시 계획하세요.
+      heading: 트립은 더 이상 불가능함
+    notCalculated:
+      awaiting: 계산을 기다리는 중…
+      description: 트립이 계산되는 동안 잠시 기다려 주십시오.
+      heading: 트립이 아직 계산되지 않음
+    snoozed:
+      description: 트립 모니터링의 스누즈를 해제하여 상태 업데이트를 확인하세요.
+      heading: 오늘 트립 모니터링이 일시 중지되었습니다.
+    upcoming:
+      nextTripBegins: >-
+        다음 트립은 {tripDatetime, date, ::eeeee yyyyMMdd}, {tripDatetime, time,
+        short}에 시작됩니다.
+      tripBegins: >-
+        트립이 {tripStart, time, short}에 시작될 것으로 예정되어 있습니다. (실시간 모니터링은
+        {monitoringStart, time, short}에 시작됩니다.)
+      tripStartIsDelayed: 트립 시작 시간이 ${duration} 지연됩니다!
+      tripStartIsEarly: 트립이 예상보다 ${duration} 일찍 시작됩니다!
+      tripStartsSoonNoUpdates: 트립이 곧 시작됩니다 (실시간 업데이트를 사용할 수 없습니다).
+      tripStartsSoonOnTime: 트립은 곧 정시에 시작됩니다.
+  TripSummary:
+    arriveAt: "도착 "
+    leaveAt: "출발 "
+  TripSummaryPane:
+    happensOnDays: "발생: <strong>{days}</strong>"
+    notifications: "알림: <strong>출발 예정 시간 {leadTimeInMinutes} 분 전</strong>"
+    notificationsDisabled: "알림: <strong>비활성화됨</strong>"
+  TripTools:
+    copyLink: 링크 복사
+    linkCopied: 복사됨
+    reportEmailSubject: OpenTripPlanner로 문제 보고
+    reportEmailTemplate: |
+      *** 사용자 안내 ***
+       이 기능을 사용하면 사이트 관리자에게 검토할 수 있도록 보고서를 이메일로 전송할 수 있습니다.
+       아래 프롬프트를 작성한 후, 귀하의 일반 이메일 프로그램을 사용하여 전송하여 주십시오.
+       
+       *** 다음을 작성해 주십시오 ***
+       
+       발생한 문제:
+       
+      시도하려고 했던 트립의 종류 (예: 도보 + 대중 교통, 자전거 + 대중 교통, 자동차 + 대중 교통)::
+       
+       *** 기술적 문제의 세부 내용 ***
+    reportIssue: 문제 보고
+  TripViewer:
+    accessible: 접근성이 있음
+    bicyclesAllowed: 허용됨
+    header: 트립 뷰어
+    routeHeader: "노선: <strong>{routeShortName}</strong> {routeLongName}"
+    viewStop: 보기
+  UserAccountScreen:
+    confirmDelete: 귀하의 사용자 계정을 삭제하시겠습니까? 한 번 그렇게 하신 경우, 복구할 수 없습니다.
+  UserSettings:
+    confirmDeletion: 최근 검색이나 장소가 저장되어 있습니다. 최근 장소 또는 검색을 비활성화하면 이러한 항목이 제거됩니다. 계속하시겠습니까?
+    favoriteStops: 좋아하는 정류장
+    myPreferences: 내 환경설정
+    mySavedPlaces: 내 저장 장소 (<manageLink>관리</manageLink>)
+    noFavoriteStops: 좋아하지 않는 정류장
+    recentPlaces: 최근 장소
+    recentSearchSummary: "{from}에서 {to}까지 {mode}"
+    recentSearches: 최근 검색
+    rememberSearches: 최근 검색어/장소를 기억하십니까?
+    stopId: "정류장 ID: {stopId}"
+    storageDisclaimer: >
+      저장하기로 선택한 환경설정, 장소 또는 설정은 브라우저의 로컬 저장소에 저장됩니다. TriMet은 귀하의 집, 직장 또는 기타 위치에
+      대한 정보에 접근할 수 없습니다. 언제든지 최근 장소/검색 기억을 끄고 저장된 집/직장 위치 및 즐겨찾는 정류장을 지우실 수
+      있습니다.
+  UserTripSettings:
+    forgetOptions: 내 옵션 잊기
+    rememberOptions: 트립 옵션 기억하기
+    restoreDefaults: 기본 설정 복원
+    restoreMyDefaults: 내 기본 설정 복원
+  VerifyEmailPane:
+    emailIsVerified: 내 이메일이 확인되었습니다!
+    instructions1: |
+      귀하의 이메일의 받은 편지함을 확인한 후, 메시지의 링크를 따라 이메일 주소를 확인하여 계정 설정을 완료하세요.
+    instructions2: 확인 후, 아래의 버튼을 클릭하여 계속 진행하십시오.
+    resendVerification: 확인 이메일을 다시 전송
+  ViewSwitcher:
+    switcher: 변경
+  WelcomeScreen:
+    prompt: 어디로 가고 싶으신가요?
+config:
+  accessModes:
+    bicycle: 대중교통 + 개인 자전거
+    bicycle_rent: 대중교통 + 공유자전거
+    car_hail: 승차 공유
+    car_park: 파크 앤 라이드
+    micromobility: 대중교통 + 개인 전동스쿠터
+    micromobility_rent: 대중교통 + 전동스쿠터 대여
+  bicycleModes:
+    bicycle: 내 자전거
+    bicycle_rent: 공유자전거
+  flex:
+    both: 자세한 내용은 일정의 하단을 참조하십시오
+    call-ahead: 전화로 예약
+    continuous-dropoff: 정류장에 대한 정보는 상담원과 연락
+    flex-service: 플렉스 서비스
+    flex-service-colon: "플렉스 서비스:"
+  micromobilityModes:
+    micromobility: 내 전동스쿠터
+    micromobility_rent: 대여한 전동스쿠터
 util:
   state:
     errorPlanningTrip: 트립을 계획하는 중에 오류가 발생했습니다.
     networkUnavailable: 현재 {network} 네트워크를 사용할 수 없습니다.
     noTripFound: 트립을 찾을 수 없습니다.
-    noTripFoundForMode: '{modes}의 트립을 찾을 수 없습니다.'
-    noTripFoundReason: 지정된 최대 거리 내 또는 지정된 시간에 대중 교통 서비스가 없거나, 출발지 또는 도착지가 안전하게 접근가능하지
-      못할 수 있습니다.
-    noTripFoundWithReason: '{noTripFound} {reason}'
-config:
-  accessModes:
-    bicycle_rent: 대중교통 + 공유자전거
-    bicycle: 대중교통 + 개인 자전거
-    car_hail: 승차 공유
-    car_park: 파크 앤 라이드
-    micromobility_rent: 대중교통 + 전동스쿠터 대여
-    micromobility: 대중교통 + 개인 전동스쿠터
-  micromobilityModes:
-    micromobility: 내 전동스쿠터
-    micromobility_rent: 대여한 전동스쿠터
-  flex:
-    flex-service: 플렉스 서비스
-    flex-service-colon: '플렉스 서비스:'
-    both: 자세한 내용은 일정의 하단을 참조하십시오
-    call-ahead: 전화로 예약
-    continuous-dropoff: 정류장에 대한 정보는 상담원과 연락
-  bicycleModes:
-    bicycle: 내 자전거
-    bicycle_rent: 공유자전거
+    noTripFoundForMode: "{modes}의 트립을 찾을 수 없습니다."
+    noTripFoundReason: 지정된 최대 거리 내 또는 지정된 시간에 대중 교통 서비스가 없거나, 출발지 또는 도착지가 안전하게 접근가능하지 못할 수 있습니다.
+    noTripFoundWithReason: "{noTripFound} {reason}"

--- a/i18n/vi.yml
+++ b/i18n/vi.yml
@@ -1,569 +1,112 @@
 _id: vi
 _name: Vietnamese
-
-# This file contains localized strings (a.k.a. messages) for the language indicated above:
-#   - Messages are organized in various categories and sub-categories.
-#   - A component or JS module can use messages from one or more categories.
-#   - In the code, messages are retrieved using an ID that is simply the path to the message.
-#     Use the dot '.' to separate categories and sub-categories in the path.
-#     For instance, for the message defined in YML below:
-#         common
-#           modes
-#             subway: Metro#
-#     then use the snippet below with the corresponding message id:
-#         <FormattedMessage id='common.modes.subway' /> // renders "Metro".
-#
-# It is important that message ids in the code be consistent with
-# the categories in this file. Below are some general guidelines:
-#   - For starters, there are an 'actions', 'components' and 'common'
-#     categories. Additional categories may be added as needed.
-#   - Each sub-category under 'components' denotes a component and
-#     should contain messages that are used only by that component (e.g. button captions).
-#   - In contrast, some strings are common to multiple components,
-#     so it makes sense to group them by theme (e.g. accessModes) under the 'common' category.
-
-# Messages that are generated from actions
-components:
-  UserTripSettings:
-    forgetOptions: Hãy quên các tùy chọn của tôi
-    rememberOptions: Hãy nhớ các tùy chọn chuyến đi
-    restoreDefaults: Khôi phục mặc định
-    restoreMyDefaults: Khôi phục mặc định của tôi
-  A11yPrefs:
-    accessibilityRoutingByDefault: Thích những chuyến đi có thể truy cập theo mặc
-      định
-  BackToTripPlanner:
-    backToTripPlanner: Quay lại phần lên kế hoạch chuyến đi
-  BatchResultsScreen:
-    showResults: Hiển thị kết quả
-    expandMap: Mở rộng bản đồ
-  BatchRoutingPanel:
-    shortTitle: Lên kế hoạch cho chuyến đi
-  BatchSettings:
-    destination: điểm đến
-    origin: điểm xuất phát
-    planTripTooltip: Lên kế hoạch cho chuyến đi
-    validationMessage: 'Vui lòng xác định các khu vực sau để lên kế hoạch cho một
-      chuyến đi: {issues}'
-    settings: Cài đặt chuyến đi
-  CallTakerPanel:
-    groupSize: 'Quy mô nhóm:'
-    advancedOptions: Tùy chọn nâng cao
-    intermediateDestination: Nhập điểm đến trung gian
-  BeforeSignInScreen:
-    message: "Để truy cập trang này, bạn sẽ cần phải đăng nhập. Vui lòng đợi trong\
-      \ khi chúng tôi chuyển hướng bạn đến trang đăng nhập…\n"
-    mainTitle: Đăng nhập bạn vào
-  DateTimePreview:
-    arriveAt: Đến {arriveTime, time, short}
-    dayLastWeek: '{formattedDayOfWeek} trước'
-    departAt: Khởi hành {departTime, time, short}
-    editDepartOrArrival: Chỉnh sửa thời gian khởi hành hoặc thời gian đến
-    leaveNow: Rời đi ngay bây giờ
-    range: '{startTime, time, short} đến {endTime, time, short}'
-  DefaultItinerary:
-    multiModeSummary: '{accessMode} + {transitMode}'
-    clickDetails: Bấm để xem chi tiết
-  ErrorMessage:
-    warning: Cảnh báo
-    header: Không thể lên kế hoạch cho chuyến đi
-  ExistingAccountDisplay:
-    a11y: Khả năng tiếp cận
-    mainTitle: Cài đặt của tôi
-    notifications: Thông báo
-    places: Những nơi yêu thích
-    terms: Điều khoản
-  FavoritePlaceScreen:
-    addNewPlace: Thêm địa điểm mới
-    editPlace: Chỉnh sửa {placeName}
-    editPlaceGeneric: Chỉnh sửa vị trí
-    invalidAddress: Vui lòng cài đặt một vị trí cho nơi này.
-    invalidName: Vui lòng nhập tên cho nơi này.
-    nameAlreadyUsed: Bạn đã sử dụng tên này cho một nơi khác. Vui lòng nhập một tên
-      khác.
-    placeNotFound: Không tìm thấy địa điểm
-    placeNotFoundDescription: Xin lỗi, địa điểm được yêu cầu không được tìm thấy.
-  FormNavigationButtons:
-    ariaLabel: Điều hướng hình thức
-  LiveStopTimes:
-    autoRefresh: Tự động làm mới các lượt đến?
-  LocationSearch:
-    enterLocation: Nhập vị trí
-    setOrigin: Chọn điểm xuất phát
-    setDestination: Chọn điểm đến
-  MapLayers:
-    bike-rental: '{companies} Xe đạp chung'
-    car-rental: Địa điểm cho thuê xe
-    micromobility-rental: '{companies} Xe tay ga điện'
-    park-and-ride: Địa điểm đậu xe và đi xe công cộng
-    satellite: Vệ tinh
-    shared-vehicles: Phương tiện chia sẻ
-    stops: "Điểm dừng của phương tiện công cộng"
-    streets: Đường phố
-  MetroUI:
-    arriveAtTime: Đến nơi vào {time}
-    fromStop: từ {stop}
-    itineraryDescription: '{time} hành trình sử dụng {routes}'
-    leaveAt: Bạn rời khỏi
-    multipleOptions: Nhiều lựa chọn
-    orAlternatives: hoặc các tuyến đường khác cùng hướng
-    timeWalking: '{time} đi bộ'
-  MobileOptions:
-    header: Cài đặt tùy chọn tìm kiếm
-  ModeDropdown:
-    exclusiveMode: Chỉ {mode}
-  NarrativeItinerariesHeader:
-    changeSortDir: Thay đổi hướng sắp xếp
-    itinerariesAndIssues: '{itinerariesFound} và {numIssues}'
-    itinerariesFound: "{itineraryNum} hành trình được tìm thấy"
-    numIssues: '{issueNum} vấn đề'
-    searching: Tìm lựa chọn của bạn…
-    selectArrivalTime: Thời gian đến
-    selectBest: Lựa chọn tốt nhất
-    selectCost: Phí tổn
-    selectDepartureTime: Giờ khởi hành
-    selectDuration: Thời hạn
-    selectWalkTime: Thời gian đi bộ
-    sortBy: Sắp xếp theo
-    viewAll: Xem tất cả các tùy chọn
-  NewAccountWizard:
-    finish: Hoàn tất việc thiết lập tài khoản!
-    notifications: Tùy chọn thông báo
-    places: Thêm vị trí của bạn
-    terms: Tạo tài khoản mới
-    verify: Xác minh địa chỉ email của bạn
-  NotificationPrefsPane:
-    description: Bạn có thể nhận được thông báo về các chuyến đi bạn thường xuyên
-      thực hiện.
-    noneSelect: Đừng thông báo cho tôi
-    notificationChannelPrompt: Bạn muốn nhận thông báo như thế nào?
-    notificationEmailDetail: 'Email thông báo sẽ được gửi đến:'
-  PhoneNumberEditor:
-    changeNumber: Thay đổi số điện thoại
-    invalidCode: Vui lòng nhập 6 chữ số cho mã xác thực.
-    invalidPhone: Xin vui lòng nhập một số điện thoại hợp lệ.
-    pending: Chưa xác minh
-    placeholder: Nhập số điện thoại của bạn
-    prompt: 'Nhập số điện thoại của bạn để nhận thông báo SMS:'
-    requestNewCode: Yêu cầu một mã mới
-    sendVerificationText: Gửi văn bản xác minh
-    smsDetail: 'Thông báo SMS sẽ được gửi đến:'
-    verificationCode: 'Mã xác nhận:'
-    verified: Đã xác minh
-    verify: Kiểm chứng
-    verificationInstructions: "Vui lòng kiểm tra ứng dụng nhắn tin SMS trên điện thoại\
-      \ di động của bạn để thấy tin nhắn với mã xác minh và nhập mã bên dưới (mã hết\
-      \ hạn sau 10 phút).\n"
-    phoneNumberVerified: Số điện thoại {phoneNumber} đã được xác minh thành công.
-  Place:
-    enterAlert: "Nhập điểm xuất phát/điểm đến vào biểu mẫu này (hoặc cài đặt qua việc\
-      \ nhấp vào bản đồ) và nhấp vào điểm đánh dấu kết quả để cài đặt vị trí {placeType}.\n"
-    deleteThisPlace: Xóa nơi này
-    viewStop: Xem điểm dừng
-  PlaceEditor:
-    genericLocationPlaceholder: Tìm kiếm vị trí
-    locationPlaceholder: Tìm kiếm vị trí {placeName}
-    namePrompt: 'Tên địa điểm:'
-    nameExample: Quán cà phê của tôi
-    addressPrompt: 'Địa chỉ:'
-  PlanFirstLastButtons:
-    last: Cuối
-    next: Tiếp theo
-    first: Thứ nhất
-    previous: Trước
-  PlanTripButton:
-    planTrip: Lên kế hoạch cho chuyến đi
-  PrintLayout:
-    itinerary: Hành trình
-    toggleMap: Chuyển đổi bản đồ
-  RealtimeAnnotation:
-    serviceUpdate: Cập nhật dịch vụ
-    delaysShownInResults: "Kết quả chuyến đi của bạn đã được điều chỉnh dựa trên thông\
-      \ tin thời gian thực. Trong điều kiện bình thường, chuyến đi này sẽ mất {normalDuration}\
-      \ bằng cách sử dụng các tuyến sau: {routes}.\n"
-  RealtimeStatusLabel:
-    early: Sớm {minutes}
-    late: Trễ {minutes}
-    onTime: kịp thời
-    scheduled: lên kế hoạch
-  RelatedStopsPanel:
-    noArrivalFound: Không tìm thấy việc đến nơi
-    relatedStops: Điểm dừng liên quan
-    viewDetails: Xem chi tiết
-  ResultsHeader:
-    waiting: Đang chờ đợi...
-    noTripFound: Không tìm thấy chuyến đi nào
-    tripsFound: Đã tìm thấy {count} tùy chọn
-  RouteDetails:
-    moreDetails: Thêm chi tiết
-    operatedBy: Được điều hành bởi {agencyName}
-    selectADirection: Chọn một hướng…
-    stopsTo: Hướng
-  RouteViewer:
-    agencyFilter: Sàng lọc đại lý giao thông công cộng
-    allAgencies: Tất cả các đại lý phương tiện công cộng
-    allModes: Tất cả các phương tiện
-    details: ' '
-    findARoute: Tìm một tuyến đường
-    header: Xem tuyến đường
-    modeFilter: Sàng lọc phương tiện
-    noFilteredRoutesFound: Không có tuyến đường phù hợp với sàng lọc của bạn!
-    shortTitle: Xem các tuyến đường
-    title: Xem tuyến đường
-  SaveTripButton:
-    cantSaveText: Không thể tiết kiệm
-    cantSaveTooltip: Chỉ các hành trình bao gồm đi xe công cộng và không có cho thuê
-      hoặc đi xe có thể được theo dõi.
-    saveTripText: Lưu chuyến đi
-    signInText: Đăng nhập để lưu chuyến đi
-    signInTooltip: Vui lòng đăng nhập để lưu chuyến đi.
-  SavedTripScreen:
-    tripNameRequired: Vui lòng nhập tên chuyến đi.
-    tripNameAlreadyUsed: Một chuyến đi được lưu khác đã sử dụng tên này. Vui lòng
-      chọn một tên khác.
-    tooManyTrips: "Bạn đã đạt được tối đa năm chuyến đi được lưu. Vui lòng loại bỏ\
-      \ các chuyến đi không sử dụng khỏi các chuyến đi được lưu của bạn và thử lại.\n"
-  SessionTimeout:
-    body: Phiên của bạn sẽ hết hạn trong vòng một phút. Nhấn 'Tiếp tục Phiên' để tiếp
-      tục việc tìm kiếm của bạn.
-    header: Phiên sắp hết giờ!
-    keepSession: Tiếp tục phiên
-  SimpleRealtimeAnnotation:
-    usingRealtimeInfo: Chuyến đi này sử dụng thông tin lưu thông và sự trì hoãn theo
-      thời gian thực
-  SettingsPreview:
-    defaultPreviewText: Tùy chọn và Cài đặt Phương tiện Công cộng
-  StackedPaneDisplay:
-    savePreferences: Lưu lại những ưu tiên
-  StopScheduleTable:
-    block: Dãy nhà
-    departure: Khởi hành
-    destination: Đến
-    route: Tuyến
-  StopViewer:
-    displayStopId: '<strong>Điểm dừng số</strong>: {stopId}'
-    flexStop: Đây là một điểm dừng linh hoạt. Xe sẽ đưa đón khách trong khu linh hoạt
-      này theo yêu cầu. Bạn có thể phải gọi trước để được phục vụ trong khu vực này.
-    header: Xem điểm dừng
-    loadingText: Đang tải điểm dừng…
-    noStopsFound: Không tìm thấy thời gian dừng cho ngày.
-    operatorLogoAriaLabel: "Điểm dừng của {operatorName}:"
-    timezoneWarning: Thời gian khởi hành được hiển thị trong <strong>{timezoneCode}</strong>.
-    titleBarStopId: 'Điểm dừng {stopId}'
-    viewNextArrivals: Xem những xe đến tiếp theo
-    viewSchedule: Xem lịch trình
-    zoomToStop: Phóng to để dừng lại
-    findSchedule: Tìm kiếm lịch trình theo ngày
-  SubNav:
-    languages: "Ngôn ngữ"
-    languageSelector: Chọn ngôn ngữ
-    myAccount: Tài khoản của tôi
-    selectALanguage: Chọn một ngôn ngữ
-    settings: Cài đặt
-    trips: Chuyến đi
-    userMenu: Tùy chọn hồ sơ
-  TransitVehicleOverlay:
-    in_transit_to: Điểm dừng tiếp theo {stop}
-    incoming_at: Đang tiếp cận {stop}
-    stopped_at: Cửa mở tại {stop}
-    travelingAt: di chuyển với tốc độ {milesPerHour}
-    vehicleName: 'Phương tiện giao thông {vehicleNumber}'
-  TripBasicsPane:
-    checkingItineraryExistence: Kiểm tra sự tồn tại của hành trình cho mỗi ngày trong
-      tuần…
-    selectAtLeastOneDay: Vui lòng chọn ít nhất một ngày để theo dõi.
-    tripNotAvailableOnDay: Chuyến đi không có sẵn vào {repeatedDay}
-    tripDaysPrompt: Bạn thực hiện chuyến đi này vào những ngày nào?
-    tripIsAvailableOnDaysIndicated: Chuyến đi của bạn có sẵn vào những ngày trong
-      tuần như đã nêu ở trên.
-    tripNamePrompt: 'Vui lòng cung cấp tên cho chuyến đi này:'
-    unsavedChangesExistingTrip: Bạn chưa lưu chuyến đi của mình. Nếu bạn rời đi, những
-      thay đổi sẽ bị mất.
-    unsavedChangesNewTrip: Bạn chưa lưu chuyến đi mới của mình. Nếu bạn rời đi, nó
-      sẽ bị mất.
-  TripNotificationsPane:
-    advancedSettings: Cài đặt nâng cao
-    altRouteRecommended: Một tuyến đường hoặc điểm trung chuyển thay thế được khuyến
-      nghị
-    delaysAboveThreshold: Có sự chậm trễ hoặc gián đoạn của hơn
-    howToReceiveAlerts: "Để nhận thông báo cho các chuyến đi đã lưu của bạn, bật thông\
-      \ báo trong cài đặt tài khoản của bạn và thử lưu lại một chuyến đi.\n"
-    monitorThisTrip: 'Theo dõi chuyến đi này trước khi nó bắt đầu:'
-    notificationsTurnedOff: Thông báo được tắt cho tài khoản của bạn.
-    notifyViaChannelWhen: 'Thông báo cho tôi qua {channel} khi:'
-    oneHour: 1 tiếng
-    realtimeAlertFlagged: Có một cảnh báo thời gian thực được gắn cờ trên hành trình
-      của tôi
-    timeBefore: '{time} trước'
-  TripStatus:
-    alerts: '{alerts, plural, one {# cảnh báo!} other {# cảnh báo!}}'
-    deleteTrip: Xóa chuyến đi
-    planNewTrip: Lên kế hoạch cho chuyến đi mới
-  TripStatusRenderers:
-    active:
-      delayedHeading: Chuyến đi đang được tiến hành và bị trì hoãn {formattedDuration}!
-      earlyHeading: Chuyến đi đang diễn ra và sẽ đến sớm hơn {formattedDuration} so
-        với dự kiến!
-      description: Chuyến đi sẽ đến đích lúc {arrivalTime, time, short}.
-      noDataHeading: Chuyến đi đang được tiến hành (không có cập nhật thời gian thực
-        có sẵn).
-      onTimeHeading: Chuyến đi đang được tiến hành và đúng giờ.
-    base:
-      lastCheckedDefaultText: Thời gian được kiểm tra lần cuối không xác định
-      lastCheckedText: 'Kiểm tra lần cuối: cách đây {formattedDuration}'
-      togglePause: Tạm ngừng
-      tripIsNotSnoozed: Tạm dừng phần còn lại của ngày hôm nay
-      tripIsSnoozed: Bật lại phân tích chuyến đi
-      unknownState: Không xác định được trạng thái chuyến đi
-      untogglePause: Tiếp tục
-    inactive:
-      description: Tiếp tục giám sát chuyến đi để xem trạng thái cập nhật
-      heading: Tạm dừng việc giám sát chuyến đi
-    nextTripNotPossible:
-      description: "Người lập kế hoạch chuyến đi đã không thể tìm thấy chuyến đi của\
-        \ bạn ngày hôm nay. Vui lòng thử cài đặt lại hành trình của bạn để tìm một\
-        \ tuyến đường thay thế.\n"
-      heading: Không thể thực hiện chuyến đi hôm nay
-    upcoming:
-      tripStartIsDelayed: Thời gian bắt đầu chuyến đi bị trì hoãn ${duration}!
-      nextTripBegins: Chuyến tiếp theo bắt đầu vào {tripDatetime, date, ::eeeee yyyyMMdd}
-        lúc {tripDatetime, time, short}.
-      tripBegins: Chuyến đi sẽ bắt đầu lúc {tripStart, time, short}. (Việc theo dõi
-        thời gian thực sẽ bắt đầu lúc {monitoringStart, time, short}.)
-      tripStartIsEarly: Thời gian bắt đầu chuyến đi đang diễn ra sớm hơn ${duration}
-        so với dự kiến!
-      tripStartsSoonNoUpdates: Chuyến đi đang bắt đầu sớm (không có cập nhật về thời
-        gian thực).
-      tripStartsSoonOnTime: Chuyến đi đang bắt đầu sớm và sắp đúng giờ.
-    noLongerPossible:
-      heading: Không thể thực hiện chuyến đi được nữa
-      description: "Người lập kế hoạch chuyến đi không thể tìm thấy chuyến đi của\
-        \ bạn vào bất kỳ ngày nào trong tuần được chọn. Vui lòng thử cài đặt lại hành\
-        \ trình của bạn để tìm một tuyến đường thay thế.\n"
-    notCalculated:
-      awaiting: Đang chờ tính toán…
-      description: Vui lòng đợi một chút để tính toán chuyến đi.
-      heading: Chuyến đi chưa được tính toán
-    snoozed:
-      description: Bật lại tính năng giám sát chuyến đi để xem trạng thái cập nhật
-      heading: Tạm dừng việc giám sát chuyến đi cho ngày hôm nay
-  TripSummary:
-    arriveAt: "Đến nơi "
-    leaveAt: "Rời đi lúc "
-  TripTools:
-    reportEmailTemplate: "*** HƯỚNG DẪN SỬ DỤNG ***\n Tính năng này cho phép bạn gửi\
-      \ báo cáo qua email cho quản trị viên trang web để xem xét.\n Vui lòng điền\
-      \ vào lời nhắc bên dưới và gửi bằng chương trình email thông thường của bạn.\n\
-      \ \n *** VUI LÒNG ĐIỀN ĐẦY ĐỦ PHẦN SAU ĐÂY ***\n \n Sự cố gặp phải:\n \n Loại\
-      \ chuyến đi bạn muốn thực hiện (ví dụ: đi bộ + đi xe công cộng, đi xe đạp +\
-      \ đi xe công cộng, đi xe hơi + đi xe công cộng):\n \n *** CHI TIẾT KỸ THUẬT***\n"
-    reportEmailSubject: Báo cáo sự cố với OpenTripPlanner
-    copyLink: Sao chép đường dẫn
-    linkCopied: Đã sao chép
-    reportIssue: Báo cáo sự cố
-  UserSettings:
-    confirmDeletion: Bạn có các tìm kiếm và/hoặc địa điểm gần đây được lưu trữ. Việc
-      vô hiệu hóa tính năng lưu trữ các địa điểm/tìm kiếm gần đây sẽ loại bỏ các mục
-      này. Tiếp tục?
-    favoriteStops: Điểm dừng yêu thích
-    myPreferences: Ưu tiên của tôi
-    mySavedPlaces: Những nơi đã lưu của tôi (<manageLink>quản lý</manageLink>)
-    noFavoriteStops: Không có điểm dừng yêu thích
-    recentSearches: Tìm kiếm gần đây
-    recentSearchSummary: '{mode} từ {from} đến {to}'
-    recentPlaces: Những nơi gần đây
-    rememberSearches: Nhớ các tìm kiếm/địa điểm gần đây?
-    stopId: 'Điểm dừng số {stopId}'
-    storageDisclaimer: "Bất kỳ tùy chọn, địa điểm hoặc cài đặt nào bạn chọn để lưu\
-      \ sẽ được lưu trữ cục bộ trong trình duyệt của bạn. TriMet sẽ không có quyền\
-      \ truy cập kiến thức về nhà ở, chỗ làm hoặc bất kỳ vị trí nào khác của bạn.\
-      \ Tại bất kỳ thời điểm nào, bạn có thể chọn tắt ghi nhớ các địa điểm/tìm kiếm\
-      \ gần đây và xóa các địa điểm nhà ở/chỗ làm đã lưu của bạn và các điểm dừng\
-      \ yêu thích.\n"
-  AccountSetupFinishPane:
-    message: Bạn đã sẵn sàng để bắt đầu lên kế hoạch cho các chuyến đi của bạn.
-  AddPlaceButton:
-    addPlace: Thêm địa điểm
-    needOriginDestination: Xác định nguồn gốc hoặc đích đến để thêm các địa điểm trung
-      gian
-    tooManyPlaces: Địa điểm trung gian tối đa đạt được
-  AfterSignInScreen:
-    message: Nếu trang này không tải sau vài giây, <redirectLink>bấm vào đây</redirectLink>.
-    mainTitle: Chuyển hướng...
-  AmenitiesPanel:
-    bikesAvailable: "{count, plural,\n =0 {Không có xe đạp}\n other {# xe đạp có sẵn}\n\
-      \ }\n"
-    bikesAtStation: "{companyLength, plural,\n =0 {xe đạp tại {name}}\n other {xe\
-      \ đạp {company} tại {name}}\n }\n"
-    bikesNearby: "{count, plural,\n =0 {Không có xe đạp {company} nào gần đây}\n other\
-      \ {# xe đạp của {company} gần đó}\n }\n"
-    nearbyAmenities: Các tiện nghi gần đó
-    noNearbyBikes: Không tìm thấy xe đạp cho thuê gần đó.
-    noNearbyScooters: Không tìm thấy dịch vụ cho thuê xe hạng nhẹ gần đây.
-    noPRLotsFound: Không có bãi đậu xe và đi xe công cộng gần đây.
-    scootersNearby: "{count, plural,\n =0 {Không có xe tay ga điện {company} nào gần\
-      \ đây} \n other {Có # xe tay ga điện {company} gần đó} \n }\n"
-    spacesAvailable: "{count, plural,\n =0 {Không có chỗ đậu xe}\n other {# chỗ đậu\
-      \ xe có sẵn}\n }\n"
-  AppMenu:
-    callHistory: Lịch sử cuộc gọi
-    closeMenu: Đóng danh mục
-    fieldTrip: Chuyến đi thực địa
-    mailables: Sẵn sàng để gửi
-    openMenu: Mở danh mục
-    skipNavigation: Bỏ qua điều hướng
-  NavLoginButton:
-    help: Giúp đỡ
-    myAccount: Tài khoản của tôi
-    signIn: Đăng nhập
-    signOut: Đăng xuất
-  ResultsError:
-    backToSearch: Quay lại tìm kiếm
-  SwitchButton:
-    defaultContent: Đổi
-    switchLocations: Chuyển đổi địa điểm
-  TripSummaryPane:
-    happensOnDays: 'Xảy ra vào: <strong>{days}</strong>'
-    notifications: 'Thông báo: <strong>{leadTimeInMinutes} phút trước khi khởi hành
-      theo lịch trình</strong>'
-    notificationsDisabled: 'Thông báo: <strong>Đã tắt</strong>'
-  TripViewer:
-    accessible: Truy cập được
-    bicyclesAllowed: Được phép
-    header: Xem chuyến đi
-    routeHeader: 'Tuyến: <strong>{routeShortName}</strong> {routeLongName}'
-    viewStop: Lượt xem
-  UserAccountScreen:
-    confirmDelete: Bạn có chắc bạn muốn xóa tài khoản người dùng của mình không? Một
-      khi bạn làm như vậy, nó không thể được phục hồi.
-  VerifyEmailPane:
-    emailIsVerified: Email của tôi đã được xác minh!
-    instructions2: Khi bạn đã được xác minh, nhấp vào nút bên dưới để tiếp tục.
-    instructions1: "Vui lòng kiểm tra hộp thư đến trong email của bạn và vào đường\
-      \ link trong tin nhắn để xác minh địa chỉ email của bạn trước khi hoàn thành\
-      \ việc thiết lập tài khoản của bạn.\n"
-    resendVerification: Gửi lại email xác minh
-  AdvancedOptions:
-    bannedRoutes: Chọn các tuyến đường bị cấm…
-    maxBike: Đạp xe tối đa {unitsString}
-    maxWalk: Đi bộ tối đa {unitsString}
-    preferredRoutes: Chọn các tuyến đường ưa thích…
-    walkReluctance: Tránh đi bộ
-  BatchSearchScreen:
-    header: Lên kế hoạch cho chuyến đi của bạn
-  DateTimeOptions:
-    departAt: Khởi hành lúc
-    now: Hiện nay
-    arriveBy: Đến nơi trước
-  DateTimeScreen:
-    header: Cài đặt ngày/giờ
-  DeleteUser:
-    deleteMyAccount: Xóa tài khoản của tôi
-  EnhancedStopMarker:
-    stopID: 'Điểm dừng số'
-    stopViewer: Xem điểm dừng
-  FavoritePlaceList:
-    addAnotherPlace: Thêm một nơi khác
-    description: 'Thêm những địa điểm bạn thường đến để tiết kiệm thời gian lên kế
-      hoạch cho chuyến đi:'
-    editThisPlace: Chỉnh sửa nơi này
-    setAddressForPlaceType: Cài đặt địa chỉ {placeType} của bạn
-  NotFound:
-    description: Nội dung bạn yêu cầu không có sẵn.
-    header: Không tìm thấy nội dung
-  RelatedPanel:
-    hideExtraStops: Ẩn các điểm dừng thêm
-    showExtraStops: Hiển thị thêm {count} điểm dừng
-  SavedTripEditor:
-    editSavedTrip: Chỉnh sửa chuyến đi được lưu
-    saveNewTrip: Lưu chuyến đi mới
-    tripInformation: Thông tin chuyến đi
-    tripNotFound: Không tìm thấy chuyến đi
-    tripNotFoundDescription: Xin lỗi, không tìm thấy chuyến đi được yêu cầu.
-    tripNotifications: Thông báo chuyến đi
-  SavedTripList:
-    fromTo: Từ {from} đến {to}
-    myTrips: Chuyến đi của tôi
-    noSavedTrips: Bạn không có những chuyến đi được lưu
-    noSavedTripsInstructions: Trước tiên, thực hiện tìm kiếm chuyến đi từ bản đồ.
-    pause: Tạm ngừng
-    resume: Tiếp tục
-  StopTimeCell:
-    imminentArrival: Đến hạn
-    realtime: Dựa trên dữ liệu thời gian thực
-    scheduled: Dựa trên dữ liệu theo lịch trình
-  TermsOfUsePane:
-    mustAgreeToTerms: Bạn phải đồng ý với các điều khoản của dịch vụ để tiếp tục.
-    confirmDeletionPrompt: "Việc xóa bỏ sự đồng ý của bạn đối với việc lưu trữ các\
-      \ chuyến đi lịch sử sẽ khiến lịch sử chuyến đi của bạn bị xóa. Bạn có chắc chắn\
-      \ muốn tiếp tục không?\n"
-    termsOfServiceStatement: "Tôi xác nhận rằng tôi từ 18 tuổi trở lên và tôi đã đọc\
-      \ và đồng ý với <termsOfUseLink>Điều khoản của dịch vụ</termsOfUseLink> để sử\
-      \ dụng Công cụ lập kế hoạch chuyến đi.\n"
-    termsOfStorageStatement: "Không bắt buộc: Tôi đồng ý để Công cụ lập kế hoạch chuyến\
-      \ đi lưu trữ các chuyến đi đã lên kế hoạch trước đây của tôi để cải thiện dịch\
-      \ vụ chuyển tuyến trong khu vực của tôi. <termsOfStorageLink>Thêm thông tin…</termsOfStorageLink>\n"
-  ViewSwitcher:
-    switcher: Nút bật tắt
-  WelcomeScreen:
-    prompt: Bạn muốn đi đâu?
-  PointPopup:
-    zoomToLocation: Phóng to đến vị trí
-  ItinerarySummary:
-    itineraryDetails: Chi tiết hành trình
-    minMaxFare: '{minTotalFare} - {maxTotalFare}'
+actions:
+  callTaker:
+    callQuerySaveError: "Lỗi khi lưu trữ các truy vấn cuộc gọi: {err}"
+    callSaveError: "Không thể lưu cuộc gọi: {err}"
+    checkSessionError: "Lỗi khi thiết lập phiên ủy quyền: {err}"
+    couldNotFindCallError: Không thể tìm thấy cuộc gọi. Đang hủy yêu cầu lưu truy vấn.
+    fetchCallsError: "Lỗi khi tìm nạp cuộc gọi: {err}"
+    queryFetchError: "Lỗi khi tìm nạp các truy vấn: {err}"
+  fieldTrip:
+    addNoteError: "Lỗi khi thêm ghi chú chuyến đi:"
+    confirmOverwriteItineraries: |
+      Hành động này sẽ ghi đè lên một hành trình {outbound, select,
+        true {xuất ngoại}
+        other {đến}
+        } đã được lên kế hoạch trước đó cho yêu cầu này. Bạn có muốn tiếp tục không?
+    deleteItinerariesError: "Lỗi khi xóa kế hoạch chuyến đi:"
+    deleteNoteError: "Lỗi khi xóa ghi chú chuyến đi:"
+    editSubmitterNotesError: "Lỗi khi chỉnh sửa ghi chú của người gửi:"
+    fetchFieldTripError: "Lỗi khi tìm nạp các chuyến đi: {err}"
+    fetchFieldTripsError: "Lỗi khi tìm nạp các chuyến đi: {err}"
+    fetchTripsForDateError: "Lỗi khi tìm nạp các chuyến đi cho ngày đi du lịch: {err}"
+    incompatibleTripDateError: >-
+      Ngày đi dự kiến ({tripDate}) không phải là ngày đi theo yêu cầu
+      ({requestDate})
+    itineraryCapacityError: >-
+      Không thể lưu kế hoạch chuyến đi: Không thể lưu kế hoạch chuyến đi này do
+      thiếu sức chứa trên một hoặc nhiều xe. Vui lòng lên kế hoạch lại chuyến đi
+      của bạn.
+    maxTripRequestsExceeded: Đã vượt quá số lượng yêu cầu chuyến đi mà không có kết quả hợp lệ
+    saveItinerariesError: "Không lưu được hành trình: {err}"
+    setDateError: "Lỗi khi cài đặt ngày:"
+    setGroupSizeError: "Lỗi khi cài đặt kích thước nhóm:"
+    setPaymentError: "Lỗi khi cài đặt thông tin thanh toán:"
+    setRequestStatusError: "Lỗi khi cài đặt trạng thái yêu cầu:"
+  location:
+    geolocationNotSupportedError: Định vị địa lý không được hỗ trợ bởi trình duyệt của bạn
+    unknownPositionError: Lỗi không xác định khi tìm vị trí
+  map:
+    currentLocation: (Vị trí hiện tại)
+  user:
+    accountDeleted: Tài khoản người dùng của bạn ({email}) đã bị xóa.
+    authTokenError: Lỗi khi lấy mã thông báo ủy quyền.
+    confirmDeleteMonitoredTrip: Bạn có muốn loại bỏ chuyến đi này không?
+    confirmDeletePlace: Bạn có muốn loại bỏ nơi này không?
+    emailVerificationResent: Thông báo xác minh email đã được gửi lại.
+    genericError: "Phát sinh lỗi: {err}"
+    itineraryExistenceCheckFailed: Lỗi kiểm tra xem chuyến đi được chọn của bạn là có thể.
+    preferencesSaved: Những sở thích của bạn đã được lưu lại.
+    smsInvalidCode: Mã bạn nhập không hợp lệ. Vui lòng thử lại.
+    smsResendThrottled: >-
+      Một SMS xác minh đã được gửi đến số điện thoại được chỉ định chưa đầy một
+      phút trước. Vui lòng thử lại sau vài phút.
+    smsVerificationFailed: >-
+      Điện thoại của bạn không thể được xác minh. Có lẽ mã bạn đã nhập đã hết
+      hạn. Vui lòng yêu cầu một mã mới và thử lại.
 common:
-  coordinates: '{lat}, {lon}'
+  coordinates: "{lat}, {lon}"
+  dateExpressions:
+    today: Hôm nay
+    tomorrow: Ngày mai
+    yesterday: Hôm qua
   daysOfWeek:
     friday: Thứ sáu
-    sunday: Chủ nhật
     monday: Thứ hai
     saturday: Thứ bảy
+    sunday: Chủ nhật
     thursday: Thứ năm
     tuesday: Thứ ba
     wednesday: Thứ tư
   daysOfWeekCompact:
-    tuesday: Thứ ba
     friday: Thứ sáu
-    thursday: Thứ năm
+    monday: Thứ hai
     saturday: Thứ bảy
     sunday: Chủ nhật
-    monday: Thứ hai
+    thursday: Thứ năm
+    tuesday: Thứ ba
     wednesday: Thứ tư
   daysOfWeekPlural:
-    monday: Các thứ hai
     friday: Các thứ sáu
+    monday: Các thứ hai
     saturday: Các thứ bảy
     sunday: Các chủ nhật
     thursday: Các thứ năm
     tuesday: Các thứ ba
     wednesday: Các thứ tư
   forms:
+    back: Trở lại
     cancel: Hủy bỏ
     close: Đóng
-    edit: Chỉnh sửa
-    next: Tiếp theo
-    print: In
-    save: Tiết kiệm
-    yes: Đúng
-    defaultValue: '{value} (mặc định)'
-    back: Trở lại
+    defaultValue: "{value} (mặc định)"
     delete: Xóa bỏ
+    edit: Chỉnh sửa
     error: lỗi!
     finish: Kết thúc
-    no: Không
+    next: Tiếp theo
+    "no": Không
+    print: In
+    save: Tiết kiệm
     startOver: Bắt đầu lại
+    "yes": Đúng
   itineraryDescriptions:
-    calories: '{calories, number} calo'
+    calories: "{calories, number} calo"
     noItineraryToDisplay: Không có hành trình để hiển thị.
-    transfers: '{transfers, plural, =0 {} other {# chuyển}}'
     noTransitFareProvided: Không có thông tin giá vé
-    relativeCo2: >
-      {co2}
-      CO₂ {isMore, select,
-      true {nhiều}
-      other {ít}
-      } hơn so với xe hơi
+    relativeCo2: |
+      {co2} CO₂ {isMore, select, true {nhiều} other {ít} } hơn so với xe hơi
+    transfers: "{transfers} chuyển"
   modes:
     bicycle_rent: Chia sẻ xe đạp
     bike: Xe đạp
@@ -592,108 +135,585 @@ common:
     dining: ăn uống
     home: nhà
     work: công việc
+  routing:
+    routeAndNumber: Tuyến {routeId}
+    routeToHeadsign: Đến {headsign}
   searchForms:
-    enterDestination: "Nhập điểm đến hoặc {mapAction} vào bản đồ…"
-    enterStartLocation: "Nhập vị trí bắt đầu hoặc {mapAction} vào bản đồ…"
-    tap: chạm
     click: nhấp
+    enterDestination: Nhập điểm đến hoặc {mapAction} vào bản đồ…
+    enterStartLocation: Nhập vị trí bắt đầu hoặc {mapAction} vào bản đồ…
+    tap: chạm
   time:
-    departureArrivalTimes: '{startTime, time, short}—{endTime, time, short}'
+    departureArrivalTimes: "{startTime, time, short}—{endTime, time, short}"
     duration:
       aFewSeconds: vài giây
       nDays: "{days} ngày"
       nHours: "{hours, plural, =1 {một tiếng} other {# tiếng}}"
       nMinutes: "{minutes, plural, =1 {một phút} other {# phút}}"
-    durationAgo: "Cách đây {duration}"
-    tripDurationFormat: "{hours, plural, =0 {} other {# giờ }}{minutes} phút { seconds,\
-      \ plural, =0 {} other {# giây}}"
-  dateExpressions:
-    today: Hôm nay
-    tomorrow: Ngày mai
-    yesterday: Hôm qua
-  routing:
-    routeAndNumber: Tuyến {routeId}
-    routeToHeadsign: Đến {headsign}
+    durationAgo: Cách đây {duration}
+    tripDurationFormat: >-
+      {hours, plural, =0 {} other {# giờ }}{minutes} phút { seconds, plural, =0
+      {} other {# giây}}
+components:
+  A11yPrefs:
+    accessibilityRoutingByDefault: Thích những chuyến đi có thể truy cập theo mặc định
+  AccountSetupFinishPane:
+    message: Bạn đã sẵn sàng để bắt đầu lên kế hoạch cho các chuyến đi của bạn.
+  AddPlaceButton:
+    addPlace: Thêm địa điểm
+    needOriginDestination: Xác định nguồn gốc hoặc đích đến để thêm các địa điểm trung gian
+    tooManyPlaces: Địa điểm trung gian tối đa đạt được
+  AdvancedOptions:
+    bannedRoutes: Chọn các tuyến đường bị cấm…
+    maxBike: Đạp xe tối đa {unitsString}
+    maxWalk: Đi bộ tối đa {unitsString}
+    preferredRoutes: Chọn các tuyến đường ưa thích…
+    walkReluctance: Tránh đi bộ
+  AfterSignInScreen:
+    mainTitle: Chuyển hướng...
+    message: >-
+      Nếu trang này không tải sau vài giây, <redirectLink>bấm vào
+      đây</redirectLink>.
+  AmenitiesPanel:
+    bikesAtStation: |
+      {companyLength, plural,
+       =0 {xe đạp tại {name}}
+       other {xe đạp {company} tại {name}}
+       }
+    bikesAvailable: |
+      {count, plural,
+       =0 {Không có xe đạp}
+       other {# xe đạp có sẵn}
+       }
+    bikesNearby: |
+      {count, plural,
+       =0 {Không có xe đạp {company} nào gần đây}
+       other {# xe đạp của {company} gần đó}
+       }
+    nearbyAmenities: Các tiện nghi gần đó
+    noNearbyBikes: Không tìm thấy xe đạp cho thuê gần đó.
+    noNearbyScooters: Không tìm thấy dịch vụ cho thuê xe hạng nhẹ gần đây.
+    noPRLotsFound: Không có bãi đậu xe và đi xe công cộng gần đây.
+    scootersNearby: |
+      {count, plural,
+       =0 {Không có xe tay ga điện {company} nào gần đây} 
+       other {Có # xe tay ga điện {company} gần đó} 
+       }
+    spacesAvailable: |
+      {count, plural,
+       =0 {Không có chỗ đậu xe}
+       other {# chỗ đậu xe có sẵn}
+       }
+  AppMenu:
+    callHistory: Lịch sử cuộc gọi
+    closeMenu: Đóng danh mục
+    fieldTrip: Chuyến đi thực địa
+    mailables: Sẵn sàng để gửi
+    openMenu: Mở danh mục
+    skipNavigation: Bỏ qua điều hướng
+  BackToTripPlanner:
+    backToTripPlanner: Quay lại phần lên kế hoạch chuyến đi
+  BatchResultsScreen:
+    expandMap: Mở rộng bản đồ
+    showResults: Hiển thị kết quả
+  BatchRoutingPanel:
+    shortTitle: Lên kế hoạch cho chuyến đi
+  BatchSearchScreen:
+    header: Lên kế hoạch cho chuyến đi của bạn
+  BatchSettings:
+    destination: điểm đến
+    origin: điểm xuất phát
+    planTripTooltip: Lên kế hoạch cho chuyến đi
+    settings: Cài đặt chuyến đi
+    validationMessage: >-
+      Vui lòng xác định các khu vực sau để lên kế hoạch cho một chuyến đi:
+      {issues}
+  BeforeSignInScreen:
+    mainTitle: Đăng nhập bạn vào
+    message: >
+      Để truy cập trang này, bạn sẽ cần phải đăng nhập. Vui lòng đợi trong khi
+      chúng tôi chuyển hướng bạn đến trang đăng nhập…
+  CallTakerPanel:
+    advancedOptions: Tùy chọn nâng cao
+    groupSize: "Quy mô nhóm:"
+    intermediateDestination: Nhập điểm đến trung gian
+  DateTimeOptions:
+    arriveBy: Đến nơi trước
+    departAt: Khởi hành lúc
+    now: Hiện nay
+  DateTimePreview:
+    arriveAt: Đến {arriveTime, time, short}
+    dayLastWeek: "{formattedDayOfWeek} trước"
+    departAt: Khởi hành {departTime, time, short}
+    editDepartOrArrival: Chỉnh sửa thời gian khởi hành hoặc thời gian đến
+    leaveNow: Rời đi ngay bây giờ
+    range: "{startTime, time, short} đến {endTime, time, short}"
+  DateTimeScreen:
+    header: Cài đặt ngày/giờ
+  DefaultItinerary:
+    clickDetails: Bấm để xem chi tiết
+    multiModeSummary: "{accessMode} + {transitMode}"
+  DeleteUser:
+    deleteMyAccount: Xóa tài khoản của tôi
+  EnhancedStopMarker:
+    stopID: Điểm dừng số
+    stopViewer: Xem điểm dừng
+  ErrorMessage:
+    header: Không thể lên kế hoạch cho chuyến đi
+    warning: Cảnh báo
+  ExistingAccountDisplay:
+    a11y: Khả năng tiếp cận
+    mainTitle: Cài đặt của tôi
+    notifications: Thông báo
+    places: Những nơi yêu thích
+    terms: Điều khoản
+  FavoritePlaceList:
+    addAnotherPlace: Thêm một nơi khác
+    description: >-
+      Thêm những địa điểm bạn thường đến để tiết kiệm thời gian lên kế hoạch cho
+      chuyến đi:
+    editThisPlace: Chỉnh sửa nơi này
+    setAddressForPlaceType: Cài đặt địa chỉ {placeType} của bạn
+  FavoritePlaceScreen:
+    addNewPlace: Thêm địa điểm mới
+    editPlace: Chỉnh sửa {placeName}
+    editPlaceGeneric: Chỉnh sửa vị trí
+    invalidAddress: Vui lòng cài đặt một vị trí cho nơi này.
+    invalidName: Vui lòng nhập tên cho nơi này.
+    nameAlreadyUsed: Bạn đã sử dụng tên này cho một nơi khác. Vui lòng nhập một tên khác.
+    placeNotFound: Không tìm thấy địa điểm
+    placeNotFoundDescription: Xin lỗi, địa điểm được yêu cầu không được tìm thấy.
+  FormNavigationButtons:
+    ariaLabel: Điều hướng hình thức
+  ItinerarySummary:
+    itineraryDetails: Chi tiết hành trình
+    minMaxFare: "{minTotalFare} - {maxTotalFare}"
+  LiveStopTimes:
+    autoRefresh: Tự động làm mới các lượt đến?
+  LocationSearch:
+    enterLocation: Nhập vị trí
+    setDestination: Chọn điểm đến
+    setOrigin: Chọn điểm xuất phát
+  MapLayers:
+    bike-rental: "{companies} Xe đạp chung"
+    car-rental: Địa điểm cho thuê xe
+    micromobility-rental: "{companies} Xe tay ga điện"
+    park-and-ride: Địa điểm đậu xe và đi xe công cộng
+    satellite: Vệ tinh
+    shared-vehicles: Phương tiện chia sẻ
+    stops: Điểm dừng của phương tiện công cộng
+    streets: Đường phố
+  MetroUI:
+    arriveAtTime: Đến nơi vào {time}
+    fromStop: từ {stop}
+    itineraryDescription: "{time} hành trình sử dụng {routes}"
+    leaveAt: Bạn rời khỏi
+    multipleOptions: Nhiều lựa chọn
+    orAlternatives: hoặc các tuyến đường khác cùng hướng
+    timeWalking: "{time} đi bộ"
+  MobileOptions:
+    header: Cài đặt tùy chọn tìm kiếm
+  ModeDropdown:
+    exclusiveMode: Chỉ {mode}
+  NarrativeItinerariesHeader:
+    changeSortDir: Thay đổi hướng sắp xếp
+    itinerariesAndIssues: "{itinerariesFound} và {numIssues}"
+    itinerariesFound: "{itineraryNum} hành trình được tìm thấy"
+    numIssues: "{issueNum} vấn đề"
+    searching: Tìm lựa chọn của bạn…
+    selectArrivalTime: Thời gian đến
+    selectBest: Lựa chọn tốt nhất
+    selectCost: Phí tổn
+    selectDepartureTime: Giờ khởi hành
+    selectDuration: Thời hạn
+    selectWalkTime: Thời gian đi bộ
+    sortBy: Sắp xếp theo
+    viewAll: Xem tất cả các tùy chọn
+  NavLoginButton:
+    help: Giúp đỡ
+    myAccount: Tài khoản của tôi
+    signIn: Đăng nhập
+    signOut: Đăng xuất
+  NewAccountWizard:
+    finish: Hoàn tất việc thiết lập tài khoản!
+    notifications: Tùy chọn thông báo
+    places: Thêm vị trí của bạn
+    terms: Tạo tài khoản mới
+    verify: Xác minh địa chỉ email của bạn
+  NotFound:
+    description: Nội dung bạn yêu cầu không có sẵn.
+    header: Không tìm thấy nội dung
+  NotificationPrefsPane:
+    description: >-
+      Bạn có thể nhận được thông báo về các chuyến đi bạn thường xuyên thực
+      hiện.
+    noneSelect: Đừng thông báo cho tôi
+    notificationChannelPrompt: Bạn muốn nhận thông báo như thế nào?
+    notificationEmailDetail: "Email thông báo sẽ được gửi đến:"
+  PhoneNumberEditor:
+    changeNumber: Thay đổi số điện thoại
+    invalidCode: Vui lòng nhập 6 chữ số cho mã xác thực.
+    invalidPhone: Xin vui lòng nhập một số điện thoại hợp lệ.
+    pending: Chưa xác minh
+    phoneNumberVerified: Số điện thoại {phoneNumber} đã được xác minh thành công.
+    placeholder: Nhập số điện thoại của bạn
+    prompt: "Nhập số điện thoại của bạn để nhận thông báo SMS:"
+    requestNewCode: Yêu cầu một mã mới
+    sendVerificationText: Gửi văn bản xác minh
+    smsDetail: "Thông báo SMS sẽ được gửi đến:"
+    verificationCode: "Mã xác nhận:"
+    verificationInstructions: >
+      Vui lòng kiểm tra ứng dụng nhắn tin SMS trên điện thoại di động của bạn để
+      thấy tin nhắn với mã xác minh và nhập mã bên dưới (mã hết hạn sau 10
+      phút).
+    verified: Đã xác minh
+    verify: Kiểm chứng
+  Place:
+    deleteThisPlace: Xóa nơi này
+    enterAlert: >
+      Nhập điểm xuất phát/điểm đến vào biểu mẫu này (hoặc cài đặt qua việc nhấp
+      vào bản đồ) và nhấp vào điểm đánh dấu kết quả để cài đặt vị trí
+      {placeType}.
+    viewStop: Xem điểm dừng
+  PlaceEditor:
+    addressPrompt: "Địa chỉ:"
+    genericLocationPlaceholder: Tìm kiếm vị trí
+    locationPlaceholder: Tìm kiếm vị trí {placeName}
+    nameExample: Quán cà phê của tôi
+    namePrompt: "Tên địa điểm:"
+  PlanFirstLastButtons:
+    first: Thứ nhất
+    last: Cuối
+    next: Tiếp theo
+    previous: Trước
+  PlanTripButton:
+    planTrip: Lên kế hoạch cho chuyến đi
+  PointPopup:
+    zoomToLocation: Phóng to đến vị trí
+  PrintLayout:
+    itinerary: Hành trình
+    toggleMap: Chuyển đổi bản đồ
+  RealtimeAnnotation:
+    delaysShownInResults: >
+      Kết quả chuyến đi của bạn đã được điều chỉnh dựa trên thông tin thời gian
+      thực. Trong điều kiện bình thường, chuyến đi này sẽ mất {normalDuration}
+      bằng cách sử dụng các tuyến sau: {routes}.
+    serviceUpdate: Cập nhật dịch vụ
+  RealtimeStatusLabel:
+    early: Sớm {minutes}
+    late: Trễ {minutes}
+    onTime: kịp thời
+    scheduled: lên kế hoạch
+  RelatedPanel:
+    hideExtraStops: Ẩn các điểm dừng thêm
+    showExtraStops: Hiển thị thêm {count} điểm dừng
+  RelatedStopsPanel:
+    noArrivalFound: Không tìm thấy việc đến nơi
+    relatedStops: Điểm dừng liên quan
+    viewDetails: Xem chi tiết
+  ResultsError:
+    backToSearch: Quay lại tìm kiếm
+  ResultsHeader:
+    noTripFound: Không tìm thấy chuyến đi nào
+    tripsFound: Đã tìm thấy {count} tùy chọn
+    waiting: Đang chờ đợi...
+  RouteDetails:
+    moreDetails: Thêm chi tiết
+    operatedBy: Được điều hành bởi {agencyName}
+    selectADirection: Chọn một hướng…
+    stopsTo: Hướng
+  RouteViewer:
+    agencyFilter: Sàng lọc đại lý giao thông công cộng
+    allAgencies: Tất cả các đại lý phương tiện công cộng
+    allModes: Tất cả các phương tiện
+    details: " "
+    findARoute: Tìm một tuyến đường
+    header: Xem tuyến đường
+    modeFilter: Sàng lọc phương tiện
+    noFilteredRoutesFound: Không có tuyến đường phù hợp với sàng lọc của bạn!
+    shortTitle: Xem các tuyến đường
+    title: Xem tuyến đường
+  SaveTripButton:
+    cantSaveText: Không thể tiết kiệm
+    cantSaveTooltip: >-
+      Chỉ các hành trình bao gồm đi xe công cộng và không có cho thuê hoặc đi xe
+      có thể được theo dõi.
+    saveTripText: Lưu chuyến đi
+    signInText: Đăng nhập để lưu chuyến đi
+    signInTooltip: Vui lòng đăng nhập để lưu chuyến đi.
+  SavedTripEditor:
+    editSavedTrip: Chỉnh sửa chuyến đi được lưu
+    saveNewTrip: Lưu chuyến đi mới
+    tripInformation: Thông tin chuyến đi
+    tripNotFound: Không tìm thấy chuyến đi
+    tripNotFoundDescription: Xin lỗi, không tìm thấy chuyến đi được yêu cầu.
+    tripNotifications: Thông báo chuyến đi
+  SavedTripList:
+    fromTo: Từ {from} đến {to}
+    myTrips: Chuyến đi của tôi
+    noSavedTrips: Bạn không có những chuyến đi được lưu
+    noSavedTripsInstructions: Trước tiên, thực hiện tìm kiếm chuyến đi từ bản đồ.
+    pause: Tạm ngừng
+    resume: Tiếp tục
+  SavedTripScreen:
+    tooManyTrips: >
+      Bạn đã đạt được tối đa năm chuyến đi được lưu. Vui lòng loại bỏ các chuyến
+      đi không sử dụng khỏi các chuyến đi được lưu của bạn và thử lại.
+    tripNameAlreadyUsed: >-
+      Một chuyến đi được lưu khác đã sử dụng tên này. Vui lòng chọn một tên
+      khác.
+    tripNameRequired: Vui lòng nhập tên chuyến đi.
+  SessionTimeout:
+    body: >-
+      Phiên của bạn sẽ hết hạn trong vòng một phút. Nhấn 'Tiếp tục Phiên' để
+      tiếp tục việc tìm kiếm của bạn.
+    header: Phiên sắp hết giờ!
+    keepSession: Tiếp tục phiên
+  SettingsPreview:
+    defaultPreviewText: Tùy chọn và Cài đặt Phương tiện Công cộng
+  SimpleRealtimeAnnotation:
+    usingRealtimeInfo: >-
+      Chuyến đi này sử dụng thông tin lưu thông và sự trì hoãn theo thời gian
+      thực
+  StackedPaneDisplay:
+    savePreferences: Lưu lại những ưu tiên
+  StopScheduleTable:
+    block: Dãy nhà
+    departure: Khởi hành
+    destination: Đến
+    route: Tuyến
+  StopTimeCell:
+    imminentArrival: Đến hạn
+    realtime: Dựa trên dữ liệu thời gian thực
+    scheduled: Dựa trên dữ liệu theo lịch trình
+  StopViewer:
+    displayStopId: "<strong>Điểm dừng số</strong>: {stopId}"
+    findSchedule: Tìm kiếm lịch trình theo ngày
+    flexStop: >-
+      Đây là một điểm dừng linh hoạt. Xe sẽ đưa đón khách trong khu linh hoạt
+      này theo yêu cầu. Bạn có thể phải gọi trước để được phục vụ trong khu vực
+      này.
+    header: Xem điểm dừng
+    loadingText: Đang tải điểm dừng…
+    noStopsFound: Không tìm thấy thời gian dừng cho ngày.
+    operatorLogoAriaLabel: "Điểm dừng của {operatorName}:"
+    timezoneWarning: Thời gian khởi hành được hiển thị trong <strong>{timezoneCode}</strong>.
+    titleBarStopId: Điểm dừng {stopId}
+    viewNextArrivals: Xem những xe đến tiếp theo
+    viewSchedule: Xem lịch trình
+    zoomToStop: Phóng to để dừng lại
+  SubNav:
+    languageSelector: Chọn ngôn ngữ
+    languages: Ngôn ngữ
+    myAccount: Tài khoản của tôi
+    selectALanguage: Chọn một ngôn ngữ
+    settings: Cài đặt
+    trips: Chuyến đi
+    userMenu: Tùy chọn hồ sơ
+  SwitchButton:
+    defaultContent: Đổi
+    switchLocations: Chuyển đổi địa điểm
+  TermsOfUsePane:
+    confirmDeletionPrompt: >
+      Việc xóa bỏ sự đồng ý của bạn đối với việc lưu trữ các chuyến đi lịch sử
+      sẽ khiến lịch sử chuyến đi của bạn bị xóa. Bạn có chắc chắn muốn tiếp tục
+      không?
+    mustAgreeToTerms: Bạn phải đồng ý với các điều khoản của dịch vụ để tiếp tục.
+    termsOfServiceStatement: >
+      Tôi xác nhận rằng tôi từ 18 tuổi trở lên và tôi đã đọc và đồng ý với
+      <termsOfUseLink>Điều khoản của dịch vụ</termsOfUseLink> để sử dụng Công cụ
+      lập kế hoạch chuyến đi.
+    termsOfStorageStatement: >
+      Không bắt buộc: Tôi đồng ý để Công cụ lập kế hoạch chuyến đi lưu trữ các
+      chuyến đi đã lên kế hoạch trước đây của tôi để cải thiện dịch vụ chuyển
+      tuyến trong khu vực của tôi. <termsOfStorageLink>Thêm thông
+      tin…</termsOfStorageLink>
+  TransitVehicleOverlay:
+    in_transit_to: Điểm dừng tiếp theo {stop}
+    incoming_at: Đang tiếp cận {stop}
+    stopped_at: Cửa mở tại {stop}
+    travelingAt: di chuyển với tốc độ {milesPerHour}
+    vehicleName: Phương tiện giao thông {vehicleNumber}
+  TripBasicsPane:
+    checkingItineraryExistence: Kiểm tra sự tồn tại của hành trình cho mỗi ngày trong tuần…
+    selectAtLeastOneDay: Vui lòng chọn ít nhất một ngày để theo dõi.
+    tripDaysPrompt: Bạn thực hiện chuyến đi này vào những ngày nào?
+    tripIsAvailableOnDaysIndicated: Chuyến đi của bạn có sẵn vào những ngày trong tuần như đã nêu ở trên.
+    tripNamePrompt: "Vui lòng cung cấp tên cho chuyến đi này:"
+    tripNotAvailableOnDay: Chuyến đi không có sẵn vào {repeatedDay}
+    unsavedChangesExistingTrip: Bạn chưa lưu chuyến đi của mình. Nếu bạn rời đi, những thay đổi sẽ bị mất.
+    unsavedChangesNewTrip: Bạn chưa lưu chuyến đi mới của mình. Nếu bạn rời đi, nó sẽ bị mất.
+  TripNotificationsPane:
+    advancedSettings: Cài đặt nâng cao
+    altRouteRecommended: Một tuyến đường hoặc điểm trung chuyển thay thế được khuyến nghị
+    delaysAboveThreshold: Có sự chậm trễ hoặc gián đoạn của hơn
+    howToReceiveAlerts: >
+      Để nhận thông báo cho các chuyến đi đã lưu của bạn, bật thông báo trong
+      cài đặt tài khoản của bạn và thử lưu lại một chuyến đi.
+    monitorThisTrip: "Theo dõi chuyến đi này trước khi nó bắt đầu:"
+    notificationsTurnedOff: Thông báo được tắt cho tài khoản của bạn.
+    notifyViaChannelWhen: "Thông báo cho tôi qua {channel} khi:"
+    oneHour: 1 tiếng
+    realtimeAlertFlagged: Có một cảnh báo thời gian thực được gắn cờ trên hành trình của tôi
+    timeBefore: "{time} trước"
+  TripStatus:
+    alerts: "{alerts, plural, one {# cảnh báo!} other {# cảnh báo!}}"
+    deleteTrip: Xóa chuyến đi
+    planNewTrip: Lên kế hoạch cho chuyến đi mới
+  TripStatusRenderers:
+    active:
+      delayedHeading: Chuyến đi đang được tiến hành và bị trì hoãn {formattedDuration}!
+      description: Chuyến đi sẽ đến đích lúc {arrivalTime, time, short}.
+      earlyHeading: >-
+        Chuyến đi đang diễn ra và sẽ đến sớm hơn {formattedDuration} so với dự
+        kiến!
+      noDataHeading: Chuyến đi đang được tiến hành (không có cập nhật thời gian thực có sẵn).
+      onTimeHeading: Chuyến đi đang được tiến hành và đúng giờ.
+    base:
+      lastCheckedDefaultText: Thời gian được kiểm tra lần cuối không xác định
+      lastCheckedText: "Kiểm tra lần cuối: cách đây {formattedDuration}"
+      togglePause: Tạm ngừng
+      tripIsNotSnoozed: Tạm dừng phần còn lại của ngày hôm nay
+      tripIsSnoozed: Bật lại phân tích chuyến đi
+      unknownState: Không xác định được trạng thái chuyến đi
+      untogglePause: Tiếp tục
+    inactive:
+      description: Tiếp tục giám sát chuyến đi để xem trạng thái cập nhật
+      heading: Tạm dừng việc giám sát chuyến đi
+    nextTripNotPossible:
+      description: >
+        Người lập kế hoạch chuyến đi đã không thể tìm thấy chuyến đi của bạn
+        ngày hôm nay. Vui lòng thử cài đặt lại hành trình của bạn để tìm một
+        tuyến đường thay thế.
+      heading: Không thể thực hiện chuyến đi hôm nay
+    noLongerPossible:
+      description: >
+        Người lập kế hoạch chuyến đi không thể tìm thấy chuyến đi của bạn vào
+        bất kỳ ngày nào trong tuần được chọn. Vui lòng thử cài đặt lại hành
+        trình của bạn để tìm một tuyến đường thay thế.
+      heading: Không thể thực hiện chuyến đi được nữa
+    notCalculated:
+      awaiting: Đang chờ tính toán…
+      description: Vui lòng đợi một chút để tính toán chuyến đi.
+      heading: Chuyến đi chưa được tính toán
+    snoozed:
+      description: Bật lại tính năng giám sát chuyến đi để xem trạng thái cập nhật
+      heading: Tạm dừng việc giám sát chuyến đi cho ngày hôm nay
+    upcoming:
+      nextTripBegins: >-
+        Chuyến tiếp theo bắt đầu vào {tripDatetime, date, ::eeeee yyyyMMdd} lúc
+        {tripDatetime, time, short}.
+      tripBegins: >-
+        Chuyến đi sẽ bắt đầu lúc {tripStart, time, short}. (Việc theo dõi thời
+        gian thực sẽ bắt đầu lúc {monitoringStart, time, short}.)
+      tripStartIsDelayed: Thời gian bắt đầu chuyến đi bị trì hoãn ${duration}!
+      tripStartIsEarly: >-
+        Thời gian bắt đầu chuyến đi đang diễn ra sớm hơn ${duration} so với dự
+        kiến!
+      tripStartsSoonNoUpdates: Chuyến đi đang bắt đầu sớm (không có cập nhật về thời gian thực).
+      tripStartsSoonOnTime: Chuyến đi đang bắt đầu sớm và sắp đúng giờ.
+  TripSummary:
+    arriveAt: "Đến nơi "
+    leaveAt: "Rời đi lúc "
+  TripSummaryPane:
+    happensOnDays: "Xảy ra vào: <strong>{days}</strong>"
+    notifications: >-
+      Thông báo: <strong>{leadTimeInMinutes} phút trước khi khởi hành theo lịch
+      trình</strong>
+    notificationsDisabled: "Thông báo: <strong>Đã tắt</strong>"
+  TripTools:
+    copyLink: Sao chép đường dẫn
+    linkCopied: Đã sao chép
+    reportEmailSubject: Báo cáo sự cố với OpenTripPlanner
+    reportEmailTemplate: |
+      *** HƯỚNG DẪN SỬ DỤNG ***
+       Tính năng này cho phép bạn gửi báo cáo qua email cho quản trị viên trang web để xem xét.
+       Vui lòng điền vào lời nhắc bên dưới và gửi bằng chương trình email thông thường của bạn.
+       
+       *** VUI LÒNG ĐIỀN ĐẦY ĐỦ PHẦN SAU ĐÂY ***
+       
+       Sự cố gặp phải:
+       
+       Loại chuyến đi bạn muốn thực hiện (ví dụ: đi bộ + đi xe công cộng, đi xe đạp + đi xe công cộng, đi xe hơi + đi xe công cộng):
+       
+       *** CHI TIẾT KỸ THUẬT***
+    reportIssue: Báo cáo sự cố
+  TripViewer:
+    accessible: Truy cập được
+    bicyclesAllowed: Được phép
+    header: Xem chuyến đi
+    routeHeader: "Tuyến: <strong>{routeShortName}</strong> {routeLongName}"
+    viewStop: Lượt xem
+  UserAccountScreen:
+    confirmDelete: >-
+      Bạn có chắc bạn muốn xóa tài khoản người dùng của mình không? Một khi bạn
+      làm như vậy, nó không thể được phục hồi.
+  UserSettings:
+    confirmDeletion: >-
+      Bạn có các tìm kiếm và/hoặc địa điểm gần đây được lưu trữ. Việc vô hiệu
+      hóa tính năng lưu trữ các địa điểm/tìm kiếm gần đây sẽ loại bỏ các mục
+      này. Tiếp tục?
+    favoriteStops: Điểm dừng yêu thích
+    myPreferences: Ưu tiên của tôi
+    mySavedPlaces: Những nơi đã lưu của tôi (<manageLink>quản lý</manageLink>)
+    noFavoriteStops: Không có điểm dừng yêu thích
+    recentPlaces: Những nơi gần đây
+    recentSearchSummary: "{mode} từ {from} đến {to}"
+    recentSearches: Tìm kiếm gần đây
+    rememberSearches: Nhớ các tìm kiếm/địa điểm gần đây?
+    stopId: Điểm dừng số {stopId}
+    storageDisclaimer: >
+      Bất kỳ tùy chọn, địa điểm hoặc cài đặt nào bạn chọn để lưu sẽ được lưu trữ
+      cục bộ trong trình duyệt của bạn. TriMet sẽ không có quyền truy cập kiến
+      thức về nhà ở, chỗ làm hoặc bất kỳ vị trí nào khác của bạn. Tại bất kỳ
+      thời điểm nào, bạn có thể chọn tắt ghi nhớ các địa điểm/tìm kiếm gần đây
+      và xóa các địa điểm nhà ở/chỗ làm đã lưu của bạn và các điểm dừng yêu
+      thích.
+  UserTripSettings:
+    forgetOptions: Hãy quên các tùy chọn của tôi
+    rememberOptions: Hãy nhớ các tùy chọn chuyến đi
+    restoreDefaults: Khôi phục mặc định
+    restoreMyDefaults: Khôi phục mặc định của tôi
+  VerifyEmailPane:
+    emailIsVerified: Email của tôi đã được xác minh!
+    instructions1: >
+      Vui lòng kiểm tra hộp thư đến trong email của bạn và vào đường link trong
+      tin nhắn để xác minh địa chỉ email của bạn trước khi hoàn thành việc thiết
+      lập tài khoản của bạn.
+    instructions2: Khi bạn đã được xác minh, nhấp vào nút bên dưới để tiếp tục.
+    resendVerification: Gửi lại email xác minh
+  ViewSwitcher:
+    switcher: Nút bật tắt
+  WelcomeScreen:
+    prompt: Bạn muốn đi đâu?
+config:
+  accessModes:
+    bicycle: Giao thông công cộng + Xe đạp cá nhân
+    bicycle_rent: Giao thông công cộng + Xe đạp chung
+    car_hail: Đi taxi
+    car_park: Đậu xe và đi xe công cộng
+    micromobility: Giao thông công cộng + Xe tay ga điện của tôi
+    micromobility_rent: Giao thông công cộng + Xe tay ga điện cho thuê
+  bicycleModes:
+    bicycle: Xe đạp của tôi
+    bicycle_rent: Xe đạp chung
+  flex:
+    both: Xem dưới cùng của hành trình để biết chi tiết
+    call-ahead: Gọi để đặt trước.
+    continuous-dropoff: Giao tiếp với người vận hành về điểm dừng
+    flex-service: Dịch vụ linh hoạt
+    flex-service-colon: "Dịch vụ flex:"
+  micromobilityModes:
+    micromobility: Xe tay ga điện của tôi
+    micromobility_rent: Xe tay ga điện cho thuê
 util:
   state:
     errorPlanningTrip: Đã xảy ra lỗi khi lập kế hoạch chuyến đi.
     networkUnavailable: Mạng {network} hiện tại không có sẵn.
     noTripFound: Không tìm thấy chuyến đi nào.
     noTripFoundForMode: Không tìm thấy chuyến đi nào cho {modes}.
-    noTripFoundWithReason: '{noTripFound} {reason}'
-    noTripFoundReason: Có thể không có dịch vụ vận chuyển trong khoảng cách được chỉ
-      định tối đa hoặc vào thời điểm đã chỉ định, hoặc điểm xuất phát hoặc điểm cuối
-      của bạn có thể không thể truy cập an toàn.
-config:
-  accessModes:
-    bicycle_rent: Giao thông công cộng + Xe đạp chung
-    bicycle: Giao thông công cộng + Xe đạp cá nhân
-    car_hail: Đi taxi
-    car_park: Đậu xe và đi xe công cộng
-    micromobility_rent: Giao thông công cộng + Xe tay ga điện cho thuê
-    micromobility: Giao thông công cộng + Xe tay ga điện của tôi
-  bicycleModes:
-    bicycle: Xe đạp của tôi
-    bicycle_rent: Xe đạp chung
-  micromobilityModes:
-    micromobility: Xe tay ga điện của tôi
-    micromobility_rent: Xe tay ga điện cho thuê
-  flex:
-    flex-service: Dịch vụ linh hoạt
-    flex-service-colon: 'Dịch vụ flex:'
-    both: Xem dưới cùng của hành trình để biết chi tiết
-    continuous-dropoff: Giao tiếp với người vận hành về điểm dừng
-    call-ahead: Gọi để đặt trước.
-actions:
-  fieldTrip:
-    addNoteError: 'Lỗi khi thêm ghi chú chuyến đi:'
-    confirmOverwriteItineraries: "Hành động này sẽ ghi đè lên một hành trình {outbound,\
-      \ select,\n  true {xuất ngoại}\n  other {đến}\n  } đã được lên kế hoạch trước\
-      \ đó cho yêu cầu này. Bạn có muốn tiếp tục không?\n"
-    deleteNoteError: 'Lỗi khi xóa ghi chú chuyến đi:'
-    deleteItinerariesError: 'Lỗi khi xóa kế hoạch chuyến đi:'
-    editSubmitterNotesError: 'Lỗi khi chỉnh sửa ghi chú của người gửi:'
-    fetchFieldTripsError: 'Lỗi khi tìm nạp các chuyến đi: {err}'
-    fetchTripsForDateError: 'Lỗi khi tìm nạp các chuyến đi cho ngày đi du lịch: {err}'
-    fetchFieldTripError: 'Lỗi khi tìm nạp các chuyến đi: {err}'
-    maxTripRequestsExceeded: Đã vượt quá số lượng yêu cầu chuyến đi mà không có kết
-      quả hợp lệ
-    incompatibleTripDateError: Ngày đi dự kiến ({tripDate}) không phải là ngày đi
-      theo yêu cầu ({requestDate})
-    itineraryCapacityError: 'Không thể lưu kế hoạch chuyến đi: Không thể lưu kế hoạch
-      chuyến đi này do thiếu sức chứa trên một hoặc nhiều xe. Vui lòng lên kế hoạch
-      lại chuyến đi của bạn.'
-    saveItinerariesError: 'Không lưu được hành trình: {err}'
-    setGroupSizeError: 'Lỗi khi cài đặt kích thước nhóm:'
-    setDateError: 'Lỗi khi cài đặt ngày:'
-    setRequestStatusError: 'Lỗi khi cài đặt trạng thái yêu cầu:'
-    setPaymentError: 'Lỗi khi cài đặt thông tin thanh toán:'
-  location:
-    geolocationNotSupportedError: Định vị địa lý không được hỗ trợ bởi trình duyệt
-      của bạn
-    unknownPositionError: Lỗi không xác định khi tìm vị trí
-  user:
-    accountDeleted: Tài khoản người dùng của bạn ({email}) đã bị xóa.
-    authTokenError: Lỗi khi lấy mã thông báo ủy quyền.
-    confirmDeletePlace: Bạn có muốn loại bỏ nơi này không?
-    confirmDeleteMonitoredTrip: Bạn có muốn loại bỏ chuyến đi này không?
-    emailVerificationResent: Thông báo xác minh email đã được gửi lại.
-    genericError: 'Phát sinh lỗi: {err}'
-    itineraryExistenceCheckFailed: Lỗi kiểm tra xem chuyến đi được chọn của bạn là
-      có thể.
-    smsResendThrottled: Một SMS xác minh đã được gửi đến số điện thoại được chỉ định
-      chưa đầy một phút trước. Vui lòng thử lại sau vài phút.
-    preferencesSaved: Những sở thích của bạn đã được lưu lại.
-    smsInvalidCode: Mã bạn nhập không hợp lệ. Vui lòng thử lại.
-    smsVerificationFailed: Điện thoại của bạn không thể được xác minh. Có lẽ mã bạn
-      đã nhập đã hết hạn. Vui lòng yêu cầu một mã mới và thử lại.
-  callTaker:
-    callQuerySaveError: 'Lỗi khi lưu trữ các truy vấn cuộc gọi: {err}'
-    callSaveError: 'Không thể lưu cuộc gọi: {err}'
-    checkSessionError: 'Lỗi khi thiết lập phiên ủy quyền: {err}'
-    couldNotFindCallError: Không thể tìm thấy cuộc gọi. Đang hủy yêu cầu lưu truy
-      vấn.
-    fetchCallsError: 'Lỗi khi tìm nạp cuộc gọi: {err}'
-    queryFetchError: 'Lỗi khi tìm nạp các truy vấn: {err}'
-  map:
-    currentLocation: (Vị trí hiện tại)
+    noTripFoundReason: >-
+      Có thể không có dịch vụ vận chuyển trong khoảng cách được chỉ định tối đa
+      hoặc vào thời điểm đã chỉ định, hoặc điểm xuất phát hoặc điểm cuối của bạn
+      có thể không thể truy cập an toàn.
+    noTripFoundWithReason: "{noTripFound} {reason}"

--- a/i18n/zh.yml
+++ b/i18n/zh.yml
@@ -1,561 +1,103 @@
 _id: zh
 _name: Chinese (Simplified)
-
-# This file contains localized strings (a.k.a. messages) for the language indicated above:
-#   - Messages are organized in various categories and sub-categories.
-#   - A component or JS module can use messages from one or more categories.
-#   - In the code, messages are retrieved using an ID that is simply the path to the message.
-#     Use the dot '.' to separate categories and sub-categories in the path.
-#     For instance, for the message defined in YML below:
-#         common
-#           modes
-#             subway: Metro#
-#     then use the snippet below with the corresponding message id:
-#         <FormattedMessage id='common.modes.subway' /> // renders "Metro".
-#
-# It is important that message ids in the code be consistent with
-# the categories in this file. Below are some general guidelines:
-#   - For starters, there are an 'actions', 'components' and 'common'
-#     categories. Additional categories may be added as needed.
-#   - Each sub-category under 'components' denotes a component and
-#     should contain messages that are used only by that component (e.g. button captions).
-#   - In contrast, some strings are common to multiple components,
-#     so it makes sense to group them by theme (e.g. accessModes) under the 'common' category.
-
-# Messages that are generated from actions
 actions:
+  callTaker:
+    callQuerySaveError: "存储通话查询时出现错误: {err}"
+    callSaveError: "无法保存通话: {err}"
+    checkSessionError: "建立授权使用时出现错误: {err}"
+    couldNotFindCallError: 找不到通话.取消保存查询请求.
+    fetchCallsError: "获取通话时出现错误: {err}"
+    queryFetchError: "获取查询时出现错误: {err}"
   fieldTrip:
-    addNoteError: '添加行程记录时出现错误:'
-    confirmOverwriteItineraries: "此操作将覆盖此请求的先前计划的{outbound, select,\n  true {出站}\n\
-      \  other {入站}\n  } 行程. 你想继续吗?\n"
-    deleteItinerariesError: '删除行程计划时出现错误:'
-    deleteNoteError: '删除行程计划时出现错误:'
-    editSubmitterNotesError: '编辑提交者备注时出现错误:'
-    fetchFieldTripError: '获取行程时出现错误: {err}'
-    fetchFieldTripsError: '获取行程时出现错误: {err}'
-    fetchTripsForDateError: '获取旅行日期的行程时出现错误: {err}'
+    addNoteError: "添加行程记录时出现错误:"
+    confirmOverwriteItineraries: |
+      此操作将覆盖此请求的先前计划的{outbound, select,
+        true {出站}
+        other {入站}
+        } 行程. 你想继续吗?
+    deleteItinerariesError: "删除行程计划时出现错误:"
+    deleteNoteError: "删除行程计划时出现错误:"
+    editSubmitterNotesError: "编辑提交者备注时出现错误:"
+    fetchFieldTripError: "获取行程时出现错误: {err}"
+    fetchFieldTripsError: "获取行程时出现错误: {err}"
+    fetchTripsForDateError: "获取旅行日期的行程时出现错误: {err}"
     incompatibleTripDateError: 计划的旅行日期 ({tripDate}) 不是请求的旅行日期 ({requestDate})
-    itineraryCapacityError: '无法保存计划: 由于一辆或多辆车辆容量不足, 无法保存此计划. 请重新计划您的旅行.'
+    itineraryCapacityError: "无法保存计划: 由于一辆或多辆车辆容量不足, 无法保存此计划. 请重新计划您的旅行."
     maxTripRequestsExceeded: 超出了没有有效结果的行程请求数
-    saveItinerariesError: '未能保存行程: {err}'
+    saveItinerariesError: "未能保存行程: {err}"
     setDateError: 设置日期时出现错误：
-    setGroupSizeError: '设置团体大小时出现错误:'
-    setPaymentError: '设置付款信息时出现错误:'
-    setRequestStatusError: '设置请求状态时出现错误:'
+    setGroupSizeError: "设置团体大小时出现错误:"
+    setPaymentError: "设置付款信息时出现错误:"
+    setRequestStatusError: "设置请求状态时出现错误:"
+  location:
+    geolocationNotSupportedError: 您的浏览器不支持地理定位
+    unknownPositionError: 获取位置的未知错误
+  map:
+    currentLocation: (当前位置)
   user:
     accountDeleted: 您的用户账户({email})已被删除.
     authTokenError: 获取授权凭证时出现错误.
     confirmDeleteMonitoredTrip: 你想取消这次旅行吗?
     confirmDeletePlace: 你想删除这个地方吗?
     emailVerificationResent: 电子邮件验证信息已被重新发送.
-    genericError: '遇到了一个错误: {err}'
+    genericError: "遇到了一个错误: {err}"
     itineraryExistenceCheckFailed: 检查你选择的旅行是否可行时出现错误.
     preferencesSaved: 您的偏好已被保存.
     smsInvalidCode: 您输入的代码无效. 请再试一次.
     smsResendThrottled: 不到一分钟前一条验证短信已经发送到指定的电话号码上. 请稍后再试.
     smsVerificationFailed: 您的手机无法被验证. 也许你输入的代码已经过期. 请申请一个新的代码并重新尝试.
-  callTaker:
-    callQuerySaveError: '存储通话查询时出现错误: {err}'
-    callSaveError: '无法保存通话: {err}'
-    checkSessionError: '建立授权使用时出现错误: {err}'
-    couldNotFindCallError: 找不到通话.取消保存查询请求.
-    fetchCallsError: '获取通话时出现错误: {err}'
-    queryFetchError: '获取查询时出现错误: {err}'
-  location:
-    geolocationNotSupportedError: 您的浏览器不支持地理定位
-    unknownPositionError: 获取位置的未知错误
-  map:
-    currentLocation: (当前位置)
-components:
-  BatchSettings:
-    destination: 目的地
-    origin: 出发地
-    planTripTooltip: 计划行程
-    settings: 行程设置
-    validationMessage: '请定义以下字段来计划旅行: {issues}'
-  BeforeSignInScreen:
-    mainTitle: 签到
-    message: "为了访问这个页面 你将需要登录. 我们会将您重新定向到登录页面，请稍等.\n"
-  CallTakerPanel:
-    advancedOptions: 进阶选项
-    groupSize: '团体规模:'
-    intermediateDestination: 输入中间目的地
-  DateTimePreview:
-    arriveAt: 到达 {arriveTime, time, short}
-    dayLastWeek: 上 {formattedDayOfWeek}
-    departAt: 出发 {departTime, time, short}
-    leaveNow: 现在离开
-    range: '{startTime, time, short} 到 {endTime, time, short}'
-    editDepartOrArrival: 编辑出发或到达时间
-  DefaultItinerary:
-    clickDetails: 点击查看详情
-    multiModeSummary: '{accessMode} + {transitMode}'
-  ExistingAccountDisplay:
-    a11y: 无障碍
-    mainTitle: 我的设置
-    notifications: 通知
-    places: 最喜欢的地点
-    terms: 条款
-  FavoritePlaceScreen:
-    addNewPlace: 添加新地点
-    editPlace: 编辑 {placeName}
-    editPlaceGeneric: 编辑地点
-    invalidAddress: 请为这个地点设定一个位置.
-    invalidName: 请为这个地点输入一个名称.
-    nameAlreadyUsed: 您已经在另一个地点使用这个名字. 请输入一个不同的名字.
-    placeNotFound: 未找到地点
-    placeNotFoundDescription: 对不起, 没有找到要求的地方.
-  LiveStopTimes:
-    autoRefresh: 自动刷新传入的到达?
-  LocationSearch:
-    enterLocation: 输入位置
-    setDestination: 设置目的地
-    setOrigin: 设置出发地
-  MapLayers:
-    bike-rental: '{companies} 共享单车'
-    car-rental: 租车地点
-    micromobility-rental: '{companies} 电动滑板车'
-    park-and-ride: 停车和乘车地点
-    satellite: 卫星
-    shared-vehicles: 共享车辆
-    stops: 公共交通站点
-    streets: 街道
-  MetroUI:
-    arriveAtTime: '{time} 到达'
-    fromStop: 从 {stop}
-    itineraryDescription: '{time} 行程使用 {routes}'
-    leaveAt: 您已离开
-    multipleOptions: 多种选择
-    orAlternatives: 或同一方向的其他路线
-    timeWalking: '{time} 步行'
-  MobileOptions:
-    header: 设置搜索选项
-  ModeDropdown:
-    exclusiveMode: 仅 {mode}
-  NarrativeItinerariesHeader:
-    changeSortDir: 改变排序方向
-    itinerariesAndIssues: '{itinerariesFound} 和 {numIssues}'
-    itinerariesFound: "发现{itineraryNum}条行程"
-    numIssues: "{issueNum, plural,\n one {# 问题}\n other {# 个问题}\n }"
-    searching: 寻找你的选择…
-    selectArrivalTime: 抵达时间
-    selectBest: 最佳选择
-    selectCost: 费用
-    selectDepartureTime: 出发时间
-    selectDuration: 旅行时长
-    selectWalkTime: 步行时间
-    sortBy: 排序方式
-    viewAll: 查看所有选项
-  NavLoginButton:
-    help: 帮助
-    myAccount: 我的账户
-    signIn: 登录
-    signOut: 签出
-  NewAccountWizard:
-    finish: 账户设置完成!
-    notifications: 通知偏好
-    places: 添加您的位置
-    terms: 创建一个新账户
-    verify: 验证您的电子邮件地址
-  NotificationPrefsPane:
-    description: 你可以收到关于你常用行程的通知.
-    noneSelect: 不要通知我
-    notificationChannelPrompt: 您希望如何接收通知?
-    notificationEmailDetail: '通知邮件将被发送至:'
-  PhoneNumberEditor:
-    changeNumber: 更改电话号码
-    invalidCode: 请输入6位数的验证码.
-    invalidPhone: 请输入一个有效的电话号码.
-    pending: 待定
-    placeholder: 输入你的电话号码
-    prompt: '输入你的电话号码以便收到短信通知:'
-    requestNewCode: 申请一个新的代码
-    sendVerificationText: 发送验证短信
-    smsDetail: '短信通知将被发送到:'
-    verificationCode: '验证码:'
-    verificationInstructions: "请检查您手机上的短信应用查看是否有验证码的短信并输入以下代码 (代码在10分钟后失效).\n"
-    verified: 已验证
-    verify: 核实
-    phoneNumberVerified: 电话号码 {phoneNumber} 已成功验证。
-  Place:
-    deleteThisPlace: 删除这个地点
-    enterAlert: "在表格中输入出发地/目的地(或通过地图点击设置)并点击产生的标记设置为 {placeType} 地点.\n"
-    viewStop: 查看车站
-  PlaceEditor:
-    genericLocationPlaceholder: 搜索地点
-    locationPlaceholder: 搜索 {placeName} 位置
-    namePrompt: '地名:'
-    nameExample: 我的咖啡店
-    addressPrompt: '地址:'
-  PlanFirstLastButtons:
-    first: 首先
-    last: 最后一次
-    next: 下一个
-    previous: 上一个
-  PlanTripButton:
-    planTrip: 计划行程
-  PrintLayout:
-    itinerary: 行程
-    toggleMap: 切换地图
-  RealtimeAnnotation:
-    serviceUpdate: 服务更新
-    delaysShownInResults: "你的旅行结果已经根据实时信息进行了调整. 在正常情况下使用以下路线, 这个行程需要 {normalDuration}:\
-      \ {routes}.\n"
-  RealtimeStatusLabel:
-    early: 提前 {minutes}
-    scheduled: 预定的
-    late: 迟到 {minutes}
-    onTime: 准时
-  RelatedPanel:
-    hideExtraStops: 隐藏额外车站
-    showExtraStops: 显示 {count}个额外的车站
-  ResultsError:
-    backToSearch: 返回搜索
-  RouteDetails:
-    moreDetails: 更多细节
-    operatedBy: 由 {agencyName} 运营
-    selectADirection: 选择一个方向…
-    stopsTo: 邁向
-  RouteViewer:
-    agencyFilter: 运输机构筛选
-    allAgencies: 所有运输机构
-    allModes: 所有模式
-    details: ' '
-    findARoute: 查找路线
-    header: 路线查看器
-    modeFilter: 旅行模式筛选
-    noFilteredRoutesFound: 没有符合你筛选的路线!
-    shortTitle: 查看路线
-    title: 路线查看器
-  SavedTripEditor:
-    editSavedTrip: 编辑已保存的行程
-    saveNewTrip: 保存新的行程
-    tripInformation: 行程信息
-    tripNotFound: 未找到行程
-    tripNotFoundDescription: 对不起, 没有找到所要求的行程.
-    tripNotifications: 行程通知
-  SavedTripList:
-    fromTo: 从 {from} 到 {to}
-    myTrips: 我的行程
-    noSavedTrips: 你没有保存的行程
-    noSavedTripsInstructions: 首先从地图上进行行程搜索.
-    pause: 暂停
-    resume: 继续
-  SaveTripButton:
-    cantSaveText: 无法保存
-    cantSaveTooltip: 只有包括交通的行程而没有租车或叫车的行程可以被监控.
-    saveTripText: 保存行程
-    signInText: 登录以保存行程
-    signInTooltip: 请登录以保存行程.
-  SimpleRealtimeAnnotation:
-    usingRealtimeInfo: 这个行程使用实时交通和延迟信息
-  SettingsPreview:
-    defaultPreviewText: 公共交通选择和偏好
-  StackedPaneDisplay:
-    savePreferences: 保存偏好
-  StopScheduleTable:
-    block: 堵塞
-    departure: 出发
-    route: 路线
-    destination: 到
-  StopViewer:
-    displayStopId: '<strong>公交车站ID</strong>: {stopId}'
-    flexStop: 此站为灵活站. 根据要求车辆将在这个灵活的区域上下乘客. 在这个区域, 你可能需要提前打电话申请服务.
-    header: 车站查看器
-    loadingText: 加载车站信息…
-    noStopsFound: 未找到该日期的车站时间.
-    operatorLogoAriaLabel: "公交车站 {operatorName}:"
-    timezoneWarning: 出发时间以 <strong>{timezoneCode}</strong> 显示.
-    titleBarStopId: 车站 {stopId}
-    viewNextArrivals: 查看下一个公共交通到达
-    viewSchedule: 查看时间表
-    zoomToStop: 缩放到车站
-    findSchedule: 按日期搜索时间表
-  TermsOfUsePane:
-    confirmDeletionPrompt: "取消您对存储历史旅行的同意将导致您的旅行历史被删除. 你确定你要继续吗？\n"
-    mustAgreeToTerms: 您必须同意服务条款才能继续.
-    termsOfStorageStatement: "可选的: 我同意 Trip Planner 存储我的历史计划行程，以改善我所在地区的交通服务. <termsOfStorageLink>更多信息...</termsOfStorageLink>\n"
-    termsOfServiceStatement: "我确认我已年满 18 岁并且我已阅读并同意 <termsOfUseLink>服务条款</termsOfUseLink\
-      \ > 使用 Trip Planner.\n"
-  TransitVehicleOverlay:
-    in_transit_to: 下一车站 {stop}
-    incoming_at: 接近 {stop}
-    stopped_at: 巴士车门在 {stop} 打开
-    travelingAt: 以 {milesPerHour} 行进
-    vehicleName: 车辆 {vehicleNumber}
-  TripNotificationsPane:
-    advancedSettings: 进阶设置
-    altRouteRecommended: 建议采用替代路线或换乘点
-    delaysAboveThreshold: 延误或中断超过
-    howToReceiveAlerts: "要接收已保存行程的提醒, 请在你的账户设置中启用通知, 并尝试再次保存一个行程.\n"
-    monitorThisTrip: '在开始之前监控此行程:'
-    notificationsTurnedOff: 你账户的通知被关闭了.
-    notifyViaChannelWhen: '通过 {channel} 通知我当:'
-    oneHour: 1小时
-    realtimeAlertFlagged: 在我的行程中有一个实时警报标志着
-  TripStatus:
-    deleteTrip: 删除行程
-    planNewTrip: 计划新的行程
-    alerts: '{alerts, plural, one {# 警报!} other {# 警报!}}'
-  TripStatusRenderers:
-    base:
-      lastCheckedDefaultText: 最后一次检查时间未知
-      lastCheckedText: '最后一次检查: {formattedDuration} 前'
-      togglePause: 暂停
-      tripIsNotSnoozed: 将今天剩下的时间设为打盹状态
-      tripIsSnoozed: 重新开启行程分析功能
-      unknownState: 未知的旅行状态
-      untogglePause: 继续
-    noLongerPossible:
-      heading: 行程已不可能进行
-      description: "行程规划器无法找到您在一周内任何选定日期的行程。请尝试重新规划您的行程，寻找其他路线。\n"
-    snoozed:
-      heading: 今天行程监控为打盹状态
-      description: 重新启用行程监控以查看最新状态.
-    upcoming:
-      nextTripBegins: 下一趟旅程于 {tripDatetime, date, ::eeeee yyyyMMdd} {tripDatetime,
-        time, short} 开始.
-      tripStartIsDelayed: 行程开始时间延迟 ${duration}!
-      tripStartsSoonOnTime: 行程即将开始而且大约是准时的.
-      tripBegins: 您的行程将于 {tripStart, time, short} 开始. (实时跟踪将于{monitoringStart, time,
-        short}开始.)
-      tripStartIsEarly: 开始时间比预期早 ${duration}!
-      tripStartsSoonNoUpdates: 行程即将开始 (没有实时更新).
-    active:
-      delayedHeading: 旅程正在进行中并延迟了{formattedDuration}!
-      description: 旅程将于 {arrivalTime, time, short} 到达目的地.
-      earlyHeading: 旅程正在进行中将比预计时间早 {formattedDuration} 到达!
-      noDataHeading: 旅程正在进行中 (没有可用的实时更新).
-      onTimeHeading: 旅程正在进行中而且大约是准时的.
-    inactive:
-      description: 恢复行程监控以查看最新状态
-      heading: 行程监控暂停了
-    nextTripNotPossible:
-      heading: 今天的行程已不可能进行
-      description: "行程规划器无法找到您今天的行程. 请尝试重新规划您的行程寻找其他路线.\n"
-    notCalculated:
-      awaiting: 等待计算…
-      description: 请稍等一下以便计算行程.
-      heading: 尚未计算的行程
-  TripSummaryPane:
-    notificationsDisabled: '通知: <strong>已禁用</strong>'
-    happensOnDays: '发生在: <strong>{days}</strong>'
-    notifications: '通知: <strong>预定出发前 {leadTimeInMinutes} </strong>'
-  TripTools:
-    linkCopied: 已复制
-    reportEmailSubject: 报告OpenTripPlanner的问题
-    reportEmailTemplate: "***对用户的指示***\n 该功能允许你通过电子邮件将报告发送给网站管理员进行审查.请填写下面的提示并使用你的常规电子邮件程序发送.\n\
-      \ \n ***请填写以下内容***\n \n 遇到的问题:\n \n 你想要的旅行类型:\n \n ***技术细节***\n"
-    copyLink: 复制链接
-    reportIssue: 报告问题
-  TripViewer:
-    accessible: 可通行
-    bicyclesAllowed: 允许的
-    header: 行程查看器
-    routeHeader: 路线:<strong>{routeShortName}</strong> {routeLongName}
-    viewStop: 查阅
-  UserAccountScreen:
-    confirmDelete: 您确定要删除你的用户账户吗?一旦您这样做, 它就无法恢复.
-  UserSettings:
-    confirmDeletion: 您有最近的搜索或地点存储.若停止存储最近的地点或搜索的功能，则这些项目将被删除.要继续吗?
-    favoriteStops: 最喜爱的车站
-    myPreferences: 我的偏好
-    mySavedPlaces: 我保存的位置 (<manageLink>管理</manageLink>)
-    noFavoriteStops: 没有最喜欢的车站
-    recentPlaces: 最近的地方
-    recentSearches: 最近的搜索
-    recentSearchSummary: 从 {from} {mode} 到 {to}
-    rememberSearches: 还记得最近的搜索/地方吗?
-    stopId: '车站 ID: {stopId}'
-    storageDisclaimer: "您选择保存的任何偏好, 地点或设置将被保存在您的浏览器的当地存储中. TriMet将无法获得关于您住家、工作或任何其他地点的信息.\
-      \ 在任何时候, 您都可以选择关闭记忆最近的地方或搜索, 并清除您保存的住家或工作地点和最喜欢的车站.\n"
-  VerifyEmailPane:
-    emailIsVerified: 我的电子邮件被验证了!
-    instructions1: "在完成账户设置之前请检查您的电子邮件收件箱并按照信息中的链接来验证您的电子邮件地址.\n"
-    instructions2: 一旦您被验证，请点击下面的按钮继续.
-    resendVerification: 重新发送验证邮件
-  UserTripSettings:
-    forgetOptions: 忘记我的选择
-    rememberOptions: 记住行程选择
-    restoreDefaults: 恢复默认设置
-    restoreMyDefaults: 恢复我的默认值
-  AccountSetupFinishPane:
-    message: 你已经准备好开始计划你的旅行.
-  AmenitiesPanel:
-    bikesAtStation: "{companyLength, plural,\n =0 {{name} 有辆自行车 }\n other {{name}\
-      \ 有 {company} 自行车 }\n }\n"
-    bikesAvailable: "{count, plural,\n =0 {自行车不可用}\n one {# 辆自行车可用}\n other {# 辆自行车可用}\n\
-      \ }\n"
-    bikesNearby: "{count, plural,\n =0 {附近没有 {company} 自行车}\n one {附近有 # 辆 {company}\
-      \ 自行车}\n other {附近有 # 辆 {company} 自行车}\n }\n"
-    nearbyAmenities: 附近的设施
-    noNearbyBikes: 附近没有发现自行车出租.
-    noNearbyScooters: 附近没有微型交通工具出租.
-    noPRLotsFound: 附近没有Park-and-Ride.
-    scootersNearby: "{count, plural,\n =0 {附近没有 {company} 电动滑板车}\n one {附近有 # {company}\
-      \ 电动滑板车}\n other {附近有 # {company} 电动滑板车}\n }\n"
-    spacesAvailable: "{count, plural,\n =0 {没有可用的车位}\n one {# 个可车位}\n other {# 个可车位}\n\
-      \ }\n"
-  AppMenu:
-    callHistory: 呼叫历史
-    closeMenu: 关闭菜单
-    fieldTrip: 旅行标题
-    mailables: 准备发布
-    openMenu: 打开菜单
-    skipNavigation: 跳过导航
-  StopTimeCell:
-    imminentArrival: 到达
-    realtime: 基于实时数据
-    scheduled: 基于预定数据
-  SubNav:
-    languages: "语言"
-    languageSelector: 选择语言
-    myAccount: 我的帐户
-    selectALanguage: 选择语言
-    settings: 设置
-    trips: 行程
-    userMenu: 个人资料选项
-  SwitchButton:
-    defaultContent: 切换
-    switchLocations: 切换位置
-  WelcomeScreen:
-    prompt: 你想去哪里？
-  ViewSwitcher:
-    switcher: 切换按钮
-  A11yPrefs:
-    accessibilityRoutingByDefault: 默认情况下优先选择无障碍旅行
-  AddPlaceButton:
-    addPlace: 添加地点
-    needOriginDestination: 定义出发地或目的地以增加中途地点
-    tooManyPlaces: 已达到最多中途地点
-  AdvancedOptions:
-    bannedRoutes: 选择禁行路线…
-    maxBike: 最大骑自行车 {unitsString}
-    maxWalk: 最大步行 {unitsString}
-    preferredRoutes: 选择首选路线…
-    walkReluctance: 避免步行
-  AfterSignInScreen:
-    mainTitle: 重新定向…
-    message: 如果几秒钟后页面没有加载, 请 <redirectLink>点击这里</redirectLink>.
-  BackToTripPlanner:
-    backToTripPlanner: 返回到行程计划表
-  BatchResultsScreen:
-    expandMap: 扩大地图
-    showResults: 显示结果
-  BatchRoutingPanel:
-    shortTitle: 计划行程
-  BatchSearchScreen:
-    header: 计划您的行程
-  DateTimeOptions:
-    arriveBy: 到达
-    now: 现在
-    departAt: 出发时间
-  DateTimeScreen:
-    header: 设置日期/时间
-  DeleteUser:
-    deleteMyAccount: 删除我的账户
-  EnhancedStopMarker:
-    stopID: '车站 ID:'
-    stopViewer: 车站查看器
-  ErrorMessage:
-    header: 无法计划行程
-    warning: 警告
-  FavoritePlaceList:
-    addAnotherPlace: 添加另一个地点
-    description: '添加你经常去的地点以节省计划行程的时间:'
-    editThisPlace: 编辑此位置
-    setAddressForPlaceType: 设置您的 {placeType} 地址
-  FormNavigationButtons:
-    ariaLabel: 表格导航
-  NotFound:
-    description: 您要求的内容不存在.
-    header: 未找到内容
-  RelatedStopsPanel:
-    noArrivalFound: 未发现抵达者
-    relatedStops: 相关车站
-    viewDetails: 查看详情
-  ResultsHeader:
-    noTripFound: 没有找到行程
-    tripsFound: 我们发现了 {count} 选项
-    waiting: 等待...
-  SavedTripScreen:
-    tripNameAlreadyUsed: 另一个保存行程已经使用了这个名字. 请选择一个不同的名字.
-    tripNameRequired: 请输入一个行程名称.
-    tooManyTrips: "你已经达到了五次保存行程的上限. 请从你保存行程中删除未使用的行程然后再试一次.\n"
-  TripBasicsPane:
-    checkingItineraryExistence: 检查一周中每一天的行程存在…
-    selectAtLeastOneDay: 请至少选择一天进行监测.
-    tripDaysPrompt: 您这次行程是在哪天进行的?
-    tripIsAvailableOnDaysIndicated: 您的行程可以在上述一周的日子里进行.
-    tripNamePrompt: '请为这次旅行提供一个名称:'
-    tripNotAvailableOnDay: 此行程每 {repeatedDay} 不举行!
-    unsavedChangesExistingTrip: 您还没有保存你的行程. 如果您离开了，变更就会消失.
-    unsavedChangesNewTrip: 您还没有保存您的新旅行. 如果您离开，它就会消失.
-  TripSummary:
-    arriveAt: "到达 "
-    leaveAt: "离开 "
-  SessionTimeout:
-    header: 使用时间即将结束!
-    keepSession: 继续使用
-    body: 您的使用时间将在一分钟内到期.按“继续使用”以继续您的搜索.
-  PointPopup:
-    zoomToLocation: 缩放到位置
-  ItinerarySummary:
-    itineraryDetails: 行程详情
-    minMaxFare: '{minTotalFare} - {maxTotalFare}'
 common:
-  daysOfWeekCompact:
-    tuesday: 周二
-    friday: 周五
-    saturday: 周六
-    monday: 周一
-    sunday: 周日
-    thursday: 周四
-    wednesday: 周三
-  daysOfWeekPlural:
-    friday: 每周五
-    tuesday: 每周二
-    monday: 每周一
-    saturday: 每周六
-    sunday: 每周日
-    thursday: 每周四
-    wednesday: 每周三
-  forms:
-    cancel: 取消
-    finish: 完成
-    next: 下一页
-    no: 否
-    back: 后退
-    close: 关闭
-    defaultValue: '{value} (默认)'
-    delete: 删除
-    edit: 编辑
-    error: 错误!
-    print: 打印
-    save: 保存
-    startOver: 重新开始
-    yes: 是
-  itineraryDescriptions:
-    calories: '{calories, number} 大卡'
-    noTransitFareProvided: 没有票价信息
-    noItineraryToDisplay: 没有显示行程.
-    transfers: '{transfers, plural, =0 {} other {# 换乘}}'
-    relativeCo2: >
-      {co2} {isMore, select, true {更多} other {更少} } CO₂ 比单独驾车
-  time:
-    departureArrivalTimes: '{startTime, time, short}—{endTime, time, short}'
-    duration:
-      aFewSeconds: 几秒钟
-      nDays: "{days} 天"
-      nHours: "{hours} 小时"
-      nMinutes: "{minutes} 分钟"
-    durationAgo: "{duration} 前"
-    tripDurationFormat: "{hours, plural, =0 {} other {# 小时 }}{minutes} 分钟} { seconds,\
-      \ plural, =0 {} other {# 秒}}"
+  coordinates: "{lat}, {lon}"
   dateExpressions:
     today: 今天
     tomorrow: 明天
     yesterday: 昨天
+  daysOfWeek:
+    friday: 周五
+    monday: 周一
+    saturday: 周六
+    sunday: 周日
+    thursday: 周四
+    tuesday: 周二
+    wednesday: 周三
+  daysOfWeekCompact:
+    friday: 周五
+    monday: 周一
+    saturday: 周六
+    sunday: 周日
+    thursday: 周四
+    tuesday: 周二
+    wednesday: 周三
+  daysOfWeekPlural:
+    friday: 每周五
+    monday: 每周一
+    saturday: 每周六
+    sunday: 每周日
+    thursday: 每周四
+    tuesday: 每周二
+    wednesday: 每周三
+  forms:
+    back: 后退
+    cancel: 取消
+    close: 关闭
+    defaultValue: "{value} (默认)"
+    delete: 删除
+    edit: 编辑
+    error: 错误!
+    finish: 完成
+    next: 下一页
+    "no": 否
+    print: 打印
+    save: 保存
+    startOver: 重新开始
+    "yes": 是
+  itineraryDescriptions:
+    calories: "{calories, number} 大卡"
+    noItineraryToDisplay: 没有显示行程.
+    noTransitFareProvided: 没有票价信息
+    relativeCo2: |
+      {co2} {isMore, select, true {更多} other {更少} } CO₂ 比单独驾车
+    transfers: "{transfers} 换乘"
   modes:
     bicycle_rent: 共享单车
     bike: 自行车
@@ -576,14 +118,6 @@ common:
     tram: 电车
     transit: 公共交通
     walk: 步行
-  daysOfWeek:
-    friday: 周五
-    monday: 周一
-    saturday: 周六
-    sunday: 周日
-    thursday: 周四
-    tuesday: 周二
-    wednesday: 周三
   notifications:
     email: 电子邮件
     sms: 短信
@@ -595,13 +129,514 @@ common:
   routing:
     routeAndNumber: 路线 {routeId}
     routeToHeadsign: 到 {headsign}
-  coordinates: '{lat}, {lon}'
   searchForms:
-    enterDestination: "输入目的地名称或{mapAction}地图…"
-    enterStartLocation: "输入出发地点或{mapAction}地图…"
-    tap: 点击
     click: 点击
+    enterDestination: 输入目的地名称或{mapAction}地图…
+    enterStartLocation: 输入出发地点或{mapAction}地图…
+    tap: 点击
+  time:
+    departureArrivalTimes: "{startTime, time, short}—{endTime, time, short}"
+    duration:
+      aFewSeconds: 几秒钟
+      nDays: "{days} 天"
+      nHours: "{hours} 小时"
+      nMinutes: "{minutes} 分钟"
+    durationAgo: "{duration} 前"
+    tripDurationFormat: >-
+      {hours, plural, =0 {} other {# 小时 }}{minutes} 分钟} { seconds, plural, =0 {}
+      other {# 秒}}
+components:
+  A11yPrefs:
+    accessibilityRoutingByDefault: 默认情况下优先选择无障碍旅行
+  AccountSetupFinishPane:
+    message: 你已经准备好开始计划你的旅行.
+  AddPlaceButton:
+    addPlace: 添加地点
+    needOriginDestination: 定义出发地或目的地以增加中途地点
+    tooManyPlaces: 已达到最多中途地点
+  AdvancedOptions:
+    bannedRoutes: 选择禁行路线…
+    maxBike: 最大骑自行车 {unitsString}
+    maxWalk: 最大步行 {unitsString}
+    preferredRoutes: 选择首选路线…
+    walkReluctance: 避免步行
+  AfterSignInScreen:
+    mainTitle: 重新定向…
+    message: 如果几秒钟后页面没有加载, 请 <redirectLink>点击这里</redirectLink>.
+  AmenitiesPanel:
+    bikesAtStation: |
+      {companyLength, plural,
+       =0 {{name} 有辆自行车 }
+       other {{name} 有 {company} 自行车 }
+       }
+    bikesAvailable: |
+      {count, plural,
+       =0 {自行车不可用}
+       one {# 辆自行车可用}
+       other {# 辆自行车可用}
+       }
+    bikesNearby: |
+      {count, plural,
+       =0 {附近没有 {company} 自行车}
+       one {附近有 # 辆 {company} 自行车}
+       other {附近有 # 辆 {company} 自行车}
+       }
+    nearbyAmenities: 附近的设施
+    noNearbyBikes: 附近没有发现自行车出租.
+    noNearbyScooters: 附近没有微型交通工具出租.
+    noPRLotsFound: 附近没有Park-and-Ride.
+    scootersNearby: |
+      {count, plural,
+       =0 {附近没有 {company} 电动滑板车}
+       one {附近有 # {company} 电动滑板车}
+       other {附近有 # {company} 电动滑板车}
+       }
+    spacesAvailable: |
+      {count, plural,
+       =0 {没有可用的车位}
+       one {# 个可车位}
+       other {# 个可车位}
+       }
+  AppMenu:
+    callHistory: 呼叫历史
+    closeMenu: 关闭菜单
+    fieldTrip: 旅行标题
+    mailables: 准备发布
+    openMenu: 打开菜单
+    skipNavigation: 跳过导航
+  BackToTripPlanner:
+    backToTripPlanner: 返回到行程计划表
+  BatchResultsScreen:
+    expandMap: 扩大地图
+    showResults: 显示结果
+  BatchRoutingPanel:
+    shortTitle: 计划行程
+  BatchSearchScreen:
+    header: 计划您的行程
+  BatchSettings:
+    destination: 目的地
+    origin: 出发地
+    planTripTooltip: 计划行程
+    settings: 行程设置
+    validationMessage: "请定义以下字段来计划旅行: {issues}"
+  BeforeSignInScreen:
+    mainTitle: 签到
+    message: |
+      为了访问这个页面 你将需要登录. 我们会将您重新定向到登录页面，请稍等.
+  CallTakerPanel:
+    advancedOptions: 进阶选项
+    groupSize: "团体规模:"
+    intermediateDestination: 输入中间目的地
+  DateTimeOptions:
+    arriveBy: 到达
+    departAt: 出发时间
+    now: 现在
+  DateTimePreview:
+    arriveAt: 到达 {arriveTime, time, short}
+    dayLastWeek: 上 {formattedDayOfWeek}
+    departAt: 出发 {departTime, time, short}
+    editDepartOrArrival: 编辑出发或到达时间
+    leaveNow: 现在离开
+    range: "{startTime, time, short} 到 {endTime, time, short}"
+  DateTimeScreen:
+    header: 设置日期/时间
+  DefaultItinerary:
+    clickDetails: 点击查看详情
+    multiModeSummary: "{accessMode} + {transitMode}"
+  DeleteUser:
+    deleteMyAccount: 删除我的账户
+  EnhancedStopMarker:
+    stopID: "车站 ID:"
+    stopViewer: 车站查看器
+  ErrorMessage:
+    header: 无法计划行程
+    warning: 警告
+  ExistingAccountDisplay:
+    a11y: 无障碍
+    mainTitle: 我的设置
+    notifications: 通知
+    places: 最喜欢的地点
+    terms: 条款
+  FavoritePlaceList:
+    addAnotherPlace: 添加另一个地点
+    description: "添加你经常去的地点以节省计划行程的时间:"
+    editThisPlace: 编辑此位置
+    setAddressForPlaceType: 设置您的 {placeType} 地址
+  FavoritePlaceScreen:
+    addNewPlace: 添加新地点
+    editPlace: 编辑 {placeName}
+    editPlaceGeneric: 编辑地点
+    invalidAddress: 请为这个地点设定一个位置.
+    invalidName: 请为这个地点输入一个名称.
+    nameAlreadyUsed: 您已经在另一个地点使用这个名字. 请输入一个不同的名字.
+    placeNotFound: 未找到地点
+    placeNotFoundDescription: 对不起, 没有找到要求的地方.
+  FormNavigationButtons:
+    ariaLabel: 表格导航
+  ItinerarySummary:
+    itineraryDetails: 行程详情
+    minMaxFare: "{minTotalFare} - {maxTotalFare}"
+  LiveStopTimes:
+    autoRefresh: 自动刷新传入的到达?
+  LocationSearch:
+    enterLocation: 输入位置
+    setDestination: 设置目的地
+    setOrigin: 设置出发地
+  MapLayers:
+    bike-rental: "{companies} 共享单车"
+    car-rental: 租车地点
+    micromobility-rental: "{companies} 电动滑板车"
+    park-and-ride: 停车和乘车地点
+    satellite: 卫星
+    shared-vehicles: 共享车辆
+    stops: 公共交通站点
+    streets: 街道
+  MetroUI:
+    arriveAtTime: "{time} 到达"
+    fromStop: 从 {stop}
+    itineraryDescription: "{time} 行程使用 {routes}"
+    leaveAt: 您已离开
+    multipleOptions: 多种选择
+    orAlternatives: 或同一方向的其他路线
+    timeWalking: "{time} 步行"
+  MobileOptions:
+    header: 设置搜索选项
+  ModeDropdown:
+    exclusiveMode: 仅 {mode}
+  NarrativeItinerariesHeader:
+    changeSortDir: 改变排序方向
+    itinerariesAndIssues: "{itinerariesFound} 和 {numIssues}"
+    itinerariesFound: 发现{itineraryNum}条行程
+    numIssues: |-
+      {issueNum, plural,
+       one {# 问题}
+       other {# 个问题}
+       }
+    searching: 寻找你的选择…
+    selectArrivalTime: 抵达时间
+    selectBest: 最佳选择
+    selectCost: 费用
+    selectDepartureTime: 出发时间
+    selectDuration: 旅行时长
+    selectWalkTime: 步行时间
+    sortBy: 排序方式
+    viewAll: 查看所有选项
+  NavLoginButton:
+    help: 帮助
+    myAccount: 我的账户
+    signIn: 登录
+    signOut: 签出
+  NewAccountWizard:
+    finish: 账户设置完成!
+    notifications: 通知偏好
+    places: 添加您的位置
+    terms: 创建一个新账户
+    verify: 验证您的电子邮件地址
+  NotFound:
+    description: 您要求的内容不存在.
+    header: 未找到内容
+  NotificationPrefsPane:
+    description: 你可以收到关于你常用行程的通知.
+    noneSelect: 不要通知我
+    notificationChannelPrompt: 您希望如何接收通知?
+    notificationEmailDetail: "通知邮件将被发送至:"
+  PhoneNumberEditor:
+    changeNumber: 更改电话号码
+    invalidCode: 请输入6位数的验证码.
+    invalidPhone: 请输入一个有效的电话号码.
+    pending: 待定
+    phoneNumberVerified: 电话号码 {phoneNumber} 已成功验证。
+    placeholder: 输入你的电话号码
+    prompt: "输入你的电话号码以便收到短信通知:"
+    requestNewCode: 申请一个新的代码
+    sendVerificationText: 发送验证短信
+    smsDetail: "短信通知将被发送到:"
+    verificationCode: "验证码:"
+    verificationInstructions: |
+      请检查您手机上的短信应用查看是否有验证码的短信并输入以下代码 (代码在10分钟后失效).
+    verified: 已验证
+    verify: 核实
+  Place:
+    deleteThisPlace: 删除这个地点
+    enterAlert: |
+      在表格中输入出发地/目的地(或通过地图点击设置)并点击产生的标记设置为 {placeType} 地点.
+    viewStop: 查看车站
+  PlaceEditor:
+    addressPrompt: "地址:"
+    genericLocationPlaceholder: 搜索地点
+    locationPlaceholder: 搜索 {placeName} 位置
+    nameExample: 我的咖啡店
+    namePrompt: "地名:"
+  PlanFirstLastButtons:
+    first: 首先
+    last: 最后一次
+    next: 下一个
+    previous: 上一个
+  PlanTripButton:
+    planTrip: 计划行程
+  PointPopup:
+    zoomToLocation: 缩放到位置
+  PrintLayout:
+    itinerary: 行程
+    toggleMap: 切换地图
+  RealtimeAnnotation:
+    delaysShownInResults: |
+      你的旅行结果已经根据实时信息进行了调整. 在正常情况下使用以下路线, 这个行程需要 {normalDuration}: {routes}.
+    serviceUpdate: 服务更新
+  RealtimeStatusLabel:
+    early: 提前 {minutes}
+    late: 迟到 {minutes}
+    onTime: 准时
+    scheduled: 预定的
+  RelatedPanel:
+    hideExtraStops: 隐藏额外车站
+    showExtraStops: 显示 {count}个额外的车站
+  RelatedStopsPanel:
+    noArrivalFound: 未发现抵达者
+    relatedStops: 相关车站
+    viewDetails: 查看详情
+  ResultsError:
+    backToSearch: 返回搜索
+  ResultsHeader:
+    noTripFound: 没有找到行程
+    tripsFound: 我们发现了 {count} 选项
+    waiting: 等待...
+  RouteDetails:
+    moreDetails: 更多细节
+    operatedBy: 由 {agencyName} 运营
+    selectADirection: 选择一个方向…
+    stopsTo: 邁向
+  RouteViewer:
+    agencyFilter: 运输机构筛选
+    allAgencies: 所有运输机构
+    allModes: 所有模式
+    details: " "
+    findARoute: 查找路线
+    header: 路线查看器
+    modeFilter: 旅行模式筛选
+    noFilteredRoutesFound: 没有符合你筛选的路线!
+    shortTitle: 查看路线
+    title: 路线查看器
+  SaveTripButton:
+    cantSaveText: 无法保存
+    cantSaveTooltip: 只有包括交通的行程而没有租车或叫车的行程可以被监控.
+    saveTripText: 保存行程
+    signInText: 登录以保存行程
+    signInTooltip: 请登录以保存行程.
+  SavedTripEditor:
+    editSavedTrip: 编辑已保存的行程
+    saveNewTrip: 保存新的行程
+    tripInformation: 行程信息
+    tripNotFound: 未找到行程
+    tripNotFoundDescription: 对不起, 没有找到所要求的行程.
+    tripNotifications: 行程通知
+  SavedTripList:
+    fromTo: 从 {from} 到 {to}
+    myTrips: 我的行程
+    noSavedTrips: 你没有保存的行程
+    noSavedTripsInstructions: 首先从地图上进行行程搜索.
+    pause: 暂停
+    resume: 继续
+  SavedTripScreen:
+    tooManyTrips: |
+      你已经达到了五次保存行程的上限. 请从你保存行程中删除未使用的行程然后再试一次.
+    tripNameAlreadyUsed: 另一个保存行程已经使用了这个名字. 请选择一个不同的名字.
+    tripNameRequired: 请输入一个行程名称.
+  SessionTimeout:
+    body: 您的使用时间将在一分钟内到期.按“继续使用”以继续您的搜索.
+    header: 使用时间即将结束!
+    keepSession: 继续使用
+  SettingsPreview:
+    defaultPreviewText: 公共交通选择和偏好
+  SimpleRealtimeAnnotation:
+    usingRealtimeInfo: 这个行程使用实时交通和延迟信息
+  StackedPaneDisplay:
+    savePreferences: 保存偏好
+  StopScheduleTable:
+    block: 堵塞
+    departure: 出发
+    destination: 到
+    route: 路线
+  StopTimeCell:
+    imminentArrival: 到达
+    realtime: 基于实时数据
+    scheduled: 基于预定数据
+  StopViewer:
+    displayStopId: "<strong>公交车站ID</strong>: {stopId}"
+    findSchedule: 按日期搜索时间表
+    flexStop: 此站为灵活站. 根据要求车辆将在这个灵活的区域上下乘客. 在这个区域, 你可能需要提前打电话申请服务.
+    header: 车站查看器
+    loadingText: 加载车站信息…
+    noStopsFound: 未找到该日期的车站时间.
+    operatorLogoAriaLabel: "公交车站 {operatorName}:"
+    timezoneWarning: 出发时间以 <strong>{timezoneCode}</strong> 显示.
+    titleBarStopId: 车站 {stopId}
+    viewNextArrivals: 查看下一个公共交通到达
+    viewSchedule: 查看时间表
+    zoomToStop: 缩放到车站
+  SubNav:
+    languageSelector: 选择语言
+    languages: 语言
+    myAccount: 我的帐户
+    selectALanguage: 选择语言
+    settings: 设置
+    trips: 行程
+    userMenu: 个人资料选项
+  SwitchButton:
+    defaultContent: 切换
+    switchLocations: 切换位置
+  TermsOfUsePane:
+    confirmDeletionPrompt: |
+      取消您对存储历史旅行的同意将导致您的旅行历史被删除. 你确定你要继续吗？
+    mustAgreeToTerms: 您必须同意服务条款才能继续.
+    termsOfServiceStatement: >
+      我确认我已年满 18 岁并且我已阅读并同意 <termsOfUseLink>服务条款</termsOfUseLink > 使用 Trip
+      Planner.
+    termsOfStorageStatement: >
+      可选的: 我同意 Trip Planner 存储我的历史计划行程，以改善我所在地区的交通服务.
+      <termsOfStorageLink>更多信息...</termsOfStorageLink>
+  TransitVehicleOverlay:
+    in_transit_to: 下一车站 {stop}
+    incoming_at: 接近 {stop}
+    stopped_at: 巴士车门在 {stop} 打开
+    travelingAt: 以 {milesPerHour} 行进
+    vehicleName: 车辆 {vehicleNumber}
+  TripBasicsPane:
+    checkingItineraryExistence: 检查一周中每一天的行程存在…
+    selectAtLeastOneDay: 请至少选择一天进行监测.
+    tripDaysPrompt: 您这次行程是在哪天进行的?
+    tripIsAvailableOnDaysIndicated: 您的行程可以在上述一周的日子里进行.
+    tripNamePrompt: "请为这次旅行提供一个名称:"
+    tripNotAvailableOnDay: 此行程每 {repeatedDay} 不举行!
+    unsavedChangesExistingTrip: 您还没有保存你的行程. 如果您离开了，变更就会消失.
+    unsavedChangesNewTrip: 您还没有保存您的新旅行. 如果您离开，它就会消失.
+  TripNotificationsPane:
+    advancedSettings: 进阶设置
+    altRouteRecommended: 建议采用替代路线或换乘点
+    delaysAboveThreshold: 延误或中断超过
+    howToReceiveAlerts: |
+      要接收已保存行程的提醒, 请在你的账户设置中启用通知, 并尝试再次保存一个行程.
+    monitorThisTrip: "在开始之前监控此行程:"
+    notificationsTurnedOff: 你账户的通知被关闭了.
+    notifyViaChannelWhen: "通过 {channel} 通知我当:"
+    oneHour: 1小时
+    realtimeAlertFlagged: 在我的行程中有一个实时警报标志着
+  TripStatus:
+    alerts: "{alerts, plural, one {# 警报!} other {# 警报!}}"
+    deleteTrip: 删除行程
+    planNewTrip: 计划新的行程
+  TripStatusRenderers:
+    active:
+      delayedHeading: 旅程正在进行中并延迟了{formattedDuration}!
+      description: 旅程将于 {arrivalTime, time, short} 到达目的地.
+      earlyHeading: 旅程正在进行中将比预计时间早 {formattedDuration} 到达!
+      noDataHeading: 旅程正在进行中 (没有可用的实时更新).
+      onTimeHeading: 旅程正在进行中而且大约是准时的.
+    base:
+      lastCheckedDefaultText: 最后一次检查时间未知
+      lastCheckedText: "最后一次检查: {formattedDuration} 前"
+      togglePause: 暂停
+      tripIsNotSnoozed: 将今天剩下的时间设为打盹状态
+      tripIsSnoozed: 重新开启行程分析功能
+      unknownState: 未知的旅行状态
+      untogglePause: 继续
+    inactive:
+      description: 恢复行程监控以查看最新状态
+      heading: 行程监控暂停了
+    nextTripNotPossible:
+      description: |
+        行程规划器无法找到您今天的行程. 请尝试重新规划您的行程寻找其他路线.
+      heading: 今天的行程已不可能进行
+    noLongerPossible:
+      description: |
+        行程规划器无法找到您在一周内任何选定日期的行程。请尝试重新规划您的行程，寻找其他路线。
+      heading: 行程已不可能进行
+    notCalculated:
+      awaiting: 等待计算…
+      description: 请稍等一下以便计算行程.
+      heading: 尚未计算的行程
+    snoozed:
+      description: 重新启用行程监控以查看最新状态.
+      heading: 今天行程监控为打盹状态
+    upcoming:
+      nextTripBegins: >-
+        下一趟旅程于 {tripDatetime, date, ::eeeee yyyyMMdd} {tripDatetime, time,
+        short} 开始.
+      tripBegins: >-
+        您的行程将于 {tripStart, time, short} 开始. (实时跟踪将于{monitoringStart, time,
+        short}开始.)
+      tripStartIsDelayed: 行程开始时间延迟 ${duration}!
+      tripStartIsEarly: 开始时间比预期早 ${duration}!
+      tripStartsSoonNoUpdates: 行程即将开始 (没有实时更新).
+      tripStartsSoonOnTime: 行程即将开始而且大约是准时的.
+  TripSummary:
+    arriveAt: "到达 "
+    leaveAt: "离开 "
+  TripSummaryPane:
+    happensOnDays: "发生在: <strong>{days}</strong>"
+    notifications: "通知: <strong>预定出发前 {leadTimeInMinutes} </strong>"
+    notificationsDisabled: "通知: <strong>已禁用</strong>"
+  TripTools:
+    copyLink: 复制链接
+    linkCopied: 已复制
+    reportEmailSubject: 报告OpenTripPlanner的问题
+    reportEmailTemplate: |
+      ***对用户的指示***
+       该功能允许你通过电子邮件将报告发送给网站管理员进行审查.请填写下面的提示并使用你的常规电子邮件程序发送.
+       
+       ***请填写以下内容***
+       
+       遇到的问题:
+       
+       你想要的旅行类型:
+       
+       ***技术细节***
+    reportIssue: 报告问题
+  TripViewer:
+    accessible: 可通行
+    bicyclesAllowed: 允许的
+    header: 行程查看器
+    routeHeader: 路线:<strong>{routeShortName}</strong> {routeLongName}
+    viewStop: 查阅
+  UserAccountScreen:
+    confirmDelete: 您确定要删除你的用户账户吗?一旦您这样做, 它就无法恢复.
+  UserSettings:
+    confirmDeletion: 您有最近的搜索或地点存储.若停止存储最近的地点或搜索的功能，则这些项目将被删除.要继续吗?
+    favoriteStops: 最喜爱的车站
+    myPreferences: 我的偏好
+    mySavedPlaces: 我保存的位置 (<manageLink>管理</manageLink>)
+    noFavoriteStops: 没有最喜欢的车站
+    recentPlaces: 最近的地方
+    recentSearchSummary: 从 {from} {mode} 到 {to}
+    recentSearches: 最近的搜索
+    rememberSearches: 还记得最近的搜索/地方吗?
+    stopId: "车站 ID: {stopId}"
+    storageDisclaimer: >
+      您选择保存的任何偏好, 地点或设置将被保存在您的浏览器的当地存储中. TriMet将无法获得关于您住家、工作或任何其他地点的信息. 在任何时候,
+      您都可以选择关闭记忆最近的地方或搜索, 并清除您保存的住家或工作地点和最喜欢的车站.
+  UserTripSettings:
+    forgetOptions: 忘记我的选择
+    rememberOptions: 记住行程选择
+    restoreDefaults: 恢复默认设置
+    restoreMyDefaults: 恢复我的默认值
+  VerifyEmailPane:
+    emailIsVerified: 我的电子邮件被验证了!
+    instructions1: |
+      在完成账户设置之前请检查您的电子邮件收件箱并按照信息中的链接来验证您的电子邮件地址.
+    instructions2: 一旦您被验证，请点击下面的按钮继续.
+    resendVerification: 重新发送验证邮件
+  ViewSwitcher:
+    switcher: 切换按钮
+  WelcomeScreen:
+    prompt: 你想去哪里？
 config:
+  accessModes:
+    bicycle: 公共交通 + 我的自行车
+    bicycle_rent: 公共交通 + 共享单车
+    car_hail: Ride Hail
+    car_park: Park & Ride
+    micromobility: 公共交通 + 我的电动滑板车
+    micromobility_rent: 公共交通 + 租用的电动滑板车
   bicycleModes:
     bicycle: 我的自行车
     bicycle_rent: 共享单车
@@ -610,22 +645,15 @@ config:
     call-ahead: 打电话预约
     continuous-dropoff: 与操作人员沟通停止事宜
     flex-service: 灵活的服务
-    flex-service-colon: '灵活的服务:'
-  accessModes:
-    bicycle: 公共交通 + 我的自行车
-    bicycle_rent: 公共交通 + 共享单车
-    car_hail: Ride Hail
-    car_park: Park & Ride
-    micromobility: 公共交通 + 我的电动滑板车
-    micromobility_rent: 公共交通 + 租用的电动滑板车
+    flex-service-colon: "灵活的服务:"
   micromobilityModes:
     micromobility: 我的电动滑板车
     micromobility_rent: 租用的电动滑板车
 util:
   state:
     errorPlanningTrip: 在计划行程时发生一个错误.
-    networkUnavailable: '{network} 网络目前无法使用.'
+    networkUnavailable: "{network} 网络目前无法使用."
     noTripFound: 没有找到行程.
     noTripFoundForMode: 没有发现 {modes} 的行程.
     noTripFoundReason: 在指定的最大距离内或在指定的时间可能没有公交服务, 或者您的起点或终点可能无法安全通行.
-    noTripFoundWithReason: '{noTripFound} {reason}'
+    noTripFoundWithReason: "{noTripFound} {reason}"

--- a/lib/components/narrative/line-itin/itin-summary.tsx
+++ b/lib/components/narrative/line-itin/itin-summary.tsx
@@ -175,10 +175,12 @@ export class ItinerarySummary extends Component<Props> {
 
           {/* Number of transfers, if applicable */}
           <Detail>
-            <FormattedMessage
-              id="common.itineraryDescriptions.transfers"
-              values={{ transfers: itinerary.transfers }}
-            />
+            {itinerary.transfers && (
+              <FormattedMessage
+                id="common.itineraryDescriptions.transfers"
+                values={{ transfers: itinerary.transfers }}
+              />
+            )}
           </Detail>
         </Details>
         <Routes>


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR sorts i18n yaml files (rewrites them) via a minor change that removes zero-transfer rendering from the old line-itin ItinerarySummary.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

