### PR TITLE
10x Developer Route row spacing PR 2.0

### DIFF
--- a/lib/components/util/operator-logo.tsx
+++ b/lib/components/util/operator-logo.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 const OperatorImg = styled.img`
-  height: 25px;
+  width: 25px;
 `
 
 type Props = {

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -59,17 +59,13 @@ export const RouteRowButton = styled(Button)`
   }
 `
 
-export const RouteRowElement = styled.span`
-  padding-right: 8px;
-`
 export const OperatorImg = styled.img`
   height: 25px;
-  margin-right: 8px;
 `
 
 export const ModeIconElement = styled.span`
+  display: inherit; // Allows for equal sizing and vertical centering of mode icons
   height: 28px;
-  padding-left: inherit;
   width: 28px;
 `
 
@@ -77,23 +73,18 @@ const RouteNameElement = styled.span`
   flex-shrink: 0;
   font-size: 16px;
   font-weight: 400;
-  margin-left: 8px;
 `
 const RouteDetailsContainer = styled.div`
   align-items: center;
   display: grid;
   grid-template-columns: repeat(4, auto);
+  gap: 12px;
   justify-items: center;
+  margin-left: 5px;
 `
 const RouteLongNameElement = styled.span`
   font-size: 16px;
   font-weight: 500;
-  /*
-    Top margin is same as border-top-width+margin-top of the default route renderer,
-    so that the baseline of the route short name aligns with that
-    of the route long name.
-  */
-  margin: 2px 0 0 15px;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -226,9 +217,7 @@ export class RouteRow extends PureComponent {
     return (
       <StyledRouteRow isActive={isActive} ref={this.activeRef}>
         <RouteDetailsContainer>
-          <RouteRowElement>
-            <OperatorLogo operator={operator} />
-          </RouteRowElement>
+          <OperatorLogo operator={operator} />
           {route.mode && (
             <ModeIconElement>
               <ModeIcon


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
I messed up the merge on [the previous PR](https://github.com/opentripplanner/otp-react-redux/pull/854), so transferred changes here ahahahaha. 

What this does:
Styling the route row was convoluted to say the least -- adding a margin-top: __ and padding-left: __ to try to centre the operator and mode logos in each config wasn't the best way to go about things. We've added uniform gaps between the spans in each route row and extra styling so the logos don't overflow, the grid can grid and the flex can flex.

Ultimately, everything in the route row can be ✨ aligned at all times ✨

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

