### PR TITLE
Fix more i18n warnings

### DIFF
--- a/lib/components/app/app-menu.tsx
+++ b/lib/components/app/app-menu.tsx
@@ -45,7 +45,8 @@ type AppMenuProps = {
   callTakerEnabled?: boolean
   extraMenuItems?: MenuItem[]
   fieldTripEnabled?: boolean
-  // Typescript TODO language options based on configLanguage.
+  // Typescript TODO language and language options based on configLanguage.
+  language: Record<string, any> | null
   languageOptions: Record<string, any> | null
   location: { search: string }
   mailablesEnabled?: boolean
@@ -122,20 +123,11 @@ class AppMenu extends Component<
           skipLocales,
           subMenuDivider
         } = menuItem
-        const { activeLocale, intl, language } = this.props
-        let label = configLabel
-        const shouldCheckLocales =
-          !skipLocales && language[activeLocale]?.config?.menuItems?.[id]
-        if (shouldCheckLocales) {
-          const localizationId = `config.menuItems.${id}`
-          const localizedLabel = intl.formatMessage({
-            defaultMessage: localizationId,
-            id: localizationId
-          })
-          // Override the config label if a localized label exists
-          label =
-            localizedLabel === localizationId ? configLabel : localizedLabel
-        }
+        const { activeLocale, language } = this.props
+        const localizedLabel = language?.[activeLocale]?.config?.menuItems?.[id]
+        const useLocalizedLabel = !skipLocales && localizedLabel
+        // Override the config label if a localized label exists
+        const label = useLocalizedLabel ? localizedLabel : configLabel
 
         return (
           <AppMenuItem

--- a/lib/components/app/app-menu.tsx
+++ b/lib/components/app/app-menu.tsx
@@ -122,9 +122,10 @@ class AppMenu extends Component<
           skipLocales,
           subMenuDivider
         } = menuItem
-        const { intl } = this.props
+        const { activeLocale, intl, language } = this.props
         let label = configLabel
-        const shouldCheckLocales = !skipLocales
+        const shouldCheckLocales =
+          !skipLocales && language[activeLocale]?.config?.menuItems?.[id]
         if (shouldCheckLocales) {
           const localizationId = `config.menuItems.${id}`
           const localizedLabel = intl.formatMessage({


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR addresses some warnings seen in console about "Missing translation" for app menu items such as language names and service names that don't have translated content.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

