### PR TITLE
Pass mode setting overrides from config

### DIFF
--- a/lib/components/form/batch-settings.tsx
+++ b/lib/components/form/batch-settings.tsx
@@ -55,6 +55,7 @@ type Props = {
   routingQuery: any
   setUrlSearch: (evt: any) => void
   spacedOutModeSelector?: boolean
+  subsettingOverrides: any
   urlSearchParams: URLSearchParams
 }
 
@@ -86,7 +87,8 @@ function BatchSettings({
   onPlanTripClick,
   routingQuery,
   setUrlSearch,
-  spacedOutModeSelector
+  spacedOutModeSelector,
+  subsettingOverrides
 }: Props) {
   const intl = useIntl()
 
@@ -217,6 +219,7 @@ function BatchSettings({
             modeButtons={processedModeButtons}
             onSettingsUpdate={setUrlSearch}
             onToggleModeButton={_toggleModeButton}
+            subsettingOverrides={subsettingOverrides}
           />
           <PlanTripButton
             id="plan-trip"
@@ -271,6 +274,7 @@ const mapStateToProps = (state: any) => {
     modeSettingDefinitions: state.otp?.modeSettingDefinitions || [],
     modeSettingValues,
     spacedOutModeSelector: state.otp?.config?.modes?.spacedOut,
+    subsettingOverrides: state.otp?.config?.modes?.subsettingOverrides,
     urlSearchParams
   }
 }


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Pass `subsettingOverrides` from config to Mode Selector component. Connects to https://github.com/opentripplanner/otp-ui/pull/631

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [n/a] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [n/a] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

