### PR TITLE
Enhance Login and Feedback Navbar Buttons

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -234,8 +234,8 @@ components:
   BeforeSignInScreen:
     mainTitle: Signing you in
     message: >
-      In order to access this page you will need to sign in. Please wait while
-      we redirect you to the login page...
+      In order to access this page you will need to log in. Please wait while we
+      redirect you to the login page...
   CallTakerPanel:
     advancedOptions: Advanced options
     groupSize: "Group size:"
@@ -344,8 +344,8 @@ components:
   NavLoginButton:
     help: Help
     myAccount: My account
-    signIn: Sign in
-    signOut: Sign out
+    signIn: Log in
+    signOut: Log out
   NewAccountWizard:
     finish: Account setup complete!
     notifications: Notification preferences
@@ -453,8 +453,8 @@ components:
       Only itineraries that include transit and no rentals or ride hailing can
       be monitored.
     saveTripText: Save trip
-    signInText: Sign in to save trip
-    signInTooltip: Please sign in to save trip.
+    signInText: Log in to save trip
+    signInTooltip: Please log in to save trip.
   SavedTripEditor:
     editSavedTrip: Edit saved trip
     saveNewTrip: Save new trip

--- a/lib/components/app/app-menu.tsx
+++ b/lib/components/app/app-menu.tsx
@@ -8,7 +8,6 @@ import { GraduationCap } from '@styled-icons/fa-solid/GraduationCap'
 import { History } from '@styled-icons/fa-solid/History'
 import { Undo } from '@styled-icons/fa-solid/Undo'
 import { withRouter } from 'react-router'
-import coreUtils from '@opentripplanner/core-utils'
 import React, { Component, Fragment, useContext } from 'react'
 import SlidingPane from 'react-sliding-pane'
 import type { RouteComponentProps } from 'react-router'
@@ -22,10 +21,10 @@ import { getLanguageOptions } from '../../util/i18n'
 import { isModuleEnabled, Modules } from '../../util/config'
 import { MainPanelContent } from '../../actions/ui-constants'
 import { setMainPanelContent } from '../../actions/ui'
-import InvisibleA11yLabel from '../util/invisible-a11y-label'
 import startOver from '../util/start-over'
 
 import AppMenuItem from './app-menu-item'
