### PR TITLE
fix(default-itin): fix crash when currency is undefined

### DIFF
--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -34,8 +34,13 @@ import { FlexIndicator } from './flex-indicator'
 import { ItineraryDescription } from './itinerary-description'
 import ItinerarySummary from './itinerary-summary'
 
-const { isAdvanceBookingRequired, isCoordinationRequired, isFlex, isTransit } =
-  coreUtils.itinerary
+const {
+  getItineraryCost,
+  isAdvanceBookingRequired,
+  isCoordinationRequired,
+  isFlex,
+  isTransit
+} = coreUtils.itinerary
 
 // Styled components
 const LegIconWrapper = styled.div`
@@ -117,21 +122,27 @@ const ITINERARY_ATTRIBUTES = [
     order: 2,
     render: (itinerary, options, defaultFareType) => {
       const fare = getTotalFare(itinerary, options.configCosts, defaultFareType)
-      if (fare === null || fare === undefined || fare < 0) {
+      const currency = getItineraryCost(
+        itinerary.legs,
+        defaultFareType.mediumId,
+        defaultFareType.riderCategoryId
+      )?.currency
+
+      if (
+        fare === null ||
+        fare === undefined ||
+        fare < 0 ||
+        currency === undefined
+      ) {
         return (
           <FormattedMessage id="common.itineraryDescriptions.fareUnknown" />
         )
       }
 
-      const { currency } = coreUtils.itinerary.getItineraryCost(
-        itinerary.legs,
-        defaultFareType.mediumId,
-        defaultFareType.riderCategoryId
-      )
       return (
         <FormattedNumber
           // Currency from itinerary fare or from config.
-          currency={currency}
+          currency={currency.code}
           currencyDisplay="narrowSymbol"
           // eslint-disable-next-line react/style-prop-object
           style="currency"


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Default itinerary had a bug that caused a crash when the currency was undefined. This is now handled correctly.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

