### PR TITLE
a11y: Avoid repeating route name

### DIFF
--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -144,7 +144,11 @@ export const RouteName = ({ basicRender, route, RouteRenderer }) => {
       {/* Only render long name if it's not already rendered by the RouteRenderer 
           (the long name is rendered by the routeRenderer if the short name does not exist) */}
       {route.shortName && (
-        <RouteLongNameElement>{route.longName}</RouteLongNameElement>
+        // If the route long name is the same as the route short name, then
+        // hide the route long name from assistive technology to avoid repeating the same route names.
+        <RouteLongNameElement aria-hidden={route.shortName === route.longName}>
+          {route.longName}
+        </RouteLongNameElement>
       )}
     </>
   )

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -2,8 +2,6 @@
 /* eslint-disable react/prop-types */
 import { ArrowRight } from '@styled-icons/fa-solid'
 import { Button } from 'react-bootstrap'
-
-import { Icon } from '../util/styledIcon'
 import React, { PureComponent } from 'react'
 import styled from 'styled-components'
 
@@ -13,6 +11,7 @@ import {
   getModeFromRoute
 } from '../../util/viewer'
 import { getFormattedMode } from '../../util/i18n'
+import { Icon } from '../util/styledIcon'
 import DefaultRouteRenderer from '../narrative/metro/default-route-renderer'
 import OperatorLogo from '../util/operator-logo'
 
@@ -129,25 +128,23 @@ const PatternButton = styled.button`
 
 export const RouteName = ({ basicRender, route, RouteRenderer }) => {
   const Route = RouteRenderer || DefaultRouteRenderer
-
+  const { longName, shortName } = route
   return (
     <>
-      <RouteNameElement title={`${route.shortName}`}>
+      <RouteNameElement title={`${shortName}`}>
         {!basicRender ? (
           <Route leg={generateFakeLegForRouteRenderer(route)} />
         ) : (
-          <SimpleRouteRenderer>
-            {route.shortName || route.longName}
-          </SimpleRouteRenderer>
+          <SimpleRouteRenderer>{shortName || longName}</SimpleRouteRenderer>
         )}
       </RouteNameElement>
       {/* Only render long name if it's not already rendered by the RouteRenderer 
           (the long name is rendered by the routeRenderer if the short name does not exist) */}
-      {route.shortName && (
+      {shortName && (
         // If the route long name is the same as the route short name, then
         // hide the route long name from assistive technology to avoid repeating the same route names.
-        <RouteLongNameElement aria-hidden={route.shortName === route.longName}>
-          {route.longName}
+        <RouteLongNameElement aria-hidden={shortName === longName}>
+          {longName}
         </RouteLongNameElement>
       )}
     </>


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR improves how routes are announced by screen readers by not saying a route long name if it is the same as the route short name (e.g. "MARTA Rail Blue" instead of "MARTA Rail Blue Blue").

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
| ![Before image](https://user-images.githubusercontent.com/56846598/236233752-c016000b-2328-4c95-a279-b0615a524b7d.png) | ![After image](https://user-images.githubusercontent.com/56846598/236233242-37a2ba4c-2fbf-4dd4-b8fe-bd2a96785e34.png) |

