### PR TITLE
Support External Help Link

### DIFF
--- a/lib/components/app/desktop-nav.tsx
+++ b/lib/components/app/desktop-nav.tsx
@@ -67,6 +67,7 @@ const DesktopNav = ({
   const {
     brandClickable,
     branding,
+    extraMenuItems,
     persistence,
     title = DEFAULT_APP_TITLE
   } = otpConfig
@@ -129,7 +130,7 @@ const DesktopNav = ({
             {showLogin && (
               <NavLoginButtonAuth0
                 id="login-control"
-                links={accountLinks(otpConfig)}
+                links={accountLinks(extraMenuItems)}
                 locale={locale}
                 style={{ float: 'right' }}
               />

--- a/lib/components/app/desktop-nav.tsx
+++ b/lib/components/app/desktop-nav.tsx
@@ -18,7 +18,9 @@ import ViewSwitcher from './view-switcher'
 const StyledNav = styled(Nav)`
   /* Almost override bootstrap's margin-right: -15px */
   margin-right: -5px;
-  & > li svg {
+  /* Target only the svgs in the Navbar */
+  & > li > button > svg,
+  & > li > span > button > span > svg {
     height: 18px;
   }
 
@@ -127,7 +129,7 @@ const DesktopNav = ({
             {showLogin && (
               <NavLoginButtonAuth0
                 id="login-control"
-                links={accountLinks}
+                links={accountLinks(otpConfig)}
                 locale={locale}
                 style={{ float: 'right' }}
               />

--- a/lib/components/mobile/navigation-bar.js
+++ b/lib/components/mobile/navigation-bar.js
@@ -113,7 +113,7 @@ const mapStateToProps = (state) => {
   return {
     auth0Config: getAuth0Config(state.otp.config.persistence),
     configLanguages: state.otp.config.language,
-    extraMenuItems: state.otp.config.extraMenuItems,
+    extraMenuItems: state.otp?.config?.extraMenuItems,
     locale: state.otp.ui.locale
   }
 }

--- a/lib/components/mobile/navigation-bar.js
+++ b/lib/components/mobile/navigation-bar.js
@@ -24,6 +24,7 @@ class MobileNavigationBar extends Component {
   static propTypes = {
     auth0Config: PropTypes.object,
     backScreen: PropTypes.number,
+    config: PropTypes.object,
     configLanguages: PropTypes.object,
     defaultMobileTitle: PropTypes.string,
     headerAction: PropTypes.element,
@@ -45,6 +46,7 @@ class MobileNavigationBar extends Component {
   render() {
     const {
       auth0Config,
+      config,
       configLanguages,
       defaultMobileTitle,
       headerAction,
@@ -94,7 +96,7 @@ class MobileNavigationBar extends Component {
             {auth0Config && (
               <NavLoginButtonAuth0
                 id="login-control"
-                links={accountLinks}
+                links={accountLinks(config)}
                 locale={locale}
               />
             )}
@@ -110,6 +112,7 @@ class MobileNavigationBar extends Component {
 const mapStateToProps = (state) => {
   return {
     auth0Config: getAuth0Config(state.otp.config.persistence),
+    config: state.otp.config,
     configLanguages: state.otp.config.language,
     locale: state.otp.ui.locale
   }

--- a/lib/components/mobile/navigation-bar.js
+++ b/lib/components/mobile/navigation-bar.js
@@ -24,9 +24,9 @@ class MobileNavigationBar extends Component {
   static propTypes = {
     auth0Config: PropTypes.object,
     backScreen: PropTypes.number,
-    config: PropTypes.object,
     configLanguages: PropTypes.object,
     defaultMobileTitle: PropTypes.string,
+    extraMenuItems: PropTypes.array,
     headerAction: PropTypes.element,
     headerText: PropTypes.string,
     locale: PropTypes.string,
@@ -46,9 +46,9 @@ class MobileNavigationBar extends Component {
   render() {
     const {
       auth0Config,
-      config,
       configLanguages,
       defaultMobileTitle,
+      extraMenuItems,
       headerAction,
       headerText,
       locale,
@@ -96,7 +96,7 @@ class MobileNavigationBar extends Component {
             {auth0Config && (
               <NavLoginButtonAuth0
                 id="login-control"
-                links={accountLinks(config)}
+                links={accountLinks(extraMenuItems)}
                 locale={locale}
               />
             )}
@@ -112,8 +112,8 @@ class MobileNavigationBar extends Component {
 const mapStateToProps = (state) => {
   return {
     auth0Config: getAuth0Config(state.otp.config.persistence),
-    config: state.otp.config,
     configLanguages: state.otp.config.language,
+    extraMenuItems: state.otp.config.extraMenuItems,
     locale: state.otp.ui.locale
   }
 }

--- a/lib/components/user/nav-login-button.tsx
+++ b/lib/components/user/nav-login-button.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 
 import { Dropdown } from '../util/dropdown'
 import { LinkContainerWithQuery } from '../form/connected-links'
+import { NewWindowIconA11y } from '../util/externalLink'
 import { UnstyledButton } from '../util/unstyled-button'
 import InvisibleA11yLabel from '../util/invisible-a11y-label'
 import NavbarItem from '../app/nav-item'
@@ -15,6 +16,14 @@ const Avatar = styled.img`
   height: 2em;
   margin: -15px 0;
   width: 2em;
+`
+const UnstyledHelpLink = styled.a`
+  display: block;
+  color: inherit;
+  &:hover {
+    color: inherit;
+    text-decoration: none;
+  }
 `
 
 type Link = {
@@ -75,24 +84,39 @@ const NavLoginButton = ({
           <li className="header">{displayedName}</li>
 
           {links &&
-            links.map((link, i) => (
-              <LinkContainerWithQuery
-                exact
-                key={i}
-                target={link.target}
-                to={link.url}
-              >
-                <li>
-                  <UnstyledButton>
-                    {link.messageId === 'myAccount' ? ( // messageId is 'myAccount' or 'help'
-                      <FormattedMessage id="components.NavLoginButton.myAccount" />
-                    ) : (
+            links.map((link, i) => {
+              if (link.url.startsWith('http')) {
+                return (
+                  <li>
+                    <UnstyledHelpLink href={link.url} target="_blank">
                       <FormattedMessage id="components.NavLoginButton.help" />
-                    )}
-                  </UnstyledButton>
-                </li>
-              </LinkContainerWithQuery>
-            ))}
+                      <NewWindowIconA11y
+                        size={12}
+                        style={{ marginLeft: '5px', marginTop: '-3px' }}
+                      />
+                    </UnstyledHelpLink>
+                  </li>
+                )
+              }
+              return (
+                <LinkContainerWithQuery
+                  exact
+                  key={i}
+                  target={link.target}
+                  to={link.url}
+                >
+                  <li>
+                    <UnstyledButton>
+                      {link.messageId === 'myAccount' ? ( // messageId is 'myAccount' or 'help'
+                        <FormattedMessage id="components.NavLoginButton.myAccount" />
+                      ) : (
+                        <FormattedMessage id="components.NavLoginButton.help" />
+                      )}
+                    </UnstyledButton>
+                  </li>
+                </LinkContainerWithQuery>
+              )
+            })}
 
           <hr role="presentation" />
 

--- a/lib/util/auth.js
+++ b/lib/util/auth.js
@@ -5,19 +5,24 @@ import { isOtpMiddleware } from './user'
  * Custom links under the user account dropdown.
  * TODO: Determine/implement the urls below.
  */
-export const accountLinks = [
-  {
-    messageId: 'myAccount',
-    url: ACCOUNT_PATH
-  },
-  {
-    messageId: 'help',
-    // Add a target attribute if you need the link to open in a new window, etc.
-    // (supports the same values as <a target=... >).
-    // target: '_blank',
-    url: '/help'
-  }
-]
+export const accountLinks = (config) => {
+  const helpLink =
+    config?.extraMenuItems.find((link) => link.id === 'help') || undefined
+  const helpLinkUrl = helpLink ? helpLink.href : '/help'
+  return [
+    {
+      messageId: 'myAccount',
+      url: ACCOUNT_PATH
+    },
+    {
+      messageId: 'help',
+      // Add a target attribute if you need the link to open in a new window, etc.
+      // (supports the same values as <a target=... >).
+      // target: '_blank',
+      url: helpLinkUrl
+    }
+  ]
+}
 
 /**
  * Obtains the Auth0 {domain, audience, clientId} configuration, if the following applies in config.yml:

--- a/lib/util/auth.js
+++ b/lib/util/auth.js
@@ -5,10 +5,9 @@ import { isOtpMiddleware } from './user'
  * Custom links under the user account dropdown.
  * TODO: Determine/implement the urls below.
  */
-export const accountLinks = (config) => {
-  const helpLink =
-    config?.extraMenuItems.find((link) => link.id === 'help') || undefined
-  const helpLinkUrl = helpLink ? helpLink.href : '/help'
+export const accountLinks = (extraMenuItems) => {
+  const helpLinkUrl =
+    extraMenuItems?.find((link) => link.id === 'help')?.href || '/help'
   return [
     {
       messageId: 'myAccount',


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
If there is an external "help" link supplied in the config, the "help" option inside the account dropdown will direct users to the external web address. An icon will also be added indicating the link is an external link.

<img width="197" alt="image" src="https://github.com/opentripplanner/otp-react-redux/assets/115499534/41816342-d2c2-426b-b2d6-cf6701237b82">


<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

