### PR TITLE
fix(RoutePreviewOverlay): Recenter map when overlay is shown.

### DIFF
--- a/lib/components/map/route-preview-overlay.tsx
+++ b/lib/components/map/route-preview-overlay.tsx
@@ -1,8 +1,9 @@
 import { connect } from 'react-redux'
-import { Itinerary } from '@opentripplanner/types'
-import { Layer, Source } from 'react-map-gl'
+import { getFitBoundsPadding } from '@opentripplanner/base-map/lib/util'
+import { Itinerary, Location } from '@opentripplanner/types'
+import { Layer, Source, useMap } from 'react-map-gl'
 import polyline from '@mapbox/polyline'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 import {
   getActiveItinerary,
@@ -11,14 +12,27 @@ import {
 } from '../../util/state'
 
 type Props = {
+  from: Location
   geometries: string[]
+  to: Location
   visible?: boolean
 }
 /**
  * This overlay will display thin gray lines for a set of geometries. It's to be used
  * as a stopgap until we make full use of Transitive!
  */
-const RoutePreviewOverlay = ({ geometries, visible }: Props) => {
+const RoutePreviewOverlay = ({ from, geometries, to, visible }: Props) => {
+  // Center the map over the endpoints when this overlay is shown.
+  const { current: map } = useMap()
+  useEffect(() => {
+    if (visible) {
+      map?.fitBounds([from, to], {
+        duration: 500,
+        padding: getFitBoundsPadding(map, 0.2)
+      })
+    }
+  }, [map, visible, from, to])
+
   if (!geometries || !visible) return <></>
 
   const uniqueGeometries = Array.from(new Set(geometries))
@@ -72,16 +86,23 @@ const mapStateToProps = (state: any) => {
   const visibleItinerary = getVisibleItineraryIndex(state)
   const activeItinerary = getActiveItinerary(state)
 
+  const activeSearch = getActiveSearch(state)
   // @ts-expect-error state is not typed
-  const geometries = getActiveSearch(state)?.response.flatMap(
+  const geometries = activeSearch?.response.flatMap(
     (serverResponse: { plan?: { itineraries?: Itinerary[] } }) =>
       serverResponse?.plan?.itineraries?.flatMap((itinerary) => {
         return itinerary.legs?.map((leg) => leg.legGeometry.points)
       })
   )
 
+  // @ts-expect-error state is not typed
+  const query = activeSearch ? activeSearch?.query : state.otp.currentQuery
+  const { from, to } = query
+
   return {
+    from,
     geometries,
+    to,
     visible:
       // We need an explicit check for undefined and null because 0
       // is for us true


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR makes the map center on the endpoints when the `RoutePreviewOverlay` is shown, but is that too much?

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [na] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [na] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

