### PR TITLE
fix(DateTimeButton): Retain popup while typing in the date/time fields.

### DIFF
--- a/lib/components/form/date-time-button.tsx
+++ b/lib/components/form/date-time-button.tsx
@@ -148,17 +148,14 @@ export default function DateTimeButton({
   )
 
   return (
-    <ButtonWrapper
-      {...spanInteractionProps}
-      // This will trigger mouse effects such as showing popup on hover of on check.
-      ref={reference}
-      style={style}
-    >
+    <ButtonWrapper style={style}>
       <button
         {...interactionProps}
         // Separate handler to communicate to the parent element
         // which item had a popup triggered using the keyboard.
         onClick={handleButtonClick}
+        // This will trigger mouse effects such as showing popup on hover of on check.
+        ref={reference}
         // Required by linter settings
         type="button"
       >
@@ -168,7 +165,9 @@ export default function DateTimeButton({
           </span>
           {' - '}
         </InvisibleA11yLabel>
-        <DateTimePreview />
+        <span {...spanInteractionProps}>
+          <DateTimePreview />
+        </span>
       </button>
       {open && (
         <FloatingFocusManager


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR keeps the date/time popup open while hovering on the `DateTimeButton` then clicking on the date or time fields (the popup would previously disappear).

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