+import PopupTriggerText from './popup-trigger-text'
 
 type AppMenuProps = {
   activeLocale: string
@@ -60,8 +59,6 @@ type menuItem = {
   onClick?: () => void
   subMenuDivider: boolean
 }
-
-const isMobile = coreUtils.ui.isMobile()
 
 /**
  * Sidebar which appears to show user list of options and links
@@ -256,16 +253,7 @@ class AppMenu extends Component<
               <AppMenuItem
                 icon={<SvgIcon iconName={popupTarget} />}
                 onClick={this._triggerPopup}
-                text={
-                  <>
-                    <FormattedMessage id={`config.popups.${popupTarget}`} />
-                    {isMobile && (
-                      <InvisibleA11yLabel>
-                        <FormattedMessage id="common.linkOpensNewWindow" />
-                      </InvisibleA11yLabel>
-                    )}
-                  </>
-                }
+                text={<PopupTriggerText popupTarget={popupTarget} />}
               />
             )}
             {callTakerEnabled && (

--- a/lib/components/app/app-menu.tsx
+++ b/lib/components/app/app-menu.tsx
@@ -8,6 +8,7 @@ import { GraduationCap } from '@styled-icons/fa-solid/GraduationCap'
 import { History } from '@styled-icons/fa-solid/History'
 import { Undo } from '@styled-icons/fa-solid/Undo'
 import { withRouter } from 'react-router'
+import coreUtils from '@opentripplanner/core-utils'
 import React, { Component, Fragment, useContext } from 'react'
 import SlidingPane from 'react-sliding-pane'
 import type { RouteComponentProps } from 'react-router'
@@ -21,6 +22,7 @@ import { getLanguageOptions } from '../../util/i18n'
 import { isModuleEnabled, Modules } from '../../util/config'
 import { MainPanelContent } from '../../actions/ui-constants'
 import { setMainPanelContent } from '../../actions/ui'
+import InvisibleA11yLabel from '../util/invisible-a11y-label'
 import startOver from '../util/start-over'
 
 import AppMenuItem from './app-menu-item'
@@ -58,6 +60,8 @@ type menuItem = {
   onClick?: () => void
   subMenuDivider: boolean
 }
+
+const isMobile = coreUtils.ui.isMobile()
 
 /**
  * Sidebar which appears to show user list of options and links
@@ -252,7 +256,16 @@ class AppMenu extends Component<
               <AppMenuItem
                 icon={<SvgIcon iconName={popupTarget} />}
                 onClick={this._triggerPopup}
-                text={<FormattedMessage id={`config.popups.${popupTarget}`} />}
+                text={
+                  <>
+                    <FormattedMessage id={`config.popups.${popupTarget}`} />
+                    {isMobile && (
+                      <InvisibleA11yLabel>
+                        <FormattedMessage id="common.linkOpensNewWindow" />
+                      </InvisibleA11yLabel>
+                    )}
+                  </>
+                }
               />
             )}
             {callTakerEnabled && (

--- a/lib/components/app/app-menu.tsx
+++ b/lib/components/app/app-menu.tsx
@@ -318,7 +318,7 @@ export default injectIntl(
 /**
  * Renders a label and icon either from url or font awesome type
  */
-const Icon = ({
+export const Icon = ({
   iconType,
   iconUrl
 }: {

--- a/lib/components/app/desktop-nav.tsx
+++ b/lib/components/app/desktop-nav.tsx
@@ -7,9 +7,10 @@ import styled from 'styled-components'
 import * as uiActions from '../../actions/ui'
 import { accountLinks, getAuth0Config } from '../../util/auth'
 import { DEFAULT_APP_TITLE } from '../../util/constants'
+import InvisibleA11yLabel from '../util/invisible-a11y-label'
 import NavLoginButtonAuth0 from '../user/nav-login-button-auth0'
 
-import AppMenu from './app-menu'
+import AppMenu, { Icon } from './app-menu'
 import LocaleSelector from './locale-selector'
 import ViewSwitcher from './view-switcher'
 
@@ -19,6 +20,13 @@ const NavItemOnLargeScreens = styled(NavItem)`
     display: none !important;
   }
 `
+
+const StyledNav = styled(Nav)`
+  & > li svg {
+    height: 18px;
+  }
+`
+
 // Typscript TODO: otpConfig type
 export type Props = {
   locale: string
@@ -91,12 +99,15 @@ const DesktopNav = ({
 
           <ViewSwitcher sticky />
 
-          <Nav pullRight>
+          <StyledNav pullRight>
             {popupTarget && (
               <NavItemOnLargeScreens
                 onClick={() => setPopupContent(popupTarget)}
               >
-                <FormattedMessage id={`config.popups.${popupTarget}`} />
+                <Icon iconType={popupTarget} />
+                <InvisibleA11yLabel>
+                  <FormattedMessage id={`config.popups.${popupTarget}`} />
+                </InvisibleA11yLabel>
               </NavItemOnLargeScreens>
             )}
             <LocaleSelector />
@@ -108,7 +119,7 @@ const DesktopNav = ({
                 style={{ float: 'right' }}
               />
             )}
-          </Nav>
+          </StyledNav>
         </Navbar.Header>
       </Navbar>
     </header>

--- a/lib/components/app/desktop-nav.tsx
+++ b/lib/components/app/desktop-nav.tsx
@@ -22,8 +22,15 @@ const NavItemOnLargeScreens = styled(NavItem)`
 `
 
 const StyledNav = styled(Nav)`
+  /* Almost override bootstrap's margin-right: -15px */
+  margin-right: -5px;
   & > li svg {
     height: 18px;
+  }
+
+  & .caret {
+    margin-left: 5px;
+    margin-right: -10px;
   }
 `
 

--- a/lib/components/app/desktop-nav.tsx
+++ b/lib/components/app/desktop-nav.tsx
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux'
-import { FormattedMessage } from 'react-intl'
 import { Nav, Navbar, NavItem } from 'react-bootstrap'
+import { useIntl } from 'react-intl'
 import React from 'react'
 import styled from 'styled-components'
 
@@ -60,6 +60,7 @@ const DesktopNav = ({
     persistence,
     title = DEFAULT_APP_TITLE
   } = otpConfig
+  const intl = useIntl()
   const showLogin = Boolean(getAuth0Config(persistence))
 
   const BrandingElement = brandClickable ? 'a' : 'div'
@@ -76,6 +77,11 @@ const DesktopNav = ({
         }
       }
     : { style: { ...commonStyles } }
+  const popupButtonText =
+    popupTarget &&
+    intl.formatMessage({
+      id: `config.popups.${popupTarget}`
+    })
 
   return (
     <header>
@@ -103,11 +109,10 @@ const DesktopNav = ({
             {popupTarget && (
               <NavItemOnLargeScreens
                 onClick={() => setPopupContent(popupTarget)}
+                title={popupButtonText}
               >
                 <Icon iconType={popupTarget} />
-                <InvisibleA11yLabel>
-                  <FormattedMessage id={`config.popups.${popupTarget}`} />
-                </InvisibleA11yLabel>
+                <InvisibleA11yLabel>{popupButtonText}</InvisibleA11yLabel>
               </NavItemOnLargeScreens>
             )}
             <LocaleSelector />

--- a/lib/components/app/locale-selector.tsx
+++ b/lib/components/app/locale-selector.tsx
@@ -31,7 +31,7 @@ const LocaleSelector = (props: LocaleSelectorProps): JSX.Element | null => {
             color: 'rgba(255, 255, 255, 0.85)'
           }}
         >
-          <GlobeAmericas height="18px" />
+          <GlobeAmericas />
         </span>
       }
       style={{ display: 'block ruby' }}

--- a/lib/components/app/popup-trigger-text.tsx
+++ b/lib/components/app/popup-trigger-text.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage, useIntl } from 'react-intl'
 import coreUtils from '@opentripplanner/core-utils'
-import React from 'React'
+import React from 'react'
 
 import InvisibleA11yLabel from '../util/invisible-a11y-label'
 

--- a/lib/components/app/popup-trigger-text.tsx
+++ b/lib/components/app/popup-trigger-text.tsx
@@ -1,0 +1,43 @@
+import { FormattedMessage, useIntl } from 'react-intl'
+import coreUtils from '@opentripplanner/core-utils'
+import React from 'React'
+
+import InvisibleA11yLabel from '../util/invisible-a11y-label'
+
+interface Props {
+  compact?: boolean
+  popupTarget: string
+}
+
+const isMobile = coreUtils.ui.isMobile()
+
+/**
+ * Renders the text for the button that triggers the survey/other popup.
+ * Includes "Opens in a new window" a11y indication in mobile view.
+ */
+const PopupTriggerText = ({ compact, popupTarget }: Props): JSX.Element => {
+  const intl = useIntl()
+  const normalText = intl.formatMessage({
+    id: `config.popups.${popupTarget}`
+  })
+
+  return (
+    <>
+      {compact ? (
+        <FormattedMessage
+          defaultMessage={normalText}
+          id={`config.popups.${popupTarget}-narrow`}
+        />
+      ) : (
+        normalText
+      )}
+      {isMobile && (
+        <InvisibleA11yLabel>
+          <FormattedMessage id="common.linkOpensNewWindow" />
+        </InvisibleA11yLabel>
+      )}
+    </>
+  )
+}
+
+export default PopupTriggerText

--- a/lib/components/mobile/navigation-bar.js
+++ b/lib/components/mobile/navigation-bar.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import { Navbar } from 'react-bootstrap'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
+import styled from 'styled-components'
 
 import * as uiActions from '../../actions/ui'
 import { accountLinks, getAuth0Config } from '../../util/auth'
@@ -12,6 +13,12 @@ import AppMenu from '../app/app-menu'
 import LocaleSelector from '../app/locale-selector'
 import NavLoginButtonAuth0 from '../../components/user/nav-login-button-auth0'
 import PageTitle from '../util/page-title'
+
+const MobileBar = styled.div`
+  & > li svg {
+    height: 18px;
+  }
+`
 
 class MobileNavigationBar extends Component {
   static propTypes = {
@@ -78,7 +85,7 @@ class MobileNavigationBar extends Component {
             </div>
           )}
 
-          <div className="locale-selector-and-login">
+          <MobileBar className="locale-selector-and-login">
             <LocaleSelector configLanguages={configLanguages} />
             {/* HACK: Normally, NavLoginButtonAuth0 should be inside a <Nav> element,
                 however, in mobile mode, react-bootstrap's <Nav> causes the
@@ -91,7 +98,7 @@ class MobileNavigationBar extends Component {
                 locale={locale}
               />
             )}
-          </div>
+          </MobileBar>
         </Navbar>
       </header>
     )

--- a/lib/components/narrative/narrative-itineraries-header.tsx
+++ b/lib/components/narrative/narrative-itineraries-header.tsx
@@ -4,6 +4,7 @@ import { FormattedMessage, useIntl } from 'react-intl'
 import { Itinerary } from '@opentripplanner/types'
 import { SortAmountDown } from '@styled-icons/fa-solid/SortAmountDown'
 import { SortAmountUp } from '@styled-icons/fa-solid/SortAmountUp'
+import coreUtils from '@opentripplanner/core-utils'
 import React from 'react'
 import styled from 'styled-components'
 
@@ -12,6 +13,8 @@ import InvisibleA11yLabel from '../util/invisible-a11y-label'
 
 import PlanFirstLastButtons from './plan-first-last-buttons'
 import SaveTripButton from './save-trip-button'
+
+const isMobile = coreUtils.ui.isMobile()
 
 const IssueButton = styled.button`
   background-color: #ecbe03;
@@ -153,6 +156,11 @@ export default function NarrativeItinerariesHeader({
             {popupTarget && (
               <button onClick={() => setPopupContent(popupTarget)}>
                 <FormattedMessage id={`config.popups.${popupTarget}`} />
+                {isMobile && (
+                  <InvisibleA11yLabel>
+                    <FormattedMessage id="common.linkOpensNewWindow" />
+                  </InvisibleA11yLabel>
+                )}
               </button>
             )}
             <button

--- a/lib/components/narrative/narrative-itineraries-header.tsx
+++ b/lib/components/narrative/narrative-itineraries-header.tsx
@@ -4,17 +4,15 @@ import { FormattedMessage, useIntl } from 'react-intl'
 import { Itinerary } from '@opentripplanner/types'
 import { SortAmountDown } from '@styled-icons/fa-solid/SortAmountDown'
 import { SortAmountUp } from '@styled-icons/fa-solid/SortAmountUp'
-import coreUtils from '@opentripplanner/core-utils'
 import React from 'react'
 import styled from 'styled-components'
 
 import { IconWithText, StyledIconWrapper } from '../util/styledIcon'
 import InvisibleA11yLabel from '../util/invisible-a11y-label'
+import PopupTriggerText from '../app/popup-trigger-text'
 
 import PlanFirstLastButtons from './plan-first-last-buttons'
 import SaveTripButton from './save-trip-button'
-
-const isMobile = coreUtils.ui.isMobile()
 
 const IssueButton = styled.button`
   background-color: #ecbe03;
@@ -155,12 +153,7 @@ export default function NarrativeItinerariesHeader({
           >
             {popupTarget && (
               <button onClick={() => setPopupContent(popupTarget)}>
-                <FormattedMessage id={`config.popups.${popupTarget}`} />
-                {isMobile && (
-                  <InvisibleA11yLabel>
-                    <FormattedMessage id="common.linkOpensNewWindow" />
-                  </InvisibleA11yLabel>
-                )}
+                <PopupTriggerText compact popupTarget={popupTarget} />
               </button>
             )}
             <button

--- a/lib/components/narrative/save-trip-button.js
+++ b/lib/components/narrative/save-trip-button.js
@@ -22,7 +22,7 @@ const SaveTripButton = ({ itinerary, loggedInUser, persistence }) => {
   const intl = useIntl()
   // We are dealing with the following states:
   // 1. Persistence disabled => just return null
-  // 2. User is not logged in => render something like: "Please sign in to save trip".
+  // 2. User is not logged in => render something like: "Please log in to save trip".
   // 3. itin cannot be monitored => disable the button with prompt and tooltip.
 
   let buttonDisabled

--- a/lib/components/narrative/trip-tools.js
+++ b/lib/components/narrative/trip-tools.js
@@ -11,17 +11,14 @@ import { Undo } from '@styled-icons/fa-solid/Undo'
 import { withRouter } from 'react-router'
 import bowser from 'bowser'
 import copyToClipboard from 'copy-to-clipboard'
-import coreUtils from '@opentripplanner/core-utils'
 import PropTypes from 'prop-types'
 import React, { Component, useContext, useMemo } from 'react'
 
 import * as uiActions from '../../actions/ui'
 import { ComponentContext } from '../../util/contexts'
 import { IconWithText } from '../util/styledIcon'
-import InvisibleA11yLabel from '../util/invisible-a11y-label'
+import PopupTriggerText from '../app/popup-trigger-text'
 import startOver from '../util/start-over'
-
-const isMobile = coreUtils.ui.isMobile()
 
 // Copy URL Button
 
@@ -238,21 +235,7 @@ const TripTools = ({
             <LinkButton
               Icon={PopupIcon}
               onClick={() => setPopupContent(popupTarget)}
-              text={
-                <>
-                  <FormattedMessage
-                    defaultMessage={intl.formatMessage({
-                      id: `config.popups.${popupTarget}`
-                    })}
-                    id={`config.popups.${popupTarget}-narrow`}
-                  />
-                  {isMobile && (
-                    <InvisibleA11yLabel>
-                      <FormattedMessage id="common.linkOpensNewWindow" />
-                    </InvisibleA11yLabel>
-                  )}
-                </>
-              }
+              text={<PopupTriggerText compact popupTarget={popupTarget} />}
             />
           )
         }

--- a/lib/components/narrative/trip-tools.js
+++ b/lib/components/narrative/trip-tools.js
@@ -11,13 +11,18 @@ import { Undo } from '@styled-icons/fa-solid/Undo'
 import { withRouter } from 'react-router'
 import bowser from 'bowser'
 import copyToClipboard from 'copy-to-clipboard'
+import coreUtils from '@opentripplanner/core-utils'
 import PropTypes from 'prop-types'
 import React, { Component, useContext, useMemo } from 'react'
 
 import * as uiActions from '../../actions/ui'
 import { ComponentContext } from '../../util/contexts'
 import { IconWithText } from '../util/styledIcon'
+import InvisibleA11yLabel from '../util/invisible-a11y-label'
 import startOver from '../util/start-over'
+
+const isMobile = coreUtils.ui.isMobile()
+
 // Copy URL Button
 
 class CopyUrlButton extends Component {
@@ -234,12 +239,19 @@ const TripTools = ({
               Icon={PopupIcon}
               onClick={() => setPopupContent(popupTarget)}
               text={
-                <FormattedMessage
-                  defaultMessage={intl.formatMessage({
-                    id: `config.popups.${popupTarget}`
-                  })}
-                  id={`config.popups.${popupTarget}-narrow`}
-                />
+                <>
+                  <FormattedMessage
+                    defaultMessage={intl.formatMessage({
+                      id: `config.popups.${popupTarget}`
+                    })}
+                    id={`config.popups.${popupTarget}-narrow`}
+                  />
+                  {isMobile && (
+                    <InvisibleA11yLabel>
+                      <FormattedMessage id="common.linkOpensNewWindow" />
+                    </InvisibleA11yLabel>
+                  )}
+                </>
               }
             />
           )

--- a/lib/components/user/nav-login-button.tsx
+++ b/lib/components/user/nav-login-button.tsx
@@ -2,12 +2,14 @@
 import { FormattedMessage, useIntl } from 'react-intl'
 import { NavItem } from 'react-bootstrap'
 import { User } from '@auth0/auth0-react'
+import { User as UserIcon } from '@styled-icons/fa-regular/User'
 import React, { HTMLAttributes } from 'react'
 import styled from 'styled-components'
 
 import { LinkContainerWithQuery } from '../form/connected-links'
 import { UnstyledButton } from '../util/unstyled-button'
 import Dropdown from '../util/dropdown'
+import InvisibleA11yLabel from '../util/invisible-a11y-label'
 
 const Avatar = styled.img`
   height: 2em;
@@ -30,7 +32,7 @@ interface Props extends HTMLAttributes<HTMLElement> {
 
 /**
  * This component displays the sign-in status in the nav bar.
- * - When a user is not logged in: display 'Sign In' as a link or button.
+ * - When a user is not logged in: display 'Log In' as a link or button.
  * - When a user is logged in, display an 'avatar' (retrieved from the profile prop)
  *   and a dropdown button so the user can access more options.
  */
@@ -105,7 +107,10 @@ const NavLoginButton = ({
   // Display the sign-in link if no profile is passed (user is not logged in).
   return (
     <NavItem {...commonProps} onClick={onSignInClick}>
-      <FormattedMessage id="components.NavLoginButton.signIn" />
+      <UserIcon height="18px" />
+      <InvisibleA11yLabel>
+        <FormattedMessage id="components.NavLoginButton.signIn" />
+      </InvisibleA11yLabel>
     </NavItem>
   )
 }

--- a/lib/components/user/nav-login-button.tsx
+++ b/lib/components/user/nav-login-button.tsx
@@ -105,12 +105,13 @@ const NavLoginButton = ({
   }
 
   // Display the sign-in link if no profile is passed (user is not logged in).
+  const loginText = intl.formatMessage({
+    id: 'components.NavLoginButton.signIn'
+  })
   return (
-    <NavItem {...commonProps} onClick={onSignInClick}>
+    <NavItem {...commonProps} onClick={onSignInClick} title={loginText}>
       <UserIcon height="18px" />
-      <InvisibleA11yLabel>
-        <FormattedMessage id="components.NavLoginButton.signIn" />
-      </InvisibleA11yLabel>
+      <InvisibleA11yLabel>{loginText}</InvisibleA11yLabel>
     </NavItem>
   )
 }

--- a/lib/components/user/nav-login-button.tsx
+++ b/lib/components/user/nav-login-button.tsx
@@ -110,7 +110,7 @@ const NavLoginButton = ({
   })
   return (
     <NavItem {...commonProps} onClick={onSignInClick} title={loginText}>
-      <UserIcon height="18px" />
+      <UserIcon />
       <InvisibleA11yLabel>{loginText}</InvisibleA11yLabel>
     </NavItem>
   )

--- a/lib/components/util/dropdown.tsx
+++ b/lib/components/util/dropdown.tsx
@@ -176,6 +176,7 @@ const Dropdown = ({
         role="button"
         style={style}
         tabIndex={0}
+        title={label}
       >
         {name}
         <span className="caret" role="presentation" style={{ marginLeft: 5 }} />

--- a/lib/components/util/dropdown.tsx
+++ b/lib/components/util/dropdown.tsx
@@ -179,7 +179,7 @@ const Dropdown = ({
         title={label}
       >
         {name}
-        <span className="caret" role="presentation" style={{ marginLeft: 5 }} />
+        <span className="caret" role="presentation" />
       </DropdownButton>
       {open && (
         <DropdownMenu


### PR DESCRIPTION
## Description

This PR sets the visual content of the "Give Feedback" (or other configured popup) and login buttons to be icons, so that text in some languages doesn't bleed into other content. A popup is also added to these buttons and the language selector. The login button English text is coordinated with the text from the Auth0 login screen.

## PR Checklist
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)? => improves i18n by preventing text to bleed into other content.
- [na] Are appropriate Typescript types implemented?

| Before | After |
|--------|-------|
| ![Before image](https://github.com/opentripplanner/otp-react-redux/assets/56846598/6d0422b6-b1c8-49f6-a43d-dcba7993fe85) | ![After image](https://github.com/opentripplanner/otp-react-redux/assets/56846598/201981a2-78a5-4865-8db0-6b70c1e17e07) |


