### PR TITLE
Fix: pass configurable layer props to overlays

### DIFF
--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -278,6 +278,10 @@ class DefaultMap extends Component {
     const baseLayerUrls = baseLayersWithNames?.map((bl) => bl.url)
     const baseLayerNames = baseLayersWithNames?.map((bl) => bl.name)
 
+    const overlayLayers = overlays.find(
+      (overlay) => overlay.type === 'otp2'
+    ).layers
+
     return (
       <MapContainer className="percy-hide">
         <BaseMap
@@ -307,7 +311,7 @@ class DefaultMap extends Component {
           <ElevationPointMarker />
 
           {/* The configurable overlays */}
-          {overlays?.map((overlayConfig, k) => {
+          {overlayLayers?.map((overlayConfig, k) => {
             const namedLayerProps = {
               ...overlayConfig,
               id: k,


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

The configuration structure changed with the introduction of the new mode selector. This refactors how the layer information is passed from the config.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [n/a] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [n/a] Are all languages supported (Internationalization/Localization)?
- [n/a] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

