### PR TITLE
Fix itinerary existence

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -510,6 +510,8 @@ components:
     pause: Pause
     resume: Resume
   SavedTripScreen:
+    itineraryLoaded: Itinerary loaded
+    itineraryLoading: Loading itinerary
     tooManyTrips: >
       You already have reached the maximum of five saved trips. Please remove
       unused trips from your saved trips, and try again.

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -487,6 +487,8 @@ components:
     pause: Arrêter
     resume: Reprendre
   SavedTripScreen:
+    itineraryLoaded: Trajet chargé
+    itineraryLoading: Chargement du trajet
     tooManyTrips: >
       Vous avez déjà atteint le nombre maximum de 5 trajets enregistrés.
       Veuillez supprimer les trajets enregistrés qui sont inutilisés, puis

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -911,6 +911,9 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
 
     combinations.forEach((combo) => {
       const query = generateOtp2Query(combo)
+
+      console.log('OTP2 query', query)
+
       dispatch(
         createGraphQLQueryAction(
           query.query,
@@ -974,6 +977,8 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
                     ...response.data?.plan,
                     itineraries: withCollapsedShortNames
                   },
+                  // TODO: only keep necessary query attributes/vars.
+                  query,
                   requestId: searchId
                 },
                 searchId

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -401,7 +401,7 @@ export function setLocale(locale) {
     window.localStorage.setItem('lang', matchedLocale)
 
     if (loggedInUser) {
-      loggedInUser.preferredLanguage = matchedLocale
+      loggedInUser.preferredLocale = matchedLocale
       dispatch(createOrUpdateUser(loggedInUser, false))
     }
   }

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -448,13 +448,13 @@ class NarrativeItineraries extends Component {
                     </S.ModeResultContainer>
                   )
                 })
-              ) : (
+              ) : !pending ? (
                 <ListContainer>
                   {itinerariesWithCo2.map((itin) =>
                     this._renderItineraryRow(itin)
                   )}
                 </ListContainer>
-              )}
+              ) : null}
               {this._renderLoadingDivs()}
               {groupItineraries &&
                 !itineraryIsExpanded &&

--- a/lib/components/user/monitored-trip/saved-trip-screen.js
+++ b/lib/components/user/monitored-trip/saved-trip-screen.js
@@ -2,7 +2,7 @@
 import * as yup from 'yup'
 import { connect } from 'react-redux'
 import { Form, Formik } from 'formik'
-import { injectIntl } from 'react-intl'
+import { FormattedMessage, injectIntl } from 'react-intl'
 import { withAuthenticationRequired } from '@auth0/auth0-react'
 import clone from 'clone'
 import React, { Component } from 'react'
@@ -17,6 +17,7 @@ import { RETURN_TO_CURRENT_ROUTE } from '../../../util/ui'
 import { TRIPS_PATH } from '../../../util/constants'
 import AccountPage from '../account-page'
 import AwaitingScreen from '../awaiting-screen'
+import InvisibleA11yLabel from '../../util/invisible-a11y-label'
 import withLoggedInUserSupport from '../with-logged-in-user-support'
 
 import SavedTripEditor from './saved-trip-editor'
@@ -165,9 +166,10 @@ class SavedTripScreen extends Component {
 
   render() {
     const { isCreating, itinerary, loggedInUser, monitoredTrips } = this.props
+    const isAwaiting = !monitoredTrips || (isCreating && !itinerary)
 
     let screenContents
-    if (!monitoredTrips || (isCreating && !itinerary)) {
+    if (isAwaiting) {
       // Flash an indication while the selected and saved user trips are being loaded.
       screenContents = <AwaitingScreen />
     } else {
@@ -205,27 +207,37 @@ class SavedTripScreen extends Component {
             // and to its own blur/change/submit event handlers that automate the state.
             // We pass the Formik props below to the components rendered so that individual controls
             // can be wired to be managed by Formik.
-            (props) => {
-              return (
-                <Form noValidate>
-                  <SavedTripEditor
-                    {...props}
-                    isCreating={isCreating}
-                    notificationChannel={loggedInUser.notificationChannel}
-                    onCancel={
-                      isCreating ? this._goToTripPlanner : this._goToSavedTrips
-                    }
-                    panes={this._panes}
-                  />
-                </Form>
-              )
-            }
+            (props) => (
+              <Form noValidate>
+                <SavedTripEditor
+                  {...props}
+                  isCreating={isCreating}
+                  notificationChannel={loggedInUser.notificationChannel}
+                  onCancel={
+                    isCreating ? this._goToTripPlanner : this._goToSavedTrips
+                  }
+                  panes={this._panes}
+                />
+              </Form>
+            )
           }
         </Formik>
       )
     }
 
-    return <AccountPage>{screenContents}</AccountPage>
+    return (
+      <AccountPage>
+        <InvisibleA11yLabel role="status">
+          {/* Create a fixed element for a11y technology to detect status changes. */}
+          {isAwaiting ? (
+            <FormattedMessage id="components.SavedTripScreen.itineraryLoading" />
+          ) : (
+            <FormattedMessage id="components.SavedTripScreen.itineraryLoaded" />
+          )}
+        </InvisibleA11yLabel>
+        {screenContents}
+      </AccountPage>
+    )
   }
 }
 

--- a/lib/components/user/monitored-trip/saved-trip-screen.js
+++ b/lib/components/user/monitored-trip/saved-trip-screen.js
@@ -150,8 +150,6 @@ class SavedTripScreen extends Component {
         parseUrlQueryString()
       }
     }
