### PR TITLE
refactor(amenities-panel): don’t show vehicles not configured

### DIFF
--- a/lib/components/viewers/amenities-panel.tsx
+++ b/lib/components/viewers/amenities-panel.tsx
@@ -246,7 +246,7 @@ class AmenitiesPanel extends Component<Props, State> {
   }
 
   render() {
-    const { intl } = this.props
+    const { configCompanies, intl } = this.props
     const { expanded } = this.state
     return (
       <RelatedPanel
@@ -259,8 +259,16 @@ class AmenitiesPanel extends Component<Props, State> {
       >
         <ul className="related-items-list list-unstyled">
           {this._renderParkAndRides()}
-          {this._renderBikeRentalStations()}
-          {this._renderVehicleRentalStations()}
+          {!configCompanies ||
+            (configCompanies.find((company) =>
+              company.modes.includes('BICYCLE_RENT')
+            ) &&
+              this._renderBikeRentalStations())}
+          {!configCompanies ||
+            (configCompanies.find((company) =>
+              company.modes.includes('SCOOTER_RENT')
+            ) &&
+              this._renderVehicleRentalStations())}
         </ul>
       </RelatedPanel>
     )


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

<img width="368" alt="Screenshot 2023-07-07 at 4 31 36 PM" src="https://github.com/opentripplanner/otp-react-redux/assets/86619099/4fb879f1-f1ad-45b8-b4c0-1ec3dc07739e">
The nearby amenities panel currently shows "no scooter/bikes found" if there are none found. This is good, but can be confusing in a region with no scooters or bikes. This PR adjusts the behavior so the items only show up if scooter/bike companies are configured.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

