### PR TITLE
Fix: Add legend to mode selector fieldset

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -223,6 +223,7 @@ components:
     shortTitle: Plan Trip
   BatchSearchScreen:
     header: Plan Your Trip
+    modeSelectorLabel: Select a transit mode
   BatchSettings:
     dateTimeSettingsLabel: Date/Time Settings
     destination: destination

--- a/lib/components/form/batch-settings.tsx
+++ b/lib/components/form/batch-settings.tsx
@@ -211,6 +211,9 @@ function BatchSettings({
             accentColor={baseColor}
             activeHoverColor={accentColor.toHexString()}
             fillModeIcons={fillModeIcons}
+            label={intl.formatMessage({
+              id: 'components.BatchSearchScreen.modeSelectorLabel'
+            })}
             modeButtons={processedModeButtons}
             onSettingsUpdate={setUrlSearch}
             onToggleModeButton={_toggleModeButton}


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

Fixes accessibility issue where the mode selector `fieldset` was accompanied by an empty `legend`

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [n/a] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

