### PR TITLE
fix(BatchSettings): Set time to now before searching if leaving now.

### DIFF
--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -176,6 +176,21 @@ export function checkShouldReplanTrip(autoPlan, isMobile, oldQuery, newQuery) {
 }
 
 /**
+ * If departArrive is set to 'NOW', update the query time to current
+ */
+export function updateQueryTimeIfLeavingNow() {
+  return function (dispatch, getState) {
+    const state = getState()
+    const { config, currentQuery } = state.otp
+    const { homeTimezone } = config
+    if (currentQuery.departArrive === 'NOW') {
+      const now = coreUtils.time.getCurrentTime(homeTimezone)
+      dispatch(settingQueryParam({ time: now }))
+    }
+  }
+}
+
+/**
  * This action is dispatched when a change between the old query and new query
  * is detected. It handles checks for whether the trip should be replanned
  * (based on autoPlan strategies) as well as updating the UI state (esp. for
@@ -184,16 +199,14 @@ export function checkShouldReplanTrip(autoPlan, isMobile, oldQuery, newQuery) {
 export function formChanged(oldQuery, newQuery) {
   return function (dispatch, getState) {
     const state = getState()
-    const { config, currentQuery, ui } = state.otp
-    const { autoPlan, debouncePlanTimeMs, homeTimezone } = config
+    const { config, ui } = state.otp
+    const { autoPlan, debouncePlanTimeMs } = config
     const isMobile = coreUtils.ui.isMobile()
     const { fromChanged, oneLocationChanged, shouldReplanTrip, toChanged } =
       checkShouldReplanTrip(autoPlan, isMobile, oldQuery, newQuery)
-    // If departArrive is set to 'NOW', update the query time to current
-    if (currentQuery.departArrive === 'NOW') {
-      const now = coreUtils.time.getCurrentTime(homeTimezone)
-      dispatch(settingQueryParam({ time: now }))
-    }
+
+    dispatch(updateQueryTimeIfLeavingNow())
+
     // Only clear the main panel if a single location changed. This prevents
     // clearing the panel on load if the app is focused on a stop viewer but a
     // search query should also be visible.

--- a/lib/components/form/batch-settings.tsx
+++ b/lib/components/form/batch-settings.tsx
@@ -55,6 +55,7 @@ type Props = {
   routingQuery: any
   setUrlSearch: (evt: any) => void
   spacedOutModeSelector?: boolean
+  updateQueryTimeIfLeavingNow: () => void
   urlSearchParams: URLSearchParams
 }
 
@@ -86,7 +87,8 @@ function BatchSettings({
   onPlanTripClick,
   routingQuery,
   setUrlSearch,
-  spacedOutModeSelector
+  spacedOutModeSelector,
+  updateQueryTimeIfLeavingNow
 }: Props) {
   const intl = useIntl()
 
@@ -165,8 +167,15 @@ function BatchSettings({
     setDateTimeExpanded(false)
 
     // Plan trip.
+    updateQueryTimeIfLeavingNow()
     routingQuery()
-  }, [currentQuery, intl, onPlanTripClick, routingQuery])
+  }, [
+    currentQuery,
+    intl,
+    onPlanTripClick,
+    routingQuery,
+    updateQueryTimeIfLeavingNow
+  ])
 
   const _toggleModeButton = useCallback(
     (buttonId: string, newState: boolean) => {
@@ -277,7 +286,8 @@ const mapStateToProps = (state: any) => {
 
 const mapDispatchToProps = {
   routingQuery: apiActions.routingQuery,
-  setUrlSearch: apiActions.setUrlSearch
+  setUrlSearch: apiActions.setUrlSearch,
+  updateQueryTimeIfLeavingNow: formActions.updateQueryTimeIfLeavingNow
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(BatchSettings)


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR updates the departure time to the current local time just before performing an itinerary search, if the departure setting is set to "Leave now". Applies to `BatchSettings` only.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

