### PR TITLE
CallTaker: support persisting call taker mode to URL

### DIFF
--- a/lib/components/form/call-taker/mode-dropdown.tsx
+++ b/lib/components/form/call-taker/mode-dropdown.tsx
@@ -52,7 +52,7 @@ function ModeDropdown({ modeDropdownOptions, onChangeModes }: Props) {
       onBlur={onChange}
       onChange={onChange}
       value={
-        typeof selectedMode === 'string' && selectedMode !== undefined
+        typeof selectedMode === 'string'
           ? selectedMode
           : modeDropdownOptions?.[0].label
       }

--- a/lib/components/form/call-taker/mode-dropdown.tsx
+++ b/lib/components/form/call-taker/mode-dropdown.tsx
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import { TransportMode } from '@opentripplanner/types'
-import React, { useState } from 'react'
+import { useQueryParam } from 'use-query-params'
+import React, { useEffect } from 'react'
 
 import { defaultDropdownConfig } from '../../../util/call-taker'
 import { getModuleConfig, Modules } from '../../../util/config'
@@ -23,21 +24,39 @@ type Props = {
  * rental companies).
  */
 function ModeDropdown({ modeDropdownOptions, onChangeModes }: Props) {
-  const [selectedMode, setSelectedMode] = useState(modeDropdownOptions[0].label)
+  const [selectedMode, setSelectedMode] = useQueryParam(
+    modeDropdownOptions[0].label
+  )
 
   const onChange = React.useCallback(
     (e: React.FocusEvent<HTMLSelectElement>) => {
       setSelectedMode(e.target.value)
-      const newModes = modeDropdownOptions.find(
-        (mdo) => mdo.label === e.target.value
-      )?.combination
-      onChangeModes(newModes || [])
     },
     []
   )
 
+  useEffect(() => {
+    if (selectedMode === undefined) {
+      setSelectedMode(modeDropdownOptions?.[0].label)
+      return
+    }
+
+    const newModes = modeDropdownOptions.find(
+      (mdo) => mdo.label === selectedMode
+    )?.combination
+    onChangeModes(newModes || [])
+  }, [selectedMode, modeDropdownOptions, onChangeModes])
+
   return (
-    <select onBlur={onChange} onChange={onChange} value={selectedMode}>
+    <select
+      onBlur={onChange}
+      onChange={onChange}
+      value={
+        typeof selectedMode === 'string' && selectedMode !== undefined
+          ? selectedMode
+          : modeDropdownOptions?.[0].label
+      }
+    >
       {modeDropdownOptions?.map((o) => (
         <option key={o.label} value={o.label}>
           {o.label}


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

Calltaker mode selector wasn't persisting its state to the URL. This PR resolves this. It doesn't use the main URL parameter handler. Instead, it uses the `userQueryParam`

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

