### PR TITLE
Route Row Background Color Indicates Active

### DIFF
--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -34,7 +34,8 @@ export const RouteRowButton = styled(Button)`
   width: 100%;
 
   &:before {
-    background-color: white;
+    background-color: ${(props) =>
+      props.patternActive ? '#0071d712' : 'white'};
     border-radius: 4px;
     content: '';
     height: 100%;
@@ -199,6 +200,7 @@ export class RouteRow extends PureComponent {
           onFocus={this._onFocusOrEnter}
           onMouseEnter={this._onFocusOrEnter}
           onTouchStart={this._onFocusOrEnter}
+          patternActive={isActive}
           title={routeMapToggleText}
         />
         <PatternButton


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

Route row now has a background color to indicate to users it is an active row. 

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [n/a] Are all languages supported (Internationalization/Localization)?
- [n/a] Are appropriate Typescript types implemented?

| Before | After |
|--------|-------|
|<img width="482" alt="image" src="https://github.com/opentripplanner/otp-react-redux/assets/115499534/50e18ba4-b14b-4d62-b992-37ee3788ac7c">|<img width="482" alt="image" src="https://github.com/opentripplanner/otp-react-redux/assets/115499534/593a1e8d-df1e-429e-9227-49ab44520fdc">|

