### PR TITLE
(Mailables): Support Simultaneous Small and Large Print

### DIFF
--- a/lib/components/admin/mailables-window.js
+++ b/lib/components/admin/mailables-window.js
@@ -64,7 +64,6 @@ class SelectedMailable extends Component {
     const { index, mailable } = this.props
     const largeId = `largeFormat-${index}`
     const smallId = `smallFormat-${index}`
-    console.log(mailable)
     return (
       <SelectedMailableContainer>
         <MailableLabel mailable={mailable} />

--- a/lib/components/admin/mailables-window.js
+++ b/lib/components/admin/mailables-window.js
@@ -48,6 +48,11 @@ class SelectedMailable extends Component {
     updateField(index, 'largeFormat', evt.target.checked)
   }
 
+  _changeSmallFormat = (evt) => {
+    const { index, updateField } = this.props
+    updateField(index, 'smallFormat', evt.target.checked)
+  }
+
   _changeQuantity = (evt) => {
     const { index, updateField } = this.props
     updateField(index, 'quantity', evt.target.value)
@@ -57,7 +62,9 @@ class SelectedMailable extends Component {
 
   render() {
     const { index, mailable } = this.props
-    const id = `largeFormat-${index}`
+    const largeId = `largeFormat-${index}`
+    const smallId = `smallFormat-${index}`
+    console.log(mailable)
     return (
       <SelectedMailableContainer>
         <MailableLabel mailable={mailable} />
@@ -70,15 +77,26 @@ class SelectedMailable extends Component {
             type="number"
             value={mailable.quantity}
           />
+          <div style={{ marginTop: '5px' }}>
+            <input
+              checked={mailable.smallFormat}
+              id={smallId}
+              onChange={this._changeSmallFormat}
+              type="checkbox"
+            />
+            <label htmlFor={smallId} style={{ marginLeft: '5px' }}>
+              Small format?
+            </label>
+          </div>
           {mailable.largePrint && (
             <div style={{ marginTop: '5px' }}>
               <input
-                id={id}
+                checked={mailable.largeFormat}
+                id={largeId}
                 onChange={this._changeLargeFormat}
                 type="checkbox"
-                value={mailable.largeFormat}
               />
-              <label htmlFor={id} style={{ marginLeft: '5px' }}>
+              <label htmlFor={largeId} style={{ marginLeft: '5px' }}>
                 Large format?
               </label>
             </div>
@@ -107,7 +125,7 @@ class MailablesWindow extends Component {
   _addMailable = (mailable) => {
     if (!this.state.mailables.find((m) => m.name === mailable.name)) {
       const mailables = [...this.state.mailables]
-      mailables.push({ ...mailable, quantity: 1 })
+      mailables.push({ ...mailable, quantity: 1, smallFormat: true })
       this.setState({ mailables })
     }
   }

--- a/lib/util/mailables.js
+++ b/lib/util/mailables.js
@@ -113,13 +113,22 @@ async function writePDF(formData, imageData, otpConfig) {
 
   const tableData = {
     headers: ['Item', 'Quantity'],
-    rows: mailables.map((mailable) => {
-      let { largeFormat, largePrint, name, quantity } = mailable
-      if (largePrint && largeFormat) {
-        name += ' (LARGE PRINT)'
-      }
-      return [name, quantity]
-    })
+    rows: mailables
+      .map((mailable) => {
+        let { largeFormat, largePrint, name, quantity, smallFormat } = mailable
+        const rows = []
+
+        if (smallFormat) {
+          rows.push([name, quantity])
+        }
+
+        if (largePrint && largeFormat) {
+          name += ' (LARGE PRINT)'
+          rows.push([name, quantity])
+        }
+        return rows
+      })
+      .flat()
   }
 
   doc.table(tableData, {


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

The mailables large print feature currently disables the small print on the resulting pdf. This PR corrects this, allowing for simultaneous large and small prints. Unfortunately, there is no way to change the count for the second size. Not sure how best to solve this.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [no] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [no] Are all languages supported (Internationalization/Localization)?
- [no] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

