### PR TITLE
Fix: Create mode strings consistently across i18n

### DIFF
--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -427,12 +427,12 @@ class NarrativeItineraries extends Component {
         })
 
         // We determine which "bucket" to put this itinerary into based on what
-        // is currently a hack hack hack: looking at the presence of a space
+        // is currently a hack hack hack: looking at the presence of a "+"
         // in the mode string.
         //
         // Another approach may be cleaner, but this includes the least overhead
         const modeContainer =
-          modeString.indexOf(' ') > -1 ? modeItinMap.multi : modeItinMap.single
+          modeString.indexOf('+') > -1 ? modeItinMap.multi : modeItinMap.single
 
         // Now that we know the mode container to place our itinerary in, we do so
         if (!modeContainer[modeString]) modeContainer[modeString] = []

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -2,7 +2,7 @@
 import { connect } from 'react-redux'
 import { differenceInDays } from 'date-fns'
 import { FormattedMessage, injectIntl } from 'react-intl'
-import { isFlex } from '@opentripplanner/core-utils/lib/itinerary'
+import { isFlex, isTransit } from '@opentripplanner/core-utils/lib/itinerary'
 import clone from 'clone'
 import coreUtils from '@opentripplanner/core-utils'
 import PropTypes from 'prop-types'
@@ -426,13 +426,18 @@ class NarrativeItineraries extends Component {
           itinerary: cur
         })
 
+        const containsTransit = cur.legs
+          .map((leg) => isTransit(leg.mode))
+          .includes(true)
+
         // We determine which "bucket" to put this itinerary into based on what
         // is currently a hack hack hack: looking at the presence of a "+"
         // in the mode string.
         //
         // Another approach may be cleaner, but this includes the least overhead
-        const modeContainer =
-          modeString.indexOf('+') > -1 ? modeItinMap.multi : modeItinMap.single
+        const modeContainer = containsTransit
+          ? modeItinMap.multi
+          : modeItinMap.single
 
         // Now that we know the mode container to place our itinerary in, we do so
         if (!modeContainer[modeString]) modeContainer[modeString] = []

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -427,13 +427,10 @@ class NarrativeItineraries extends Component {
         })
 
         // Identify whether an itinerary uses transit & sort into appropriate bucket
-        const containsTransit = cur.legs
-          .map((leg) => isTransit(leg.mode))
-          .includes(true)
+        const transitLegs = cur.legs.filter((leg) => isTransit(leg.mode))
 
-        const modeContainer = containsTransit
-          ? modeItinMap.multi
-          : modeItinMap.single
+        const modeContainer =
+          transitLegs.length > 0 ? modeItinMap.multi : modeItinMap.single
 
         // Now that we know the mode container to place our itinerary in, we do so
         if (!modeContainer[modeString]) modeContainer[modeString] = []

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -426,15 +426,11 @@ class NarrativeItineraries extends Component {
           itinerary: cur
         })
 
+        // Identify whether an itinerary uses transit & sort into appropriate bucket
         const containsTransit = cur.legs
           .map((leg) => isTransit(leg.mode))
           .includes(true)
 
-        // We determine which "bucket" to put this itinerary into based on what
-        // is currently a hack hack hack: looking at the presence of a "+"
-        // in the mode string.
-        //
-        // Another approach may be cleaner, but this includes the least overhead
         const modeContainer = containsTransit
           ? modeItinMap.multi
           : modeItinMap.single


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

Sorting itineraries by filtering based on a space inadvertently sorts itineraries differently in different languages. Example: 

| English | French |
|--------|-------|
|<img width="250" alt="image" src="https://github.com/opentripplanner/otp-react-redux/assets/115499534/839c0bef-a39d-4d2f-9db7-a9f5c1943ae7">|<img width="250" alt="image" src="https://github.com/opentripplanner/otp-react-redux/assets/115499534/4bac6bdc-1b47-4d67-bfe4-e87260499ce5">| 

This PR instead sorts based on the presence of a plus sign, which should be a little more consistent although perhaps we may want to sort regardless of the mode string naming convention, in case that changes!

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [n/a] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [n/a] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

