### PR TITLE
Check existence of the correct itinerary

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -388,7 +388,7 @@ export function setLocale(locale) {
     window.localStorage.setItem('lang', matchedLocale)
 
     if (loggedInUser) {
-      loggedInUser.preferredLanguage = matchedLocale
+      loggedInUser.preferredLocale = matchedLocale
       dispatch(createOrUpdateUser(loggedInUser, false))
     }
   }

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -435,13 +435,13 @@ class NarrativeItineraries extends Component {
                     </S.ModeResultContainer>
                   )
                 })
-              ) : !pending ? (
+              ) : (
                 <ListContainer>
                   {itinerariesWithCo2.map((itin) =>
                     this._renderItineraryRow(itin)
                   )}
                 </ListContainer>
-              ) : null}
+              )}
               {this._renderLoadingDivs()}
               {groupItineraries &&
                 !itineraryIsExpanded &&

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -435,13 +435,13 @@ class NarrativeItineraries extends Component {
                     </S.ModeResultContainer>
                   )
                 })
-              ) : (
+              ) : !pending ? (
                 <ListContainer>
                   {itinerariesWithCo2.map((itin) =>
                     this._renderItineraryRow(itin)
                   )}
                 </ListContainer>
-              )}
+              ) : null}
               {this._renderLoadingDivs()}
               {groupItineraries &&
                 !itineraryIsExpanded &&

--- a/lib/components/user/monitored-trip/saved-trip-screen.js
+++ b/lib/components/user/monitored-trip/saved-trip-screen.js
@@ -163,8 +163,8 @@ class SavedTripScreen extends Component {
   }
 
   render() {
-    const { isCreating, itinerary, loggedInUser, monitoredTrips } = this.props
-    const isAwaiting = !monitoredTrips || (isCreating && !itinerary)
+    const { isCreating, loggedInUser, monitoredTrips, pending } = this.props
+    const isAwaiting = !monitoredTrips || (isCreating && pending)
 
     let screenContents
     if (isAwaiting) {
@@ -244,6 +244,7 @@ class SavedTripScreen extends Component {
 const mapStateToProps = (state, ownProps) => {
   const activeSearch = getActiveSearch(state)
   const activeItinerary = activeSearch && activeSearch.activeItinerary
+  const pending = activeSearch ? Boolean(activeSearch.pending) : false
   const itineraries = getActiveItineraries(state) || []
   const tripId = ownProps.match.params.id
   return {
@@ -253,6 +254,7 @@ const mapStateToProps = (state, ownProps) => {
     itinerary: itineraries[activeItinerary],
     loggedInUser: state.user.loggedInUser,
     monitoredTrips: state.user.loggedInUserMonitoredTrips,
+    pending,
     queryParams: state.router.location.search,
     tripId
   }

--- a/lib/util/i18n.js
+++ b/lib/util/i18n.js
@@ -170,7 +170,7 @@ export function getDefaultLocale(config, loggedInUser) {
     window.localStorage.getItem('lang') || navigator.language
 
   return (
-    loggedInUser?.preferredLanguage ||
+    loggedInUser?.preferredLocale ||
     browserLocale ||
     localization.defaultLocale ||
     'en-US'


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR makes the Save Trip screen send the correct itinerary to OTP-middleware for checking.

When requests are pending and itineraries are trickling in, the UI grabs the first one available as the itinerary to check. It might be a walk-only trip, which is incorrect. The PR makes the UI wait until all itineraries are fetched before displaying the desired one and setting that as the itinerary to check. This improvement is also applied to the narrative itineraries container so avoid superfluous renderings when the full itinerary is shown.

As a result, there should be ** *fewer* ** cases where the itinerary check results in no days available, compared to now.
Note that this PR does not address the active itinerary index in grouped itineraries or any issues with the middleware checking itineraries that could cause the remaining cases with no days available.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [na] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [na] Are all languages supported (Internationalization/Localization)?
- [na] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

