### PR TITLE
Return focus to feedback button on modal close

### DIFF
--- a/lib/components/app/app-menu-item.tsx
+++ b/lib/components/app/app-menu-item.tsx
@@ -75,6 +75,7 @@ export default class AppMenuItem extends Component<Props, State> {
         <Element
           aria-controls={subItems && containerId}
           aria-expanded={subItems && isExpanded}
+          className="navItem"
           id={id}
           onClick={subItems ? this._toggleSubmenu : onClick}
           onKeyDown={this._handleKeyDown}

--- a/lib/components/app/app-menu.tsx
+++ b/lib/components/app/app-menu.tsx
@@ -87,7 +87,6 @@ class AppMenu extends Component<
   _triggerPopup = () => {
     const { popupTarget, setPopupContent } = this.props
     setPopupContent(popupTarget)
-    this._togglePane()
   }
 
   _togglePane = () => {

--- a/lib/components/app/popup.tsx
+++ b/lib/components/app/popup.tsx
@@ -62,6 +62,21 @@ const PopupWrapper = ({ content, hideModal }: Props): JSX.Element | null => {
 
   const title = intl.formatMessage({ id: `config.popups.${id}` })
 
+  /* HACK: Since Bootstrap 3.x does not support adding id or name to navItem, 
+  we have to grab a list of all navItems by className and find the correct button.
+  Since the sliding pane "Leave Feedback" button will always be in the DOM after
+  the navbar button, reverse + find should always find the correct button to return to. */
+
+  const navItemList = Array.from(
+    document.getElementsByClassName('navItem')
+  ).reverse() as HTMLElement[]
+  const focusElement = navItemList.find((el) => el.innerText === title)
+
+  const closeModal = () => {
+    hideModal()
+    focusElement?.focus()
+  }
+
   return (
     <Modal
       aria-label={title}
@@ -74,7 +89,7 @@ const PopupWrapper = ({ content, hideModal }: Props): JSX.Element | null => {
       <CloseModalButton
         aria-label={closeText}
         className="clear-button-formatting close-button"
-        onClick={hideModal}
+        onClick={closeModal}
         title={closeText}
       >
         <StyledIconWrapper>

--- a/lib/components/app/popup.tsx
+++ b/lib/components/app/popup.tsx
@@ -81,8 +81,8 @@ const PopupWrapper = ({ content, hideModal }: Props): JSX.Element | null => {
     <Modal
       aria-label={title}
       dialogClassName="fullscreen-modal"
-      onEscapeKeyDown={hideModal}
-      onHide={hideModal}
+      onEscapeKeyDown={closeModal}
+      onHide={closeModal}
       role="presentation"
       show={shown}
     >

--- a/lib/components/app/popup.tsx
+++ b/lib/components/app/popup.tsx
@@ -1,7 +1,7 @@
 import { Modal } from 'react-bootstrap'
 import { useIntl } from 'react-intl'
 import coreUtils from '@opentripplanner/core-utils'
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect } from 'react'
 
 import { StyledIconWrapper } from '../util/styledIcon'
 import { Times } from '@styled-icons/fa-solid'
@@ -58,8 +58,6 @@ const PopupWrapper = ({ content, hideModal }: Props): JSX.Element | null => {
     }
   }, [compiledUrl, hideModal, useIframe, shown])
 
-  if (!compiledUrl || !useIframe) return null
-
   const title = intl.formatMessage({ id: `config.popups.${id}` })
 
   /* HACK: Since Bootstrap 3.x does not support adding id or name to navItem, 
@@ -72,10 +70,12 @@ const PopupWrapper = ({ content, hideModal }: Props): JSX.Element | null => {
   ).reverse() as HTMLElement[]
   const focusElement = navItemList.find((el) => el.innerText === title)
 
-  const closeModal = () => {
+  const closeModal = useCallback(() => {
     hideModal()
     focusElement?.focus()
-  }
+  }, [focusElement, hideModal])
+
+  if (!compiledUrl || !useIframe) return null
 
   return (
     <Modal

--- a/lib/components/app/popup.tsx
+++ b/lib/components/app/popup.tsx
@@ -65,6 +65,8 @@ const PopupWrapper = ({ content, hideModal }: Props): JSX.Element | null => {
   Since the sliding pane "Leave Feedback" button will always be in the DOM after
   the navbar button, reverse + find should always find the correct button to return to. */
 
+  // TODO: Replace this method with refs
+
   const navItemList = Array.from(
     document.getElementsByClassName('navItem')
   ).reverse() as HTMLElement[]


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

On modal close, focus resets to the button that the user pressed to open the modal, instead of resetting to the top of the page. 

Example: user presses the "Leave Feedback" button inside the sliding pane. With this PR, the sliding pane stays open on modal open, and when the user closes the modal, the focus is reset back to the "Leave feedback" button in the sliding pane.

This approach feels like a hack, so I'm very open to scrapping this in favor of another approach!

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?


