### PR TITLE
Add span surrounding operator logo in stop view

### DIFF
--- a/lib/components/viewers/stop-viewer.js
+++ b/lib/components/viewers/stop-viewer.js
@@ -220,17 +220,26 @@ class StopViewer extends Component {
           {stopData ? (
             <h1 style={{ paddingLeft: '0.5ch' }}>
               {agencyCount <= 1 && stationOperator && (
-                <OperatorLogo
-                  alt={intl.formatMessage(
-                    {
-                      id: 'components.StopViewer.operatorLogoAriaLabel'
-                    },
-                    {
-                      operatorName: stationOperator.name
-                    }
-                  )}
-                  operator={stationOperator}
-                />
+                /* Span with agency classname allows optional contrast/customization in user 
+                config for logos with poor contrast. Class name is hyphenated agency name 
+                e.g. "sound-transit" */
+                <span
+                  className={stationOperator.name
+                    .replace(/\s+/g, '-')
+                    .toLowerCase()}
+                >
+                  <OperatorLogo
+                    alt={intl.formatMessage(
+                      {
+                        id: 'components.StopViewer.operatorLogoAriaLabel'
+                      },
+                      {
+                        operatorName: stationOperator.name
+                      }
+                    )}
+                    operator={stationOperator}
+                  />
+                </span>
               )}
               {stopData.name}
             </h1>


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Adds a `span` with `className` surrounding the operator logo in the stop viewer, so that optional contrast or border can be added in configurations files.  Helpful for logos with dark colors that may not provide enough contrast against the dark background of the stop viewer. 

| Before | After |
|--------|-------|
|![image](https://github.com/opentripplanner/otp-react-redux/assets/115499534/6ec8f335-6793-47fd-ad78-c1271dd49510)|![image](https://github.com/opentripplanner/otp-react-redux/assets/115499534/652036fc-e6ca-4b7a-a878-6b7cc04cc166)|


<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [n/a] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [n/a] Are all languages supported (Internationalization/Localization)?
- [n/a] Are appropriate Typescript types implemented?


