### PR TITLE
Add a11y support to misc buttons

### DIFF
--- a/lib/components/app/print-layout.tsx
+++ b/lib/components/app/print-layout.tsx
@@ -115,7 +115,7 @@ class PrintLayout extends Component<Props, State> {
                 <IconWithText Icon={Print}>{printVerb}</IconWithText>
               </Button>
             </SpanWithSpace>
-            <Button bsSize="small" onClick={this._close}>
+            <Button bsSize="small" onClick={this._close} role="link">
               <IconWithText Icon={Times}>
                 <FormattedMessage id="common.forms.close" />
               </IconWithText>

--- a/lib/components/app/print-layout.tsx
+++ b/lib/components/app/print-layout.tsx
@@ -100,7 +100,11 @@ class PrintLayout extends Component<Props, State> {
         <div className="header">
           <div style={{ float: 'right' }}>
             <SpanWithSpace margin={0.25}>
-              <Button bsSize="small" onClick={this._toggleMap}>
+              <Button
+                aria-expanded={this.state.mapVisible}
+                bsSize="small"
+                onClick={this._toggleMap}
+              >
                 <IconWithText Icon={Map}>
                   <FormattedMessage id="components.PrintLayout.toggleMap" />
                 </IconWithText>

--- a/lib/components/narrative/trip-tools.js
+++ b/lib/components/narrative/trip-tools.js
@@ -53,7 +53,11 @@ class CopyUrlButton extends Component {
   render() {
     return (
       <div>
-        <Button className="tool-button" onClick={this._onClick}>
+        <Button
+          aria-live={this.state.showCopied ? 'assertive' : ''}
+          className="tool-button"
+          onClick={this._onClick}
+        >
           {this.state.showCopied ? (
             <span>
               <IconWithText Icon={Check}>

--- a/lib/components/narrative/trip-tools.js
+++ b/lib/components/narrative/trip-tools.js
@@ -89,7 +89,7 @@ class PrintButton extends Component {
   render() {
     return (
       <div>
-        <Button className="tool-button" onClick={this._onClick}>
+        <Button className="tool-button" onClick={this._onClick} role="link">
           <IconWithText Icon={Print}>
             <FormattedMessage id="common.forms.print" />
           </IconWithText>
@@ -159,7 +159,11 @@ class LinkButton extends Component {
     const { Icon, onClick, text } = this.props
     return (
       <div>
-        <Button className="tool-button" onClick={onClick || this._onClick}>
+        <Button
+          className="tool-button"
+          onClick={onClick || this._onClick}
+          role="link"
+        >
           <IconWithText Icon={Icon}>{text}</IconWithText>
         </Button>
       </div>


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
- Add `aria-live` to copy button in trip details to announce to AT that info was copied
- Add `aria-expanded` to map button in printable itinerary to announce to AT that region was expanded.
- Add `role="link"` to trip tools buttons acting as links

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [n/a] Are all languages supported (Internationalization/Localization)?
- [n/a] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

