### PR TITLE
Remove redundant Route Viewer header in mobile view

### DIFF
--- a/lib/components/mobile/mobile.css
+++ b/lib/components/mobile/mobile.css
@@ -264,3 +264,7 @@
   right: 0;
   height: 200px;
 }
+
+.otp.mobile .route-viewer-header {
+  margin: 0;
+}

--- a/lib/components/mobile/route-viewer.js
+++ b/lib/components/mobile/route-viewer.js
@@ -38,7 +38,7 @@ class MobileRouteViewer extends Component {
         />
         <main tabIndex={-1}>
           <div className="viewer-container">
-            <RouteViewer hideBackButton ModeIcon={ModeIcon} />
+            <RouteViewer hideBackButton hideHeader ModeIcon={ModeIcon} />
           </div>
 
           {/* The map is less important semantically, so keyboard focus and screen readers

--- a/lib/components/viewers/route-viewer.tsx
+++ b/lib/components/viewers/route-viewer.tsx
@@ -41,6 +41,7 @@ interface Props {
   findRouteIfNeeded: () => void
   findRoutesIfNeeded: () => void
   hideBackButton?: boolean
+  hideHeader?: boolean
   intl: IntlShape
   modes: string[]
   routes: Route[]
@@ -120,6 +121,7 @@ class RouteViewer extends Component<Props, State> {
       filter,
       findRouteIfNeeded,
       hideBackButton,
+      hideHeader,
       intl,
       modes,
       routes: sortedRoutes,
@@ -166,9 +168,11 @@ class RouteViewer extends Component<Props, State> {
           )}
 
           {/* Header Text */}
-          <h1 className="header-text">
-            <FormattedMessage id="components.RouteViewer.title" />
-          </h1>
+          {!hideHeader && (
+            <h1 className="header-text">
+              <FormattedMessage id="components.RouteViewer.title" />
+            </h1>
+          )}
           <div>
             <FormattedMessage id="components.RouteViewer.details" />
           </div>


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR hides the redundant "Route Viewer" heading when in the mobile view.

Any thoughts on removing the 5px margin around the route filter box?

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
|  ![Before image](https://user-images.githubusercontent.com/56846598/236242511-9e5813ee-5d03-4d44-a8f4-843d910d7628.png) | ![After image](https://user-images.githubusercontent.com/56846598/236242961-38ce43b8-61ad-4257-8149-d44012c3fb28.png) |

