### PR TITLE
Replace trip sort select with accessible dropdown

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -332,6 +332,9 @@ components:
       {itineraryNum, plural, one {# itinerary found} other {# itineraries found}
       }
     numIssues: "{issueNum, plural, one {# issue} other {# issues} }"
+    resultsSortedBy: >-
+      Trip results currently sorted by {sortSelected}. To change the way results
+      are sorted, use the "Sort Results" button below.
     searching: Finding your options...
     selectArrivalTime: Arrival time
     selectBest: Best option

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -339,7 +339,7 @@ components:
     selectDepartureTime: Departure time
     selectDuration: Duration
     selectWalkTime: Walk time
-    sortBy: Sort By
+    sortResults: Sort results
     viewAll: View all options
   NavLoginButton:
     help: Help

--- a/i18n/es.yml
+++ b/i18n/es.yml
@@ -30,8 +30,7 @@ actions:
       No se puede guardar el plan: este plan no se pudo guardar debido a la
       falta de capacidad en uno o más vehículos. Por favor, vuelva a planificar
       su viaje.
-    maxTripRequestsExceeded: Número de solicitudes de viaje superadas sin resultados
-      válidos
+    maxTripRequestsExceeded: Número de solicitudes de viaje superadas sin resultados válidos
     saveItinerariesError: "No se pudieron guardar los itinerarios: {err}"
     setDateError: "Error al establecer la fecha:"
     setGroupSizeError: "No se pudo establecer el tamaño del grupo:"
@@ -47,11 +46,9 @@ actions:
     authTokenError: Error al obtener un token de autorización.
     confirmDeleteMonitoredTrip: ¿Desea eliminar este viaje?
     confirmDeletePlace: ¿Quiere eliminar este lugar?
-    emailVerificationResent: El mensaje de verificación de correo electrónico ha sido
-      reenviado.
+    emailVerificationResent: El mensaje de verificación de correo electrónico ha sido reenviado.
     genericError: "Se ha encontrado un error: {err}"
-    itineraryExistenceCheckFailed: Comprobación de errores para ver si el viaje seleccionado
-      es posible.
+    itineraryExistenceCheckFailed: Comprobación de errores para ver si el viaje seleccionado es posible.
     preferencesSaved: Sus preferencias se han guardado.
     smsInvalidCode: El código introducido no es válido. Por favor, inténtelo de nuevo.
     smsResendThrottled: >-
@@ -113,6 +110,7 @@ common:
       {co2} de CO₂ en {isMore, select, true {más} other {menos} } que conducir
       solo
     transfers: "{transfers, plural, =0 {} one {# transferencia} other {# transferencias}}"
+  linkOpensNewWindow: (Abre una nueva ventana)
   modes:
     bicycle_rent: Compartir bicicleta
     bike: Bicicleta
@@ -160,7 +158,6 @@ common:
     tripDurationFormat: >-
       {hours, plural, =0 {} other {# h }}{minutes} min { seconds, plural, =0 {}
       other {# s}}
-  linkOpensNewWindow: (Abre una nueva ventana)
 components:
   A11yPrefs:
     accessibilityRoutingByDefault: Prefiera los viajes accesibles por defecto
@@ -237,8 +234,7 @@ components:
     origin: origen
     planTripTooltip: Planificar viaje
     settings: Preferencias de viaje
-    validationMessage: "Por favor, defina los siguientes campos para planificar un\
-      \ viaje: {issues}"
+    validationMessage: "Por favor, defina los siguientes campos para planificar un viaje: {issues}"
   BeforeSignInScreen:
     mainTitle: Iniciando sesión
     message: >
@@ -349,7 +345,6 @@ components:
     selectDepartureTime: Hora de salida
     selectDuration: Duración
     selectWalkTime: Tiempo de caminata
-    sortBy: Ordenar por
     viewAll: Ver todas las opciones
   NavLoginButton:
     help: Ayuda
@@ -369,8 +364,7 @@ components:
     description: Puede recibir notificaciones sobre los viajes que realiza con frecuencia.
     noneSelect: No enviar notificaciones
     notificationChannelPrompt: ¿Cómo desea recibir las notificaciones?
-    notificationEmailDetail: "Los correos electrónicos de notificación se enviarán\
-      \ a:"
+    notificationEmailDetail: "Los correos electrónicos de notificación se enviarán a:"
   PhoneNumberEditor:
     changeNumber: Cambiar número de teléfono
     invalidCode: Introduzca 6 dígitos para el código de validación.
@@ -503,8 +497,7 @@ components:
       Opciones
       y Preferencias del viaje
   SimpleRealtimeAnnotation:
-    usingRealtimeInfo: Este viaje utiliza información de tráfico y retrasos en tiempo
-      real
+    usingRealtimeInfo: Este viaje utiliza información de tráfico y retrasos en tiempo real
   StackedPaneDisplay:
     savePreferences: Guardar preferencias
   StopScheduleTable:
@@ -566,19 +559,16 @@ components:
     travelingAt: Viajando a {milesPerHour}
     vehicleName: Vehículo {vehicleNumber}
   TripBasicsPane:
-    checkingItineraryExistence: Comprobación de la existencia de itinerarios para
-      cada día de la semana…
+    checkingItineraryExistence: Comprobación de la existencia de itinerarios para cada día de la semana…
     selectAtLeastOneDay: Por favor, seleccione al menos un día para el seguimiento.
     tripDaysPrompt: ¿Qué días hace este viaje?
-    tripIsAvailableOnDaysIndicated: Su viaje está disponible en los días de la semana
-      indicados anteriormente.
+    tripIsAvailableOnDaysIndicated: Su viaje está disponible en los días de la semana indicados anteriormente.
     tripNamePrompt: "Por favor, indique un nombre para este viaje:"
     tripNotAvailableOnDay: El viaje no está disponible el {repeatedDay}
     unsavedChangesExistingTrip: >-
       Todavía no ha guardado su viaje. Si abandona la página, los cambios se
       perderán.
-    unsavedChangesNewTrip: Todavía no ha guardado su nuevo viaje. Si abandona la página,
-      se perderá.
+    unsavedChangesNewTrip: Todavía no ha guardado su nuevo viaje. Si abandona la página, se perderá.
   TripNotificationsPane:
     advancedSettings: Configuración avanzada
     altRouteRecommended: Se recomienda una ruta alternativa o un punto de transferencia

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -351,7 +351,6 @@ components:
     selectDepartureTime: Heure de départ
     selectDuration: Durée
     selectWalkTime: Temps de marche
-    sortBy: Trier par
     viewAll: Toutes les options
   NavLoginButton:
     help: Aide

--- a/i18n/ko.yml
+++ b/i18n/ko.yml
@@ -318,7 +318,6 @@ components:
     selectDepartureTime: 출발 시각
     selectDuration: 기간
     selectWalkTime: 도보 시간
-    sortBy: 정렬 기준
     viewAll: 모든 옵션 보기
   NavLoginButton:
     help: 지원

--- a/i18n/vi.yml
+++ b/i18n/vi.yml
@@ -326,7 +326,6 @@ components:
     selectDepartureTime: Giờ khởi hành
     selectDuration: Thời hạn
     selectWalkTime: Thời gian đi bộ
-    sortBy: Sắp xếp theo
     viewAll: Xem tất cả các tùy chọn
   NavLoginButton:
     help: Giúp đỡ

--- a/i18n/zh.yml
+++ b/i18n/zh.yml
@@ -318,7 +318,6 @@ components:
     selectDepartureTime: 出发时间
     selectDuration: 旅行时长
     selectWalkTime: 步行时间
-    sortBy: 排序方式
     viewAll: 查看所有选项
   NavLoginButton:
     help: 帮助

--- a/index.css
+++ b/index.css
@@ -122,6 +122,7 @@ input[type="text"]::-ms-clear {
 }
 
 .app-menu button[aria-selected="true"],
+.sort-option button[aria-selected="true"],
 #locale-selector button[aria-selected="true"] {
   font-weight: bold;
 }

--- a/lib/components/app/desktop-nav.tsx
+++ b/lib/components/app/desktop-nav.tsx
@@ -28,6 +28,13 @@ const StyledNav = styled(Nav)`
   }
 `
 
+const NavItemOnLargeScreens = styled(NavbarItem)`
+  display: block;
+  @media (max-width: 768px) {
+    display: none !important;
+  }
+`
+
 // Typscript TODO: otpConfig type
 export type Props = {
   locale: string
@@ -108,13 +115,13 @@ const DesktopNav = ({
 
           <StyledNav pullRight>
             {popupTarget && (
-              <NavbarItem
+              <NavItemOnLargeScreens
                 onClick={() => setPopupContent(popupTarget)}
                 title={popupButtonText}
               >
                 <Icon iconType={popupTarget} />
                 <InvisibleA11yLabel>{popupButtonText}</InvisibleA11yLabel>
-              </NavbarItem>
+              </NavItemOnLargeScreens>
             )}
             <LocaleSelector />
             {showLogin && (

--- a/lib/components/app/desktop-nav.tsx
+++ b/lib/components/app/desktop-nav.tsx
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { Nav, Navbar, NavItem } from 'react-bootstrap'
+import { Nav, Navbar } from 'react-bootstrap'
 import { useIntl } from 'react-intl'
 import React from 'react'
 import styled from 'styled-components'
@@ -12,14 +12,8 @@ import NavLoginButtonAuth0 from '../user/nav-login-button-auth0'
 
 import AppMenu, { Icon } from './app-menu'
 import LocaleSelector from './locale-selector'
+import NavbarItem from './nav-item'
 import ViewSwitcher from './view-switcher'
-
-const NavItemOnLargeScreens = styled(NavItem)`
-  display: block;
-  @media (max-width: 768px) {
-    display: none !important;
-  }
-`
 
 const StyledNav = styled(Nav)`
   /* Almost override bootstrap's margin-right: -15px */
@@ -114,13 +108,13 @@ const DesktopNav = ({
 
           <StyledNav pullRight>
             {popupTarget && (
-              <NavItemOnLargeScreens
+              <NavbarItem
                 onClick={() => setPopupContent(popupTarget)}
                 title={popupButtonText}
               >
                 <Icon iconType={popupTarget} />
                 <InvisibleA11yLabel>{popupButtonText}</InvisibleA11yLabel>
-              </NavItemOnLargeScreens>
+              </NavbarItem>
             )}
             <LocaleSelector />
             {showLogin && (

--- a/lib/components/app/locale-selector.tsx
+++ b/lib/components/app/locale-selector.tsx
@@ -4,9 +4,9 @@ import { useIntl } from 'react-intl'
 import React from 'react'
 
 import * as uiActions from '../../actions/ui'
+import { Dropdown } from '../util/dropdown'
 import { getLanguageOptions } from '../../util/i18n'
 import { UnstyledButton } from '../util/unstyled-button'
-import Dropdown from '../util/dropdown'
 
 interface LocaleSelectorProps {
   // Typescript TODO languageOptions based on configLanguage type.
@@ -25,7 +25,6 @@ const LocaleSelector = (props: LocaleSelectorProps): JSX.Element | null => {
       id="locale-selector"
       label={intl.formatMessage({ id: 'components.SubNav.selectALanguage' })}
       listLabel={intl.formatMessage({ id: 'components.SubNav.languages' })}
-      locale
       name={
         <span
           style={{
@@ -35,6 +34,7 @@ const LocaleSelector = (props: LocaleSelectorProps): JSX.Element | null => {
           <GlobeAmericas height="18px" />
         </span>
       }
+      nav
       style={{ display: 'block ruby' }}
       // TODO: How to make this work without block ruby?
     >

--- a/lib/components/app/locale-selector.tsx
+++ b/lib/components/app/locale-selector.tsx
@@ -25,6 +25,7 @@ const LocaleSelector = (props: LocaleSelectorProps): JSX.Element | null => {
       id="locale-selector"
       label={intl.formatMessage({ id: 'components.SubNav.selectALanguage' })}
       listLabel={intl.formatMessage({ id: 'components.SubNav.languages' })}
+      locale
       name={
         <span
           style={{

--- a/lib/components/app/locale-selector.tsx
+++ b/lib/components/app/locale-selector.tsx
@@ -21,35 +21,35 @@ const LocaleSelector = (props: LocaleSelectorProps): JSX.Element | null => {
 
   // Only render if two or more languages are configured.
   return languageOptions ? (
-    <Dropdown
-      id="locale-selector"
-      label={intl.formatMessage({ id: 'components.SubNav.selectALanguage' })}
-      listLabel={intl.formatMessage({ id: 'components.SubNav.languages' })}
-      name={
-        <span
-          style={{
-            color: 'rgba(255, 255, 255, 0.85)'
-          }}
-        >
-          <GlobeAmericas height="18px" />
-        </span>
-      }
-      nav
-      style={{ display: 'block ruby' }}
-      // TODO: How to make this work without block ruby?
-    >
-      {Object.keys(languageOptions).map((locale: string) => (
-        <li key={locale} lang={locale} role="none">
-          <UnstyledButton
-            aria-selected={locale === currentLocale || undefined}
-            onClick={() => setLocale(locale)}
-            role="option"
+    <li>
+      <Dropdown
+        id="locale-selector"
+        label={intl.formatMessage({ id: 'components.SubNav.selectALanguage' })}
+        listLabel={intl.formatMessage({ id: 'components.SubNav.languages' })}
+        name={
+          <span
+            style={{
+              color: 'rgba(255, 255, 255, 0.85)'
+            }}
           >
-            {languageOptions[locale].name}
-          </UnstyledButton>
-        </li>
-      ))}
-    </Dropdown>
+            <GlobeAmericas height="18px" />
+          </span>
+        }
+        style={{ display: 'block ruby' }}
+      >
+        {Object.keys(languageOptions).map((locale: string) => (
+          <li key={locale} lang={locale} role="none">
+            <UnstyledButton
+              aria-selected={locale === currentLocale || undefined}
+              onClick={() => setLocale(locale)}
+              role="option"
+            >
+              {languageOptions[locale].name}
+            </UnstyledButton>
+          </li>
+        ))}
+      </Dropdown>
+    </li>
   ) : null
 }
 

--- a/lib/components/app/nav-item.tsx
+++ b/lib/components/app/nav-item.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import styled from 'styled-components'
+
+type Props = {
+  children: React.ReactNode
+  onClick: () => void
+  title: string | undefined
+}
+
+export const NavbarButton = styled.button`
+  background: transparent;
+  border: none;
+  color: white;
+  display: block;
+  line-height: 20px;
+  padding: 15px;
+  transition: all 0.1s ease-in-out;
+
+  &:hover,
+  &[aria-expanded='true'] {
+    background: rgba(0, 0, 0, 0.05);
+    color: #ddd;
+    cursor: pointer;
+  }
+  &.active {
+    background: rgba(0, 0, 0, 0.05);
+  }
+`
+
+const NavbarItem = ({ children, onClick, title }: Props): JSX.Element => {
+  return (
+    <li>
+      <NavbarButton className="navItem" onClick={onClick} title={title}>
+        {children}
+      </NavbarButton>
+    </li>
+  )
+}
+
+export default NavbarItem

--- a/lib/components/app/nav-item.tsx
+++ b/lib/components/app/nav-item.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 type Props = {
   children: React.ReactNode
+  className?: string
   onClick: () => void
   title: string | undefined
 }
@@ -16,6 +17,10 @@ export const NavbarButton = styled.button`
   padding: 15px;
   transition: all 0.1s ease-in-out;
 
+  @media (max-width: 768px) {
+    padding: 10px;
+    float: right;
+  }
   &:hover,
   &[aria-expanded='true'] {
     background: rgba(0, 0, 0, 0.05);
@@ -27,9 +32,14 @@ export const NavbarButton = styled.button`
   }
 `
 
-const NavbarItem = ({ children, onClick, title }: Props): JSX.Element => {
+const NavbarItem = ({
+  children,
+  className,
+  onClick,
+  title
+}: Props): JSX.Element => {
   return (
-    <li>
+    <li className={className}>
       <NavbarButton className="navItem" onClick={onClick} title={title}>
         {children}
       </NavbarButton>

--- a/lib/components/narrative/narrative-itineraries-header.tsx
+++ b/lib/components/narrative/narrative-itineraries-header.tsx
@@ -5,7 +5,7 @@ import { FormattedMessage, useIntl } from 'react-intl'
 import { Itinerary } from '@opentripplanner/types'
 import { SortAmountDown } from '@styled-icons/fa-solid/SortAmountDown'
 import { SortAmountUp } from '@styled-icons/fa-solid/SortAmountUp'
-import React from 'react'
+import React, { useCallback } from 'react'
 import styled from 'styled-components'
 
 import { IconWithText, StyledIconWrapper } from '../util/styledIcon'
@@ -89,7 +89,15 @@ export default function NarrativeItinerariesHeader({
     ? searching
     : intl.formatList([itinerariesFound, numIssues], { type: 'conjunction' })
 
-  const sortText = sortOptions(intl).find((x) => x.value === sort.type)?.text
+  const sortOptionsArr = sortOptions(intl)
+  const sortText = sortOptionsArr.find((x) => x.value === sort.type)?.text
+
+  const handleSortClick = useCallback(
+    (value) => {
+      onSortChange(value)
+    },
+    [onSortChange]
+  )
 
   return (
     <div
@@ -200,17 +208,12 @@ export default function NarrativeItinerariesHeader({
               name={sortText}
               title={sortResultsLabel}
             >
-              {sortOptions(intl).map((x) => {
+              {sortOptionsArr.map((x) => {
                 return (
-                  <li
-                    key={x.value}
-                    style={{
-                      fontWeight: sortText === x.text ? 'bold' : undefined
-                    }}
-                  >
+                  <li className="sort-option" key={x.value}>
                     <UnstyledButton
                       aria-selected={sortText === x.text || undefined}
-                      onClick={() => onSortChange(x.value)}
+                      onClick={() => handleSortClick(x.value)}
                       role="option"
                     >
                       {x.text}

--- a/lib/components/narrative/narrative-itineraries-header.tsx
+++ b/lib/components/narrative/narrative-itineraries-header.tsx
@@ -8,6 +8,9 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { IconWithText, StyledIconWrapper } from '../util/styledIcon'
+import { sortOptions } from '../util/sortOptions'
+import { UnstyledButton } from '../util/unstyled-button'
+import Dropdown from '../util/dropdown'
 
 import PlanFirstLastButtons from './plan-first-last-buttons'
 import SaveTripButton from './save-trip-button'
@@ -51,7 +54,7 @@ export default function NarrativeItinerariesHeader({
   itineraries: unknown[]
   itinerary: Itinerary
   itineraryIsExpanded: boolean
-  onSortChange: () => void
+  onSortChange: (type: string) => VoidFunction
   onSortDirChange: () => void
   onToggleShowErrors: () => void
   onViewAllOptions: () => void
@@ -153,7 +156,7 @@ export default function NarrativeItinerariesHeader({
             style={{
               display: 'flex',
               float: 'right',
-              gap: 5,
+              gap: 7,
               marginLeft: showHeaderText ? 'inherit' : 'auto'
             }}
           >
@@ -179,48 +182,25 @@ export default function NarrativeItinerariesHeader({
                 )}
               </StyledIconWrapper>
             </button>
-            <select
-              aria-label={intl.formatMessage({
-                id: 'components.NarrativeItinerariesHeader.sortBy'
+            <Dropdown
+              id="sort-results"
+              label={intl.formatMessage({
+                id: 'components.NarrativeItinerariesHeader.sortResults'
               })}
-              onBlur={onSortChange}
-              onChange={onSortChange}
-              title={intl.formatMessage({
-                id: 'components.NarrativeItinerariesHeader.sortBy'
+              name={intl.formatMessage({
+                id: 'components.NarrativeItinerariesHeader.sortResults'
               })}
-              value={sort.type}
             >
-              <option value="BEST">
-                {intl.formatMessage({
-                  id: 'components.NarrativeItinerariesHeader.selectBest'
-                })}
-              </option>
-              <option value="DURATION">
-                {intl.formatMessage({
-                  id: 'components.NarrativeItinerariesHeader.selectDuration'
-                })}
-              </option>
-              <option value="ARRIVALTIME">
-                {intl.formatMessage({
-                  id: 'components.NarrativeItinerariesHeader.selectArrivalTime'
-                })}
-              </option>
-              <option value="DEPARTURETIME">
-                {intl.formatMessage({
-                  id: 'components.NarrativeItinerariesHeader.selectDepartureTime'
-                })}
-              </option>
-              <option value="WALKTIME">
-                {intl.formatMessage({
-                  id: 'components.NarrativeItinerariesHeader.selectWalkTime'
-                })}
-              </option>
-              <option value="COST">
-                {intl.formatMessage({
-                  id: 'components.NarrativeItinerariesHeader.selectCost'
-                })}
-              </option>
-            </select>
+              {sortOptions.map((x) => {
+                return (
+                  <li key={x.value}>
+                    <UnstyledButton onClick={() => onSortChange(x.value)}>
+                      <FormattedMessage id={x.locale} />
+                    </UnstyledButton>
+                  </li>
+                )
+              })}
+            </Dropdown>
           </div>
           <PlanFirstLastButtons />
         </>

--- a/lib/components/narrative/narrative-itineraries-header.tsx
+++ b/lib/components/narrative/narrative-itineraries-header.tsx
@@ -209,14 +209,14 @@ export default function NarrativeItinerariesHeader({
               name={sortText}
               title={sortResultsLabel}
             >
-              {sortOptionsArr.map((x) => (
-                <li className="sort-option" key={x.value}>
+              {sortOptionsArr.map((sortOption) => (
+                <li className="sort-option" key={sortOption.value}>
                   <UnstyledButton
-                    aria-selected={sortText === x.text || undefined}
-                    onClick={() => handleSortClick(x.value)}
+                    aria-selected={sortText === sortOption.text || undefined}
+                    onClick={() => handleSortClick(sortOption.value)}
                     role="option"
                   >
-                    {x.text}
+                    {sortOption.text}
                   </UnstyledButton>
                 </li>
               ))}

--- a/lib/components/narrative/narrative-itineraries-header.tsx
+++ b/lib/components/narrative/narrative-itineraries-header.tsx
@@ -5,7 +5,7 @@ import { FormattedMessage, useIntl } from 'react-intl'
 import { Itinerary } from '@opentripplanner/types'
 import { SortAmountDown } from '@styled-icons/fa-solid/SortAmountDown'
 import { SortAmountUp } from '@styled-icons/fa-solid/SortAmountUp'
-import React, { useState } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import { IconWithText, StyledIconWrapper } from '../util/styledIcon'
@@ -61,11 +61,6 @@ export default function NarrativeItinerariesHeader({
 }): JSX.Element {
   const intl = useIntl()
 
-  const [sortSelectedText, setSortSelectedText] = useState(
-    intl.formatMessage({
-      id: 'components.NarrativeItinerariesHeader.selectBest'
-    })
-  )
   const itinerariesFound = intl.formatMessage(
     {
       id: 'components.NarrativeItinerariesHeader.itinerariesFound'
@@ -94,10 +89,7 @@ export default function NarrativeItinerariesHeader({
     ? searching
     : intl.formatList([itinerariesFound, numIssues], { type: 'conjunction' })
 
-  const onClickSort = (x: { text: string; value: string }) => {
-    onSortChange(x.value)
-    setSortSelectedText(x.text)
-  }
+  const sortText = sortOptions(intl).find((x) => x.value === sort.type)?.text
 
   return (
     <div
@@ -120,7 +112,7 @@ export default function NarrativeItinerariesHeader({
                 {
                   id: 'components.NarrativeItinerariesHeader.resultsSortedBy'
                 },
-                { sortSelected: sortSelectedText }
+                { sortSelected: sortText }
               )}
             </p>
           </>
@@ -205,21 +197,20 @@ export default function NarrativeItinerariesHeader({
             <SortResultsDropdown
               id="sort-results"
               label={sortResultsLabel}
-              name={sortSelectedText}
+              name={sortText}
               title={sortResultsLabel}
             >
-              {sortOptions().map((x) => {
+              {sortOptions(intl).map((x) => {
                 return (
                   <li
                     key={x.value}
                     style={{
-                      fontWeight:
-                        sortSelectedText === x.text ? 'bold' : undefined
+                      fontWeight: sortText === x.text ? 'bold' : undefined
                     }}
                   >
                     <UnstyledButton
-                      aria-selected={sortSelectedText === x.text || undefined}
-                      onClick={() => onClickSort(x)}
+                      aria-selected={sortText === x.text || undefined}
+                      onClick={() => onSortChange(x.value)}
                       role="option"
                     >
                       {x.text}

--- a/lib/components/narrative/narrative-itineraries-header.tsx
+++ b/lib/components/narrative/narrative-itineraries-header.tsx
@@ -208,19 +208,17 @@ export default function NarrativeItinerariesHeader({
               name={sortText}
               title={sortResultsLabel}
             >
-              {sortOptionsArr.map((x) => {
-                return (
-                  <li className="sort-option" key={x.value}>
-                    <UnstyledButton
-                      aria-selected={sortText === x.text || undefined}
-                      onClick={() => handleSortClick(x.value)}
-                      role="option"
-                    >
-                      {x.text}
-                    </UnstyledButton>
-                  </li>
-                )
-              })}
+              {sortOptionsArr.map((x) => (
+                <li className="sort-option" key={x.value}>
+                  <UnstyledButton
+                    aria-selected={sortText === x.text || undefined}
+                    onClick={() => handleSortClick(x.value)}
+                    role="option"
+                  >
+                    {x.text}
+                  </UnstyledButton>
+                </li>
+              ))}
             </SortResultsDropdown>
           </div>
           <PlanFirstLastButtons />

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -98,8 +98,7 @@ class NarrativeItineraries extends Component {
     setActiveLeg(null, null)
   }
 
-  _onSortChange = (evt) => {
-    const { value: type } = evt.target
+  _onSortChange = (type) => {
     const { sort, updateItineraryFilter } = this.props
     updateItineraryFilter({ sort: { ...sort, type } })
   }

--- a/lib/components/narrative/narrative.css
+++ b/lib/components/narrative/narrative.css
@@ -3,14 +3,8 @@
 }
 
 .otp .options > .header {
-  margin: 15px 25px;
+  margin: 1em;
   font-size: 16px;
-}
-
-@media (max-width: 768px) {
-  .otp .options > .header {
-    margin: 1em;
-  }
 }
 
 /* Options scroll bar  */

--- a/lib/components/narrative/narrative.css
+++ b/lib/components/narrative/narrative.css
@@ -3,8 +3,14 @@
 }
 
 .otp .options > .header {
-  margin: 12px 10px;
+  margin: 15px 25px;
   font-size: 16px;
+}
+
+@media (max-width: 768px) {
+  .otp .options > .header {
+    margin: 1em;
+  }
 }
 
 /* Options scroll bar  */

--- a/lib/components/user/nav-login-button.css
+++ b/lib/components/user/nav-login-button.css
@@ -43,10 +43,15 @@
   padding: 15px;
 }
 .navbar-inverse .navbar-nav > li > a:hover,
-.navbar-inverse .navbar-nav > li > button:hover,
+.navbar-inverse .navbar-nav > li > span > button:hover,
 .otp.mobile .navbar .container-fluid .locale-selector-and-login > li > a:hover {
   color: #ddd;
   text-decoration: none;
+}
+
+.navbar-inverse .navbar-nav > li > span > button:hover,
+.navbar-inverse .navbar-nav > li > span > button[aria-expanded="true"] {
+  background-color: rgba(0, 0, 0, 0.1);
 }
 
 #app-menu-locale-selector {

--- a/lib/components/user/nav-login-button.css
+++ b/lib/components/user/nav-login-button.css
@@ -20,38 +20,9 @@
 }
 .otp.mobile .navbar .container-fluid .locale-selector-and-login > li {
   display: inline-block;
-  padding: 14px;
 }
 .otp.mobile .navbar li.dropdown.open {
   background-color: #080808;
-}
-.navbar-inverse .navbar-nav > li > a,
-.navbar-inverse .navbar-nav > li > span > button,
-.otp.mobile .navbar .container-fluid .locale-selector-and-login > li > span > button,
-.otp.mobile
-  .navbar
-  .container-fluid
-  .locale-selector-and-login
-  > li.dropdown.open
-  > button {
-  color: #fff;
-  text-decoration: none;
-}
-.navbar-inverse .navbar-nav > li > span > button{
-  background: transparent;
-  line-height: 20px;
-  padding: 15px;
-}
-.navbar-inverse .navbar-nav > li > a:hover,
-.navbar-inverse .navbar-nav > li > span > button:hover,
-.otp.mobile .navbar .container-fluid .locale-selector-and-login > li > a:hover {
-  color: #ddd;
-  text-decoration: none;
-}
-
-.navbar-inverse .navbar-nav > li > span > button:hover,
-.navbar-inverse .navbar-nav > li > span > button[aria-expanded="true"] {
-  background-color: rgba(0, 0, 0, 0.1);
 }
 
 #app-menu-locale-selector {

--- a/lib/components/user/nav-login-button.css
+++ b/lib/components/user/nav-login-button.css
@@ -26,17 +26,24 @@
   background-color: #080808;
 }
 .navbar-inverse .navbar-nav > li > a,
-.otp.mobile .navbar .container-fluid .locale-selector-and-login > li > a,
+.navbar-inverse .navbar-nav > li > button,
+.otp.mobile .navbar .container-fluid .locale-selector-and-login > li > button,
 .otp.mobile
   .navbar
   .container-fluid
   .locale-selector-and-login
   > li.dropdown.open
-  > a {
+  > button {
   color: #fff;
   text-decoration: none;
 }
+.navbar-inverse .navbar-nav > li > button{
+  background: transparent;
+  line-height: 20px;
+  padding: 15px;
+}
 .navbar-inverse .navbar-nav > li > a:hover,
+.navbar-inverse .navbar-nav > li > button:hover,
 .otp.mobile .navbar .container-fluid .locale-selector-and-login > li > a:hover {
   color: #ddd;
   text-decoration: none;
@@ -52,5 +59,8 @@
   }
   #app-menu-locale-selector {
     display: flex;
+  }
+  #user-selector-label {
+    background-color: transparent;
   }
 }

--- a/lib/components/user/nav-login-button.css
+++ b/lib/components/user/nav-login-button.css
@@ -26,8 +26,8 @@
   background-color: #080808;
 }
 .navbar-inverse .navbar-nav > li > a,
-.navbar-inverse .navbar-nav > li > button,
-.otp.mobile .navbar .container-fluid .locale-selector-and-login > li > button,
+.navbar-inverse .navbar-nav > li > span > button,
+.otp.mobile .navbar .container-fluid .locale-selector-and-login > li > span > button,
 .otp.mobile
   .navbar
   .container-fluid
@@ -37,7 +37,7 @@
   color: #fff;
   text-decoration: none;
 }
-.navbar-inverse .navbar-nav > li > button{
+.navbar-inverse .navbar-nav > li > span > button{
   background: transparent;
   line-height: 20px;
   padding: 15px;

--- a/lib/components/user/nav-login-button.tsx
+++ b/lib/components/user/nav-login-button.tsx
@@ -70,6 +70,7 @@ const NavLoginButton = ({
               />
             </span>
           }
+          pullRight
         >
           <li className="header">{displayedName}</li>
 

--- a/lib/components/user/nav-login-button.tsx
+++ b/lib/components/user/nav-login-button.tsx
@@ -55,50 +55,52 @@ const NavLoginButton = ({
   if (profile) {
     const displayedName = profile.nickname || profile.name
     return (
-      <Dropdown
-        id="user-selector"
-        label={intl.formatMessage({ id: 'components.SubNav.userMenu' })}
-        name={
-          <span>
-            <Avatar
-              alt={displayedName}
-              src={profile.picture}
-              title={`${displayedName}\n(${profile.email})`}
-            />
-          </span>
-        }
-        nav
-      >
-        <li className="header">{displayedName}</li>
+      <li>
+        <Dropdown
+          id="user-selector"
+          label={intl.formatMessage({ id: 'components.SubNav.userMenu' })}
+          name={
+            <span>
+              <Avatar
+                alt={displayedName}
+                src={profile.picture}
+                title={`${displayedName}\n(${profile.email})`}
+              />
+            </span>
+          }
+          nav
+        >
+          <li className="header">{displayedName}</li>
 
-        {links &&
-          links.map((link, i) => (
-            <LinkContainerWithQuery
-              exact
-              key={i}
-              target={link.target}
-              to={link.url}
-            >
-              <li>
-                <UnstyledButton>
-                  {link.messageId === 'myAccount' ? ( // messageId is 'myAccount' or 'help'
-                    <FormattedMessage id="components.NavLoginButton.myAccount" />
-                  ) : (
-                    <FormattedMessage id="components.NavLoginButton.help" />
-                  )}
-                </UnstyledButton>
-              </li>
-            </LinkContainerWithQuery>
-          ))}
+          {links &&
+            links.map((link, i) => (
+              <LinkContainerWithQuery
+                exact
+                key={i}
+                target={link.target}
+                to={link.url}
+              >
+                <li>
+                  <UnstyledButton>
+                    {link.messageId === 'myAccount' ? ( // messageId is 'myAccount' or 'help'
+                      <FormattedMessage id="components.NavLoginButton.myAccount" />
+                    ) : (
+                      <FormattedMessage id="components.NavLoginButton.help" />
+                    )}
+                  </UnstyledButton>
+                </li>
+              </LinkContainerWithQuery>
+            ))}
 
-        <hr role="presentation" />
+          <hr role="presentation" />
 
-        <li>
-          <UnstyledButton onClick={onSignOutClick}>
-            <FormattedMessage id="components.NavLoginButton.signOut" />
-          </UnstyledButton>
-        </li>
-      </Dropdown>
+          <li>
+            <UnstyledButton onClick={onSignOutClick}>
+              <FormattedMessage id="components.NavLoginButton.signOut" />
+            </UnstyledButton>
+          </li>
+        </Dropdown>
+      </li>
     )
   }
 

--- a/lib/components/user/nav-login-button.tsx
+++ b/lib/components/user/nav-login-button.tsx
@@ -5,9 +5,9 @@ import { User } from '@auth0/auth0-react'
 import React, { HTMLAttributes } from 'react'
 import styled from 'styled-components'
 
+import { Dropdown } from '../util/dropdown'
 import { LinkContainerWithQuery } from '../form/connected-links'
 import { UnstyledButton } from '../util/unstyled-button'
-import Dropdown from '../util/dropdown'
 
 const Avatar = styled.img`
   height: 2em;
@@ -67,7 +67,7 @@ const NavLoginButton = ({
             />
           </span>
         }
-        pullRight
+        nav
       >
         <li className="header">{displayedName}</li>
 

--- a/lib/components/user/nav-login-button.tsx
+++ b/lib/components/user/nav-login-button.tsx
@@ -68,7 +68,6 @@ const NavLoginButton = ({
               />
             </span>
           }
-          nav
         >
           <li className="header">{displayedName}</li>
 

--- a/lib/components/user/nav-login-button.tsx
+++ b/lib/components/user/nav-login-button.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 import { FormattedMessage, useIntl } from 'react-intl'
-import { NavItem } from 'react-bootstrap'
 import { User } from '@auth0/auth0-react'
 import { User as UserIcon } from '@styled-icons/fa-regular/User'
 import React, { HTMLAttributes } from 'react'
@@ -9,9 +8,8 @@ import styled from 'styled-components'
 import { Dropdown } from '../util/dropdown'
 import { LinkContainerWithQuery } from '../form/connected-links'
 import { UnstyledButton } from '../util/unstyled-button'
-
 import InvisibleA11yLabel from '../util/invisible-a11y-label'
-
+import NavbarItem from '../app/nav-item'
 
 const Avatar = styled.img`
   height: 2em;
@@ -112,10 +110,10 @@ const NavLoginButton = ({
     id: 'components.NavLoginButton.signIn'
   })
   return (
-    <NavItem {...commonProps} onClick={onSignInClick} title={loginText}>
+    <NavbarItem {...commonProps} onClick={onSignInClick} title={loginText}>
       <UserIcon />
       <InvisibleA11yLabel>{loginText}</InvisibleA11yLabel>
-    </NavItem>
+    </NavbarItem>
   )
 }
 

--- a/lib/components/util/dropdown.tsx
+++ b/lib/components/util/dropdown.tsx
@@ -14,6 +14,7 @@ interface Props extends HTMLAttributes<HTMLElement> {
   listLabel?: string
   name?: JSX.Element | string
   nav?: boolean
+  pullRight?: boolean
 }
 
 const DropdownButton = styled.button`
@@ -101,6 +102,7 @@ export const Dropdown = ({
   label,
   listLabel,
   name,
+  pullRight,
   style
 }: Props): JSX.Element => {
   const [open, setOpen] = useState(false)
@@ -146,6 +148,7 @@ export const Dropdown = ({
           element.click()
           if (element.id === `${id}-label` || element.id === `${id}-wrapper`) {
             toggleOpen()
+            e.preventDefault()
           }
           break
         default:
@@ -161,6 +164,7 @@ export const Dropdown = ({
       onKeyDown={_handleKeyDown}
       ref={containerRef}
       role="presentation"
+      style={{ float: pullRight ? 'right' : 'left' }}
     >
       <DropdownButton
         // Only set aria-controls when the dropdown is open

--- a/lib/components/util/dropdown.tsx
+++ b/lib/components/util/dropdown.tsx
@@ -196,12 +196,23 @@ export const Dropdown = ({
 export const SortResultsDropdown = styled(Dropdown)`
     position: relative;
 
+    // Keeps dropdown inline with itinerary buttons when scrollbar is visible
+    @media (min-width: 769px) {
+      margin-right: 10px;
+    }
+
     ${DropdownButton} {
       border-radius: 5px;
       padding: 3px 7px;
+      background: #F8FAFB;
+
+      span.caret {
+        color: inherit;
+      }
 
       &:hover {
         background: #fff;
+        color: inherit;
       }
       &.active {
         background: #fff;

--- a/lib/components/util/dropdown.tsx
+++ b/lib/components/util/dropdown.tsx
@@ -12,28 +12,23 @@ interface Props extends HTMLAttributes<HTMLElement> {
   id: string
   label?: string
   listLabel?: string
-  locale?: boolean
   name: JSX.Element | string
-  pullRight?: boolean
+  nav?: boolean
 }
 
 // TODO: make this a button once bootstrap is removed
-const DropdownButton = styled.a<{ locale?: boolean }>`
+const DropdownButton = styled.a`
   border: none;
-  border-radius: ${(props) => (props.locale ? '' : '5px')};
   color: inherit;
   display: block;
-  padding: ${(props) => (props.locale ? '' : '3px 7px;')};
   transition: all 0.1s ease-in-out;
 
   &:hover {
-    background: ${(props) =>
-      props.locale ? 'rgba(0, 0, 0, 0.05) !important' : '#fff'};
+    background: rgba(0, 0, 0, 0.05);
     cursor: pointer;
   }
   &.active {
-    background: ${(props) =>
-      props.locale ? 'rgba(0, 0, 0, 0.05) !important' : '#fff'};
+    background: rgba(0, 0, 0, 0.05);
   }
 `
 const DropdownMenu = styled.ul`
@@ -75,7 +70,6 @@ const DropdownMenu = styled.ul`
     background: rgba(0, 0, 0, 0.1);
   }
 `
-const DropdownContainer = styled.li``
 
 /**
  * Helper method to find the element within dropdown menu at the given offset
@@ -101,20 +95,22 @@ function getEntryRelativeTo(
  * a floating div is rendered below the "name" with list contents inside. Clicking anywhere
  * outside the floating div will close the dropdown.
  */
-const Dropdown = ({
+export const Dropdown = ({
   children,
+  className,
   id,
   label,
   listLabel,
-  locale,
   name,
-  pullRight,
+  nav,
   style
 }: Props): JSX.Element => {
   const [open, setOpen] = useState(false)
   const containerRef = useRef<HTMLLIElement>(null)
 
   const toggleOpen = useCallback(() => setOpen(!open), [open, setOpen])
+
+  const DropdownContainerEl = nav ? 'li' : 'span'
 
   // Adding document event listeners allows us to close the dropdown
   // when the user interacts with any part of the page that isn't the dropdown
@@ -163,15 +159,11 @@ const Dropdown = ({
   )
 
   return (
-    <DropdownContainer
-      as={!locale ? 'span' : ''}
+    <DropdownContainerEl
+      className={className}
       id={`${id}-wrapper`}
       onKeyDown={_handleKeyDown}
       ref={containerRef}
-      style={{
-        float: pullRight ? 'right' : 'left',
-        position: locale ? 'inherit' : 'relative'
-      }}
     >
       <DropdownButton
         // Only set aria-controls when the dropdown is open
@@ -180,10 +172,9 @@ const Dropdown = ({
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-label={label}
-        as={!locale ? 'button' : ''}
+        as={nav ? '' : 'button'}
         className={`${open && 'active'}`}
         id={`${id}-label`}
-        locale={locale}
         onClick={toggleOpen}
         role="button"
         style={style}
@@ -204,8 +195,25 @@ const Dropdown = ({
           {children}
         </DropdownMenu>
       )}
-    </DropdownContainer>
+    </DropdownContainerEl>
   )
 }
 
-export default Dropdown
+export const SortResultsDropdown = styled(Dropdown)`
+    position: relative;
+
+    ${DropdownButton} {
+      border-radius: 5px;
+      padding: 3px 7px;
+      min-width: 130px;
+      text-align: right;
+
+      &:hover {
+        background: #fff;
+      }
+      &.active {
+        background: #fff;
+      }
+    }
+  }
+`

--- a/lib/components/util/dropdown.tsx
+++ b/lib/components/util/dropdown.tsx
@@ -101,15 +101,12 @@ export const Dropdown = ({
   label,
   listLabel,
   name,
-  nav,
   style
 }: Props): JSX.Element => {
   const [open, setOpen] = useState(false)
   const containerRef = useRef<HTMLLIElement>(null)
 
   const toggleOpen = useCallback(() => setOpen(!open), [open, setOpen])
-
-  const DropdownContainerEl = nav ? 'li' : 'span'
 
   // Adding document event listeners allows us to close the dropdown
   // when the user interacts with any part of the page that isn't the dropdown
@@ -158,11 +155,12 @@ export const Dropdown = ({
   )
 
   return (
-    <DropdownContainerEl
+    <span
       className={className}
       id={`${id}-wrapper`}
       onKeyDown={_handleKeyDown}
       ref={containerRef}
+      role="presentation"
     >
       <DropdownButton
         // Only set aria-controls when the dropdown is open
@@ -192,7 +190,7 @@ export const Dropdown = ({
           {children}
         </DropdownMenu>
       )}
-    </DropdownContainerEl>
+    </span>
   )
 }
 

--- a/lib/components/util/dropdown.tsx
+++ b/lib/components/util/dropdown.tsx
@@ -12,23 +12,28 @@ interface Props extends HTMLAttributes<HTMLElement> {
   id: string
   label?: string
   listLabel?: string
-  name: JSX.Element
+  locale?: boolean
+  name: JSX.Element | string
   pullRight?: boolean
 }
 
 // TODO: make this a button once bootstrap is removed
-const DropdownButton = styled.a`
+const DropdownButton = styled.a<{ locale?: boolean }>`
   border: none;
+  border-radius: ${(props) => (props.locale ? '' : '5px')};
   color: inherit;
   display: block;
+  padding: ${(props) => (props.locale ? '' : '3px 7px;')};
   transition: all 0.1s ease-in-out;
 
   &:hover {
-    background: rgba(0, 0, 0, 0.05) !important;
+    background: ${(props) =>
+      props.locale ? 'rgba(0, 0, 0, 0.05) !important' : '#fff'};
     cursor: pointer;
   }
   &.active {
-    background: rgba(0, 0, 0, 0.1) !important;
+    background: ${(props) =>
+      props.locale ? 'rgba(0, 0, 0, 0.05) !important' : '#fff'};
   }
 `
 const DropdownMenu = styled.ul`
@@ -101,6 +106,7 @@ const Dropdown = ({
   id,
   label,
   listLabel,
+  locale,
   name,
   pullRight,
   style
@@ -158,10 +164,14 @@ const Dropdown = ({
 
   return (
     <DropdownContainer
+      as={!locale ? 'span' : ''}
       id={`${id}-wrapper`}
       onKeyDown={_handleKeyDown}
       ref={containerRef}
-      style={{ float: pullRight ? 'right' : 'left' }}
+      style={{
+        float: pullRight ? 'right' : 'left',
+        position: locale ? 'inherit' : 'relative'
+      }}
     >
       <DropdownButton
         // Only set aria-controls when the dropdown is open
@@ -170,8 +180,10 @@ const Dropdown = ({
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-label={label}
+        as={!locale ? 'button' : ''}
         className={`${open && 'active'}`}
         id={`${id}-label`}
+        locale={locale}
         onClick={toggleOpen}
         role="button"
         style={style}

--- a/lib/components/util/dropdown.tsx
+++ b/lib/components/util/dropdown.tsx
@@ -12,12 +12,11 @@ interface Props extends HTMLAttributes<HTMLElement> {
   id: string
   label?: string
   listLabel?: string
-  name: JSX.Element | string
+  name?: JSX.Element | string
   nav?: boolean
 }
 
-// TODO: make this a button once bootstrap is removed
-const DropdownButton = styled.a`
+const DropdownButton = styled.button`
   border: none;
   color: inherit;
   display: block;
@@ -172,11 +171,9 @@ export const Dropdown = ({
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-label={label}
-        as={nav ? '' : 'button'}
         className={`${open && 'active'}`}
         id={`${id}-label`}
         onClick={toggleOpen}
-        role="button"
         style={style}
         tabIndex={0}
       >
@@ -205,8 +202,6 @@ export const SortResultsDropdown = styled(Dropdown)`
     ${DropdownButton} {
       border-radius: 5px;
       padding: 3px 7px;
-      min-width: 130px;
-      text-align: right;
 
       &:hover {
         background: #fff;

--- a/lib/components/util/dropdown.tsx
+++ b/lib/components/util/dropdown.tsx
@@ -145,10 +145,10 @@ export const Dropdown = ({
           break
         case ' ':
         case 'Enter':
+          e.preventDefault()
           element.click()
           if (element.id === `${id}-label` || element.id === `${id}-wrapper`) {
             toggleOpen()
-            e.preventDefault()
           }
           break
         default:

--- a/lib/components/util/dropdown.tsx
+++ b/lib/components/util/dropdown.tsx
@@ -1,3 +1,4 @@
+import { NavbarButton } from '../app/nav-item'
 import React, {
   HTMLAttributes,
   KeyboardEvent,
@@ -17,18 +18,11 @@ interface Props extends HTMLAttributes<HTMLElement> {
   pullRight?: boolean
 }
 
-const DropdownButton = styled.button`
-  border: none;
+const DropdownButton = styled(NavbarButton)`
   color: inherit;
-  display: block;
-  transition: all 0.1s ease-in-out;
 
-  &:hover {
-    background: rgba(0, 0, 0, 0.05);
-    cursor: pointer;
-  }
-  &.active {
-    background: rgba(0, 0, 0, 0.05);
+  span.caret {
+    color: white;
   }
 `
 const DropdownMenu = styled.ul`

--- a/lib/components/util/sortOptions.ts
+++ b/lib/components/util/sortOptions.ts
@@ -1,0 +1,26 @@
+export const sortOptions = [
+  {
+    locale: 'components.NarrativeItinerariesHeader.selectBest',
+    value: 'BEST'
+  },
+  {
+    locale: 'components.NarrativeItinerariesHeader.selectDuration',
+    value: 'DURATION'
+  },
+  {
+    locale: 'components.NarrativeItinerariesHeader.selectArrivalTime',
+    value: 'ARRIVALTIME'
+  },
+  {
+    locale: 'components.NarrativeItinerariesHeader.selectDepartureTime',
+    value: 'DEPARTURETIME'
+  },
+  {
+    locale: 'components.NarrativeItinerariesHeader.selectWalkTime',
+    value: 'WALKTIME'
+  },
+  {
+    locale: 'components.NarrativeItinerariesHeader.selectCost',
+    value: 'COST'
+  }
+]

--- a/lib/components/util/sortOptions.ts
+++ b/lib/components/util/sortOptions.ts
@@ -1,41 +1,46 @@
-import { useIntl } from 'react-intl'
+import { IntlShape } from 'react-intl'
 
-export const sortOptions = (): {
+export const sortOptions = (
+  intl: IntlShape
+): {
   text: string
   value: string
 }[] => {
-  const OptionText = (id: string) => {
-    const intl = useIntl()
-    return intl.formatMessage({ id: id })
-  }
-
   const sortOptionsArray = [
     {
-      text: OptionText('components.NarrativeItinerariesHeader.selectBest'),
+      text: intl.formatMessage({
+        id: 'components.NarrativeItinerariesHeader.selectBest'
+      }),
       value: 'BEST'
     },
     {
-      text: OptionText('components.NarrativeItinerariesHeader.selectDuration'),
+      text: intl.formatMessage({
+        id: 'components.NarrativeItinerariesHeader.selectDuration'
+      }),
       value: 'DURATION'
     },
     {
-      text: OptionText(
-        'components.NarrativeItinerariesHeader.selectArrivalTime'
-      ),
+      text: intl.formatMessage({
+        id: 'components.NarrativeItinerariesHeader.selectArrivalTime'
+      }),
       value: 'ARRIVALTIME'
     },
     {
-      text: OptionText(
-        'components.NarrativeItinerariesHeader.selectDepartureTime'
-      ),
+      text: intl.formatMessage({
+        id: 'components.NarrativeItinerariesHeader.selectDepartureTime'
+      }),
       value: 'DEPARTURETIME'
     },
     {
-      text: OptionText('components.NarrativeItinerariesHeader.selectWalkTime'),
+      text: intl.formatMessage({
+        id: 'components.NarrativeItinerariesHeader.selectWalkTime'
+      }),
       value: 'WALKTIME'
     },
     {
-      text: OptionText('components.NarrativeItinerariesHeader.selectCost'),
+      text: intl.formatMessage({
+        id: 'components.NarrativeItinerariesHeader.selectCost'
+      }),
       value: 'COST'
     }
   ]

--- a/lib/components/util/sortOptions.ts
+++ b/lib/components/util/sortOptions.ts
@@ -1,26 +1,44 @@
-export const sortOptions = [
-  {
-    locale: 'components.NarrativeItinerariesHeader.selectBest',
-    value: 'BEST'
-  },
-  {
-    locale: 'components.NarrativeItinerariesHeader.selectDuration',
-    value: 'DURATION'
-  },
-  {
-    locale: 'components.NarrativeItinerariesHeader.selectArrivalTime',
-    value: 'ARRIVALTIME'
-  },
-  {
-    locale: 'components.NarrativeItinerariesHeader.selectDepartureTime',
-    value: 'DEPARTURETIME'
-  },
-  {
-    locale: 'components.NarrativeItinerariesHeader.selectWalkTime',
-    value: 'WALKTIME'
-  },
-  {
-    locale: 'components.NarrativeItinerariesHeader.selectCost',
-    value: 'COST'
+import { useIntl } from 'react-intl'
+
+export const sortOptions = (): {
+  text: string
+  value: string
+}[] => {
+  const OptionText = (id: string) => {
+    const intl = useIntl()
+    return intl.formatMessage({ id: id })
   }
-]
+
+  const sortOptionsArray = [
+    {
+      text: OptionText('components.NarrativeItinerariesHeader.selectBest'),
+      value: 'BEST'
+    },
+    {
+      text: OptionText('components.NarrativeItinerariesHeader.selectDuration'),
+      value: 'DURATION'
+    },
+    {
+      text: OptionText(
+        'components.NarrativeItinerariesHeader.selectArrivalTime'
+      ),
+      value: 'ARRIVALTIME'
+    },
+    {
+      text: OptionText(
+        'components.NarrativeItinerariesHeader.selectDepartureTime'
+      ),
+      value: 'DEPARTURETIME'
+    },
+    {
+      text: OptionText('components.NarrativeItinerariesHeader.selectWalkTime'),
+      value: 'WALKTIME'
+    },
+    {
+      text: OptionText('components.NarrativeItinerariesHeader.selectCost'),
+      value: 'COST'
+    }
+  ]
+
+  return sortOptionsArray
+}


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

Select to sort trip results updates page without warning (3.2.2 On Input). This PR repurposes the locale selector dropdown to provide a better approach to sorting in terms of accessibility.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
|![image](https://github.com/opentripplanner/otp-react-redux/assets/115499534/8c6c9510-5ded-4cf0-a137-3e07caae6eb9)|![image](https://github.com/opentripplanner/otp-react-redux/assets/115499534/f4eb800b-0fe5-466e-bf03-e0d47613ac6b)| -->

