### PR TITLE
Fix grouped itineraries a11y and regressions

### DIFF
--- a/lib/actions/narrative.js
+++ b/lib/actions/narrative.js
@@ -12,6 +12,12 @@ export function setActiveItinerary(payload) {
     // Update URL params.
     const urlParams = coreUtils.query.getUrlParams()
     urlParams.ui_activeItinerary = payload.index
+    if (payload.index === -1 || payload.index === '-1') {
+      // Remove the ui_itineraryView param if changing to another itinerary.
+      // Note: set to undefined instead of deleting so that it merges with the other search params.
+      urlParams.ui_itineraryView = undefined
+    }
+
     dispatch(setUrlSearch(urlParams))
   }
 }

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -308,7 +308,12 @@ export function setItineraryView(value) {
     // set the desired ui query param
     // and store the current view as previousItineraryView.
     if (value !== urlParams.ui_itineraryView) {
-      urlParams.ui_itineraryView = value
+      if (value !== ItineraryView.LIST) {
+        urlParams.ui_itineraryView = value
+      } else if (urlParams.ui_itineraryView) {
+        // Remove the ui_itineraryView param if it is set to LIST (default).
+        delete urlParams.ui_itineraryView
+      }
 
       dispatch(setUrlSearch(urlParams))
       dispatch(setPreviousItineraryView(prevItineraryView))

--- a/lib/components/narrative/metro/metro-itinerary.tsx
+++ b/lib/components/narrative/metro/metro-itinerary.tsx
@@ -28,12 +28,14 @@ import ItineraryBody from '../line-itin/connected-itinerary-body'
 import NarrativeItinerary from '../narrative-itinerary'
 import SimpleRealtimeAnnotation from '../simple-realtime-annotation'
 
-import { DepartureTimesList } from './departure-times-list'
 import {
   getFirstTransitLegStop,
   getFlexAttirbutes,
   removeInsignifigantWalkLegs
 } from './attribute-utils'
+import DepartureTimesList, {
+  SetActiveItineraryHandler
+} from './departure-times-list'
 import MetroItineraryRoutes from './metro-itinerary-routes'
 import RouteBlock from './route-block'
 
@@ -191,7 +193,7 @@ type Props = {
   intl: IntlShape
   itinerary: Itinerary
   mini?: boolean
-  setActiveItinerary: () => void
+  setActiveItinerary: SetActiveItineraryHandler
   setActiveLeg: (leg: Leg) => void
   setItineraryView: (view: string) => void
   showRealtimeAnnotation: () => void
@@ -428,6 +430,7 @@ class MetroItinerary extends NarrativeItinerary {
                     <FormattedMessage id="components.MetroUI.leaveAt" />
                   )}{' '}
                   <DepartureTimesList
+                    expanded={expanded}
                     itinerary={itinerary}
                     setActiveItinerary={setActiveItinerary}
                     showArrivals={arrivesAt}

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -368,6 +368,21 @@ class NarrativeItineraries extends Component {
     )
   }
 
+  componentDidUpdate() {
+    // If set in URL, set the active itinerary in the state, once.
+    const { activeItinerary, activeSearch, setActiveItinerary } = this.props
+    const { ui_activeItinerary: uiActiveItinerary } =
+      coreUtils.query.getUrlParams() || {}
+    if (
+      activeSearch &&
+      uiActiveItinerary !== undefined &&
+      uiActiveItinerary !== '-1' &&
+      activeItinerary !== +uiActiveItinerary
+    ) {
+      setActiveItinerary({ index: +uiActiveItinerary })
+    }
+  }
+
   // eslint-disable-next-line complexity
   render() {
     const {

--- a/lib/components/narrative/utils.tsx
+++ b/lib/components/narrative/utils.tsx
@@ -42,24 +42,3 @@ export function localizeGradationMap(
   })
   return newGradationMap
 }
-
-/**
- * Takes the itinerary start time and returns a label for button title and
- * screen readers that indicates whether the departure time is based on realtime
- * or scheduled data.
- * @param intl React-Intl object
- * @param time Itinerary start time
- * @param realTime Whether the itinerary is based on realtime data
- * @returns string with time and realtime/schedule status
- */
-export const getDepartureLabelText = (
-  intl: IntlShape,
-  time: any,
-  realTime: boolean
-): string => {
-  return `${intl.formatTime(time)} ${
-    realTime
-      ? `(${intl.formatMessage({ id: 'components.StopTimeCell.realtime' })})`
-      : `(${intl.formatMessage({ id: 'components.StopTimeCell.scheduled' })})`
-  }`
-}


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

- Fix issue when clicking grouped departure times doesn't do anything.
- Reinstate a11y clickability when itinerary is not part of a group.
- Fix an issue when clicking "View all options" where the pane showed blank content.
- Fix regression where the `ui_activeItinerary` is not shown.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [na] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

