### PR TITLE
refactor(ResponsiveWebApp): Skip passing wrapper props to web app.

### DIFF
--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -366,16 +366,14 @@ class RouterWrapperWithAuth0 extends Component {
                         }
                         key={index}
                         render={
-                          shouldRenderWebApp
-                            ? () => <WebappWithRouter {...this.props} />
-                            : undefined
+                          shouldRenderWebApp ? WebappWithRouter : undefined
                         }
                         {...routerProps}
                       />
                     )
                   })}
                   {/* For any other route, simply return the web app. */}
-                  <Route render={() => <WebappWithRouter {...this.props} />} />
+                  <Route render={WebappWithRouter} />
                 </Switch>
               </QueryParamProvider>
             </ConnectedRouter>


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

A simple refactor. The props from the route wrapper are not used by the web app component.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

