### PR TITLE
Use auth0 login page with the current locale.

### DIFF
--- a/lib/components/app/desktop-nav.tsx
+++ b/lib/components/app/desktop-nav.tsx
@@ -21,6 +21,7 @@ const NavItemOnLargeScreens = styled(NavItem)`
 `
 // Typscript TODO: otpConfig type
 export type Props = {
+  locale: string
   otpConfig: any
   popupTarget?: string
   setPopupContent: (url: string) => void
@@ -39,7 +40,12 @@ export type Props = {
  *
  * TODO: merge with the mobile navigation bar.
  */
-const DesktopNav = ({ otpConfig, popupTarget, setPopupContent }: Props) => {
+const DesktopNav = ({
+  locale,
+  otpConfig,
+  popupTarget,
+  setPopupContent
+}: Props) => {
   const { branding, persistence, title = DEFAULT_APP_TITLE } = otpConfig
   const showLogin = Boolean(getAuth0Config(persistence))
 
@@ -76,6 +82,7 @@ const DesktopNav = ({ otpConfig, popupTarget, setPopupContent }: Props) => {
               <NavLoginButtonAuth0
                 id="login-control"
                 links={accountLinks}
+                locale={locale}
                 style={{ float: 'right' }}
               />
             )}
@@ -90,6 +97,7 @@ const DesktopNav = ({ otpConfig, popupTarget, setPopupContent }: Props) => {
 // Typescript TODO: state type
 const mapStateToProps = (state: any) => {
   return {
+    locale: state.otp.ui.locale,
     otpConfig: state.otp.config,
     popupTarget: state.otp.config?.popups?.launchers?.toolbar
   }

--- a/lib/components/mobile/navigation-bar.js
+++ b/lib/components/mobile/navigation-bar.js
@@ -21,6 +21,7 @@ class MobileNavigationBar extends Component {
     defaultMobileTitle: PropTypes.string,
     headerAction: PropTypes.element,
     headerText: PropTypes.string,
+    locale: PropTypes.string,
     onBackClicked: PropTypes.func,
     setMobileScreen: PropTypes.func,
     showBackButton: PropTypes.bool
@@ -41,6 +42,7 @@ class MobileNavigationBar extends Component {
       defaultMobileTitle,
       headerAction,
       headerText,
+      locale,
       showBackButton
     } = this.props
 
@@ -83,7 +85,11 @@ class MobileNavigationBar extends Component {
                 submenus of this component to be displayed full-screen-width,
                 and that behavior is not desired here. */}
             {auth0Config && (
-              <NavLoginButtonAuth0 id="login-control" links={accountLinks} />
+              <NavLoginButtonAuth0
+                id="login-control"
+                links={accountLinks}
+                locale={locale}
+              />
             )}
           </div>
         </Navbar>
@@ -97,7 +103,8 @@ class MobileNavigationBar extends Component {
 const mapStateToProps = (state) => {
   return {
     auth0Config: getAuth0Config(state.otp.config.persistence),
-    configLanguages: state.otp.config.language
+    configLanguages: state.otp.config.language,
+    locale: state.otp.ui.locale
   }
 }
 

--- a/lib/components/user/nav-login-button-auth0.tsx
+++ b/lib/components/user/nav-login-button-auth0.tsx
@@ -1,5 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react'
-import React, { HTMLAttributes } from 'react'
+import React, { HTMLAttributes, useCallback } from 'react'
 
 import { getCurrentRoute } from '../../util/ui'
 
@@ -13,6 +13,7 @@ type AccountLink = {
 interface NavLoginButtonAuth0Props extends HTMLAttributes<HTMLElement> {
   id: string
   links: Array<AccountLink>
+  locale: string
 }
 
 /**
@@ -22,20 +23,28 @@ const NavLoginButtonAuth0 = ({
   className,
   id,
   links,
+  locale,
   style
 }: NavLoginButtonAuth0Props): JSX.Element => {
   const { isAuthenticated, loginWithRedirect, logout, user } = useAuth0()
 
   // On login, preserve the current trip query if any.
-  const handleLogin = () =>
-    loginWithRedirect({
-      appState: { returnTo: getCurrentRoute() }
-    })
-  const handleLogout = () =>
-    logout({
-      // Logout to the map with no search.
-      returnTo: window.location.origin
-    })
+  const handleLogin = useCallback(
+    () =>
+      loginWithRedirect({
+        appState: { returnTo: getCurrentRoute() },
+        ui_locales: locale
+      }),
+    [locale, loginWithRedirect]
+  )
+  const handleLogout = useCallback(
+    () =>
+      logout({
+        // Logout to the map with no search.
+        returnTo: window.location.origin
+      }),
+    [logout]
+  )
 
   // On logout, it is better to "clear" the screen, so
   // return to redirectUri set in <Auth0Provider> (no specific event handler).


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR makes the login button send the current locale to Auth0 so that the login page is shown in the same language as OTP-RR.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

