### PR TITLE
Fix endpoint save links

### DIFF
--- a/__tests__/util/user.js
+++ b/__tests__/util/user.js
@@ -9,7 +9,6 @@ describe('util > user', () => {
         expected: {
           address: '123 Main street',
           icon: 'home',
-          id: 'id123',
           lat: 12,
           lon: 34,
           name: '123 Main street',
@@ -28,7 +27,7 @@ describe('util > user', () => {
         expected: {
           address: '123 Main street',
           icon: 'briefcase',
-          id: 'id123',
+
           lat: 12,
           lon: 34,
           name: '123 Main street',

--- a/lib/components/form/user-settings.js
+++ b/lib/components/form/user-settings.js
@@ -211,7 +211,6 @@ class UserSettings extends Component {
   }
 
   render() {
-    console.log('user settings render')
     const {
       className = '',
       forgetSearch,

--- a/lib/components/form/user-settings.js
+++ b/lib/components/form/user-settings.js
@@ -184,7 +184,11 @@ class UserSettings extends Component {
 
   _getLocations = (user) => {
     const locations = [...user.savedLocations]
-    if (!locations.find(isWork)) {
+
+    const workLocation = locations.find(isWork)
+    if (workLocation) {
+      if (!workLocation.address) workLocation.address = workLocation.name
+    } else {
       locations.push({
         address: '',
         icon: 'briefcase',
@@ -192,7 +196,10 @@ class UserSettings extends Component {
         type: 'work'
       })
     }
-    if (!locations.find(isHome)) {
+    const homeLocation = locations.find(isHome)
+    if (homeLocation) {
+      if (!homeLocation.address) homeLocation.address = homeLocation.name
+    } else {
       locations.push({
         address: '',
         icon: 'home',
@@ -209,6 +216,7 @@ class UserSettings extends Component {
   }
 
   render() {
+    console.log('user settings render')
     const {
       className = '',
       forgetSearch,

--- a/lib/components/form/user-settings.js
+++ b/lib/components/form/user-settings.js
@@ -70,6 +70,8 @@ function formatElapsedTime(timestamp, intl) {
 function addOrEditPlaceIfNeeded(locations, type, icon) {
   const editedLocation = locations.find((loc) => loc.type === type)
   if (editedLocation) {
+    // Define the address field, if not already set, so that the place appears as non-blank in the main pane
+    // (i.e. so that the address is shown instead of "Set your home/work location").
     if (!editedLocation.address) editedLocation.address = editedLocation.name
   } else {
     locations.push({

--- a/lib/components/form/user-settings.js
+++ b/lib/components/form/user-settings.js
@@ -14,9 +14,7 @@ import * as userActions from '../../actions/user'
 import {
   getPlaceDetail,
   getPlaceMainText,
-  isHome,
-  isOtpMiddleware,
-  isWork
+  isOtpMiddleware
 } from '../../util/user'
 import { LinkWithQuery } from '../form/connected-links'
 import { StyledMainPanelPlace } from '../user/places/styled'
@@ -63,6 +61,24 @@ function formatElapsedTime(timestamp, intl) {
   }
 
   return intl.formatMessage({ id: 'common.time.durationAgo' }, { duration })
+}
+
+/**
+ * Helper to ensure the home and work locations are correctly populated,
+ * or a placeholder is created.
+ */
+function addOrEditPlaceIfNeeded(locations, type, icon) {
+  const editedLocation = locations.find((loc) => loc.type === type)
+  if (editedLocation) {
+    if (!editedLocation.address) editedLocation.address = editedLocation.name
+  } else {
+    locations.push({
+      address: '',
+      icon,
+      id: type,
+      type
+    })
+  }
 }
 
 class UserSettings extends Component {
@@ -184,29 +200,8 @@ class UserSettings extends Component {
 
   _getLocations = (user) => {
     const locations = [...user.savedLocations]
-
-    const workLocation = locations.find(isWork)
-    if (workLocation) {
-      if (!workLocation.address) workLocation.address = workLocation.name
-    } else {
-      locations.push({
-        address: '',
-        icon: 'briefcase',
-        id: 'work',
-        type: 'work'
-      })
-    }
-    const homeLocation = locations.find(isHome)
-    if (homeLocation) {
-      if (!homeLocation.address) homeLocation.address = homeLocation.name
-    } else {
-      locations.push({
-        address: '',
-        icon: 'home',
-        id: 'home',
-        type: 'home'
-      })
-    }
+    addOrEditPlaceIfNeeded(locations, 'home', 'home')
+    addOrEditPlaceIfNeeded(locations, 'work', 'briefcase')
     return locations
   }
 

--- a/lib/util/user.js
+++ b/lib/util/user.js
@@ -113,11 +113,10 @@ export function getPersistenceMode(persistence) {
  * - The address attribute is filled with the 'name' if available.
  */
 export function convertToPlace(location) {
-  const { icon, id, lat, lon, name, type } = location
+  const { icon, lat, lon, name, type } = location
   return {
     address: name,
     icon: isWork(location) ? 'briefcase' : icon,
-    id,
     lat,
     lon,
     name,


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR brings a fix so that when you click "Save as/Forget home/work" from an endpoint on the map, the resulting saved locations are correctly shown in the main pane under "My saved places" and in the account page under "Favorite Locations".

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

