### PR TITLE
Support Custom Stop Color

### DIFF
--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -254,7 +254,7 @@ class DefaultMap extends Component {
     } = this.props
     const { getCustomMapOverlays, getTransitiveRouteLabel, ModeIcon } =
       this.context
-    const { baseLayers, maxZoom, overlays } = mapConfig || {}
+    const { baseLayers, mapColors, maxZoom, overlays } = mapConfig || {}
     const { lat, lon, zoom } = this.state
     const vectorTilesEndpoint = makeApiUrl(config, 'vectorTiles', {})
 
@@ -277,8 +277,6 @@ class DefaultMap extends Component {
     }))
     const baseLayerUrls = baseLayersWithNames?.map((bl) => bl.url)
     const baseLayerNames = baseLayersWithNames?.map((bl) => bl.name)
-
-    const stopsColor = config.map.mapColors.stopsColor
 
     return (
       <MapContainer className="percy-hide">
@@ -337,7 +335,10 @@ class DefaultMap extends Component {
                 return <ParkAndRideOverlay {...namedLayerProps} />
               case 'stops':
                 return (
-                  <StopsOverlay {...namedLayerProps} stopsColor={stopsColor} />
+                  <StopsOverlay
+                    {...namedLayerProps}
+                    stopsColor={mapColors.stopsColor}
+                  />
                 )
               case 'micromobility-rental':
                 return (

--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -278,6 +278,8 @@ class DefaultMap extends Component {
     const baseLayerUrls = baseLayersWithNames?.map((bl) => bl.url)
     const baseLayerNames = baseLayersWithNames?.map((bl) => bl.name)
 
+    const stopsColor = config.map.mapColors.stopsColor
+
     return (
       <MapContainer className="percy-hide">
         <BaseMap
@@ -334,7 +336,9 @@ class DefaultMap extends Component {
               case 'park-and-ride':
                 return <ParkAndRideOverlay {...namedLayerProps} />
               case 'stops':
-                return <StopsOverlay {...namedLayerProps} />
+                return (
+                  <StopsOverlay {...namedLayerProps} stopsColor={stopsColor} />
+                )
               case 'micromobility-rental':
                 return (
                   <VehicleRentalOverlay


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

Takes custom stop color from config and passes to OTP-UI map overlay

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [n/a] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [n/a] Are all languages supported (Internationalization/Localization)?
- [n/a] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

