### PR TITLE
Remove excessive zoom changes when changing stops in Stop Viewer

### DIFF
--- a/lib/components/map/connected-stop-viewer-overlay.js
+++ b/lib/components/map/connected-stop-viewer-overlay.js
@@ -1,9 +1,8 @@
 // TYPESCRIPT TODO: all props here are missing types
 /* eslint-disable react/prop-types */
 import { connect } from 'react-redux'
-import { useMap } from 'react-map-gl'
 import ParkAndRideOverlay from '@opentripplanner/park-and-ride-overlay'
-import React, { useEffect } from 'react'
+import React from 'react'
 import VehicleRentalOverlay from '@opentripplanner/vehicle-rental-overlay'
 
 import * as mapActions from '../../actions/map'
@@ -20,19 +19,6 @@ const StopViewerOverlay = ({
   stopData,
   stops
 }) => {
-  const { current: mainMap } = useMap()
-  const { lat, lon } = stopData || {}
-
-  useEffect(() => {
-    if (mainMap && lat && lon) {
-      mainMap.flyTo({
-        center: { lat, lon },
-        duration: 500,
-        zoom: 16
-      })
-    }
-  }, [mainMap, lat, lon])
-
   if (!stopData) return null
   const { bikeRental, parkAndRideLocations, vehicleRental } = stopData
 


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR makes map panning smoother when changing the viewed stop in the Stop Viewer (either by clicking a nearby stop in the main pane, or by clicking Stop Viewer from the map or itinerary leg in the narrative).

Basically, the `ConnectedStopViewerOverlay` component is competing with the stop fetching actions, causing hiccups in the map animation when switching stops.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [na] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [na] Are all languages supported (Internationalization/Localization)?
- [na] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
|  ![bumpy1](https://github.com/opentripplanner/otp-react-redux/assets/56846598/699a2507-0847-41d6-b1c0-da30e67bc8fa)   |  
![bumpy2 gif](https://github.com/opentripplanner/otp-react-redux/assets/56846598/944396b1-e855-41da-a4a7-47267726b5d7)
     |

