### PR TITLE
a11y button fixes

### DIFF
--- a/lib/components/narrative/trip-tools.js
+++ b/lib/components/narrative/trip-tools.js
@@ -17,6 +17,7 @@ import React, { Component, useContext, useMemo } from 'react'
 import * as uiActions from '../../actions/ui'
 import { ComponentContext } from '../../util/contexts'
 import { IconWithText } from '../util/styledIcon'
+import InvisibleA11yLabel from '../util/invisible-a11y-label'
 import PopupTriggerText from '../app/popup-trigger-text'
 import startOver from '../util/start-over'
 
@@ -55,6 +56,12 @@ class CopyUrlButton extends Component {
   render() {
     return (
       <div>
+        {/* Announces copy button status to AT */}
+        <InvisibleA11yLabel aria-live="assertive">
+          {this.state.showCopied && (
+            <FormattedMessage id="components.TripTools.linkCopied" />
+          )}
+        </InvisibleA11yLabel>
         <Button
           aria-live={this.state.showCopied ? 'assertive' : undefined}
           className="tool-button"

--- a/lib/components/narrative/trip-tools.js
+++ b/lib/components/narrative/trip-tools.js
@@ -62,11 +62,7 @@ class CopyUrlButton extends Component {
             <FormattedMessage id="components.TripTools.linkCopied" />
           )}
         </InvisibleA11yLabel>
-        <Button
-          aria-live={this.state.showCopied ? 'assertive' : undefined}
-          className="tool-button"
-          onClick={this._onClick}
-        >
+        <Button className="tool-button" onClick={this._onClick}>
           {this.state.showCopied ? (
             <span>
               <IconWithText Icon={Check}>

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -187,6 +187,7 @@ export class RouteRow extends PureComponent {
                   routeShortName: route?.shortName
                 }}
                 mode={getModeFromRoute(route)}
+                role="image"
                 width={28}
               />
             </ModeIconElement>


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
- Adds the role "image" to mode SVGs, to ensure the aria-labels aren't overlooked by AT
- Refactors "Copy Link" button `aria-live` to be more consistent across AT

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [n/a] Are appropriate Typescript types implemented?


