### PR TITLE
fix(batch-ui): correct walk icon in all cases

### DIFF
--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -10,6 +10,7 @@ import {
   injectIntl
 } from 'react-intl'
 import { Leaf } from '@styled-icons/fa-solid/Leaf'
+import clone from 'clone'
 import coreUtils from '@opentripplanner/core-utils'
 import React from 'react'
 import styled from 'styled-components'
@@ -33,7 +34,7 @@ import { FlexIndicator } from './flex-indicator'
 import { ItineraryDescription } from './itinerary-description'
 import ItinerarySummary from './itinerary-summary'
 
-const { isAdvanceBookingRequired, isCoordinationRequired, isFlex } =
+const { isAdvanceBookingRequired, isCoordinationRequired, isFlex, isTransit } =
   coreUtils.itinerary
 
 // Styled components
@@ -140,7 +141,11 @@ const ITINERARY_ATTRIBUTES = [
     id: 'walkTime',
     order: 3,
     render: (itinerary, options) => {
-      const leg = { mode: 'WALK' }
+      const leg = clone(itinerary.legs[0])
+      if (isTransit(leg.mode)) {
+        leg.mode = 'WALK'
+      }
+
       const { LegIcon } = options
       return (
         // FIXME: For CAR mode, walk time considers driving time.


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

A previous fix for the batch ui walk icon made it a walk icon no matter the type of itinerary. This PR adjusts things to only do this if we're replacing a transit leg. This gives all the benefit of the fix with none of the regressions.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

