### PR TITLE
correct `FIELD_TRIP_DATE_TIME_FORMAT`

### DIFF
--- a/lib/actions/field-trip.js
+++ b/lib/actions/field-trip.js
@@ -59,7 +59,7 @@ export const setSaveable = createAction('SET_SAVEABLE')
 
 // these are date/time formats specifically used by otp-datastore
 const FIELD_TRIP_DATE_FORMAT = 'MM/dd/yyyy'
-const FIELD_TRIP_DATE_TIME_FORMAT = 'yyyy-MM-ddTHH:mm:ss'
+const FIELD_TRIP_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss"
 const FIELD_TRIP_TIME_FORMAT = 'HH:mm:ss'
 
 const FieldTripEndPoints = {


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

This bug has been in field trip since it was first added to OTP-RR. The date format on server requests was incorrect, causing trips to be stored incorrectly, which in turn caused all sorts of display issues. I've done lots of testing with the new format and it seems to fix most issues the field trip was having

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