-
-    // TODO: Update title bar during componentDidMount.
   }
 
   /**

--- a/lib/components/user/monitored-trip/saved-trip-screen.js
+++ b/lib/components/user/monitored-trip/saved-trip-screen.js
@@ -7,6 +7,7 @@ import { withAuthenticationRequired } from '@auth0/auth0-react'
 import clone from 'clone'
 import React, { Component } from 'react'
 
+import * as formActions from '../../../actions/form'
 import * as uiActions from '../../../actions/ui'
 import * as userActions from '../../../actions/user'
 import { ALL_DAYS, arrayToDayFields } from '../../../util/monitored-trip'
@@ -126,14 +127,27 @@ class SavedTripScreen extends Component {
   }
 
   componentDidMount() {
-    const { intl, isCreating, monitoredTrips } = this.props
-    if (isCreating && hasMaxTripCount(monitoredTrips)) {
-      // There is a middleware limit of 5 saved trips,
-      // so if that limit is already reached, alert, then show editing mode.
-      alert(
-        intl.formatMessage({ id: 'components.SavedTripScreen.tooManyTrips' })
-      )
-      this._goToSavedTrips()
+    const {
+      intl,
+      isCreating,
+      itinerary,
+      location,
+      monitoredTrips,
+      parseUrlQueryString
+    } = this.props
+    if (isCreating) {
+      if (hasMaxTripCount(monitoredTrips)) {
+        // There is a middleware limit of 5 saved trips,
+        // so if that limit is already reached, alert, then show editing mode.
+        alert(
+          intl.formatMessage({ id: 'components.SavedTripScreen.tooManyTrips' })
+        )
+        this._goToSavedTrips()
+      } else if (!itinerary && location && location.search) {
+        // If no itinerary is loaded and the user is saving a new one,
+        // parse the URL query parameters, if present.
+        parseUrlQueryString()
+      }
     }
 
     // TODO: Update title bar during componentDidMount.
@@ -150,11 +164,11 @@ class SavedTripScreen extends Component {
   }
 
   render() {
-    const { isCreating, loggedInUser, monitoredTrips } = this.props
+    const { isCreating, itinerary, loggedInUser, monitoredTrips } = this.props
 
     let screenContents
-    if (!monitoredTrips) {
-      // Flash an indication while user trips are being loaded.
+    if (!monitoredTrips || (isCreating && !itinerary)) {
+      // Flash an indication while the selected and saved user trips are being loaded.
       screenContents = <AwaitingScreen />
     } else {
       const monitoredTrip = this._getTripToEdit()
@@ -236,6 +250,7 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = {
   createOrUpdateUserMonitoredTrip: userActions.createOrUpdateUserMonitoredTrip,
+  parseUrlQueryString: formActions.parseUrlQueryString,
   routeTo: uiActions.routeTo
 }
 

--- a/lib/components/user/monitored-trip/saved-trip-screen.js
+++ b/lib/components/user/monitored-trip/saved-trip-screen.js
@@ -163,8 +163,8 @@ class SavedTripScreen extends Component {
   }
 
   render() {
-    const { isCreating, itinerary, loggedInUser, monitoredTrips } = this.props
-    const isAwaiting = !monitoredTrips || (isCreating && !itinerary)
+    const { isCreating, loggedInUser, monitoredTrips, pending } = this.props
+    const isAwaiting = !monitoredTrips || (isCreating && pending)
 
     let screenContents
     if (isAwaiting) {
@@ -244,6 +244,7 @@ class SavedTripScreen extends Component {
 const mapStateToProps = (state, ownProps) => {
   const activeSearch = getActiveSearch(state)
   const activeItinerary = activeSearch && activeSearch.activeItinerary
+  const pending = activeSearch ? Boolean(activeSearch.pending) : false
   const itineraries = getActiveItineraries(state) || []
   const tripId = ownProps.match.params.id
   return {
@@ -253,6 +254,7 @@ const mapStateToProps = (state, ownProps) => {
     itinerary: itineraries[activeItinerary],
     loggedInUser: state.user.loggedInUser,
     monitoredTrips: state.user.loggedInUserMonitoredTrips,
+    pending,
     queryParams: state.router.location.search,
     tripId
   }

--- a/lib/components/user/monitored-trip/saved-trip-screen.js
+++ b/lib/components/user/monitored-trip/saved-trip-screen.js
@@ -2,7 +2,10 @@
 import * as yup from 'yup'
 import { connect } from 'react-redux'
 import { Form, Formik } from 'formik'
+// import { format } from 'date-fns'
 import { FormattedMessage, injectIntl } from 'react-intl'
+// import { OTP_API_TIME_FORMAT } from '@opentripplanner/core-utils/lib/time'
+// import { utcToZonedTime } from 'date-fns-tz'
 import { withAuthenticationRequired } from '@auth0/auth0-react'
 import clone from 'clone'
 import qs from 'qs'
@@ -72,13 +75,36 @@ class SavedTripScreen extends Component {
   _createMonitoredTrip = () => {
     const { homeTimezone, itinerary, loggedInUser, otpQuery, queryParams } =
       this.props
+
+    console.log(queryParams, otpQuery)
+
     const monitoredDays = getItineraryDefaultMonitoredDays(
       itinerary,
       homeTimezone
     )
+    const {
+      // bikeReluctance,
+      // carReluctance,
+      modes = ['WALK'],
+      walkReluctance,
+      wheelchair
+    } = otpQuery.variables || {}
+
+    // startTime is expressed in the configured homeTimezone.
+    // const startTime = utcToZonedTime(
+    //   new Date(itinerary.startTime - 60000),
+    //   homeTimezone
+    // )
+
     const actualQueryParams = {
       ...qs.parse(queryParams),
-      mode: otpQuery.variables.modes.join(',')
+      // arriveBy: false,
+      // bikeReluctance,
+      // carReluctance,
+      mode: modes.map((modeObj) => modeObj.mode).join(','),
+      // time: format(startTime, OTP_API_TIME_FORMAT),
+      walkReluctance,
+      wheelchair
     }
     return {
       ...arrayToDayFields(monitoredDays),

--- a/lib/components/user/monitored-trip/saved-trip-screen.js
+++ b/lib/components/user/monitored-trip/saved-trip-screen.js
@@ -5,6 +5,7 @@ import { Form, Formik } from 'formik'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import { withAuthenticationRequired } from '@auth0/auth0-react'
 import clone from 'clone'
+import qs from 'qs'
 import React, { Component } from 'react'
 
 import * as formActions from '../../../actions/form'
@@ -69,11 +70,16 @@ class SavedTripScreen extends Component {
    * Initializes a monitored trip object from the props.
    */
   _createMonitoredTrip = () => {
-    const { homeTimezone, itinerary, loggedInUser, queryParams } = this.props
+    const { homeTimezone, itinerary, loggedInUser, otpQuery, queryParams } =
+      this.props
     const monitoredDays = getItineraryDefaultMonitoredDays(
       itinerary,
       homeTimezone
     )
+    const actualQueryParams = {
+      ...qs.parse(queryParams),
+      mode: otpQuery.variables.modes.join(',')
+    }
     return {
       ...arrayToDayFields(monitoredDays),
       arrivalVarianceMinutesThreshold: 5,
@@ -85,7 +91,7 @@ class SavedTripScreen extends Component {
       // when creating a monitored trip, the query params will be changed on the
       // backend so that the modes parameter will reflect the modes seen in the
       // itinerary
-      queryParams,
+      queryParams: qs.stringify(actualQueryParams),
       tripName: '',
       // FIXME: Handle populating/checking userID from middleware too,
       // so that providing this field is no longer needed.
@@ -243,10 +249,13 @@ class SavedTripScreen extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   const activeSearch = getActiveSearch(state)
+  console.log('active search', activeSearch)
   const activeItinerary = activeSearch && activeSearch.activeItinerary
   const pending = activeSearch ? Boolean(activeSearch.pending) : false
   const itineraries = getActiveItineraries(state) || []
   const tripId = ownProps.match.params.id
+  const otpQuery =
+    !pending && activeSearch?.response[activeItinerary - 1]?.query
   return {
     activeSearchId: state.otp.activeSearchId,
     homeTimezone: state.otp.config.homeTimezone,
@@ -254,6 +263,7 @@ const mapStateToProps = (state, ownProps) => {
     itinerary: itineraries[activeItinerary],
     loggedInUser: state.user.loggedInUser,
     monitoredTrips: state.user.loggedInUserMonitoredTrips,
+    otpQuery,
     pending,
     queryParams: state.router.location.search,
     tripId

--- a/lib/util/i18n.js
+++ b/lib/util/i18n.js
@@ -170,7 +170,7 @@ export function getDefaultLocale(config, loggedInUser) {
     window.localStorage.getItem('lang') || navigator.language
 
   return (
-    loggedInUser?.preferredLanguage ||
+    loggedInUser?.preferredLocale ||
     browserLocale ||
     localization.defaultLocale ||
     'en-US'


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR is against the mode selector branch to take advantage of improved graphql querying.

This PR makes the Save Trip screen send the correct itinerary to OTP-middleware for checking.

When requests are pending and itineraries are trickling in, the UI grabs the first one available as the itinerary to check. It might be a walk-only trip, which is incorrect. The PR makes the UI wait until all itineraries are fetched before displaying the desired one and setting that as the itinerary to check. This improvement is also applied to the narrative itineraries container so avoid superfluous renderings when the full itinerary is shown.

As a result, there should be ** fewer ** cases where the itinerary check results in no days available, compared to now.
Note that this PR does not address any issues with the middleware checking itineraries that could cause the remaining cases with no days available.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [na] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [na] Are all languages supported (Internationalization/Localization)?
- [na] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

