### PR TITLE
Fix itinerary order

### DIFF
--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -919,7 +919,7 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
 
     dispatch(setItineraryView(ItineraryView.LIST))
 
-    combinations.forEach((combo) => {
+    combinations.forEach((combo, index) => {
       const query = generateOtp2Query(combo)
       dispatch(
         createGraphQLQueryAction(
@@ -982,6 +982,7 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
               }
 
               return {
+                index,
                 response: {
                   plan: {
                     ...response.data?.plan,

--- a/lib/actions/field-trip.js
+++ b/lib/actions/field-trip.js
@@ -687,7 +687,7 @@ function checkValidityAndCapacity(state, request) {
 
     // iterate through itineraries to check validity and assign field trip
     // groups
-    response.plan.itineraries.forEach((itinerary) => {
+    response.plan.itineraries.forEach((itinerary, itinIdx) => {
       let itineraryCapacity = Number.POSITIVE_INFINITY
 
       // check each individual trip to see if there aren't any trips in this
@@ -744,12 +744,13 @@ function checkValidityAndCapacity(state, request) {
         // A field trip response is guaranteed to have only one itinerary, so it
         // ok to set the itinerary by response as an array with a single
         // itinerary.
-        assignedItinerariesByResponse[responseIdx] = [
-          {
-            ...itinerary,
-            fieldTripGroupSize: Math.min(itineraryCapacity, remainingGroupSize)
-          }
-        ]
+        if (!assignedItinerariesByResponse[responseIdx]) {
+          assignedItinerariesByResponse[responseIdx] = {}
+        }
+        assignedItinerariesByResponse[responseIdx][itinIdx] = {
+          ...itinerary,
+          fieldTripGroupSize: Math.min(itineraryCapacity, remainingGroupSize)
+        }
         remainingGroupSize -= itineraryCapacity
       }
     })
@@ -844,8 +845,12 @@ function makeFieldTripPlanRequests(request, outbound, intl) {
         // I do not believe that it is worth the effort. I am instead in favor of
         // re-building field trip from the ground up as a separate application.
         setInterval(() => {
-          const activeItineraries = getActiveItineraries(getState())
-          if (activeItineraries.length >= numRequests) {
+          const searchResponse = getState().otp.searches[searchId]?.response
+          const activeItineraries =
+            searchResponse?.reduce((prev, resp) => {
+              return (prev += resp?.plan?.itineraries?.length || 0)
+            }, 0) || 0
+          if (activeItineraries >= numRequests) {
             resolve()
           }
         }, 20)

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -560,7 +560,7 @@ class NarrativeItineraries extends Component {
 }
 
 const reduceErrorsFromResponse = (acc, cur) => {
-  const { routingErrors } = cur?.plan
+  const { routingErrors } = cur?.plan || {}
   if (routingErrors) {
     routingErrors.forEach((routingError) => {
       const { code, inputField } = routingError

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -327,12 +327,31 @@ function createOtpReducer(config) {
               pending: { $set: activeSearch?.pending - 1 },
               response:
                 action.payload.index !== undefined
-                  ? {
-                      [action.payload.index]: {
-                        $set: response
+                  ? state.searches[searchId].response?.[action.payload.index]
+                    ? {
+                        // Field Trip may make multiple requests, one itinerary at a time,
+                        // to divide up large groups. In that case, append the itineraries to the plan array
+                        // at the indicated response index, as if multiple itineraries were returned in one request.
+                        [action.payload.index]: {
+                          plan: {
+                            itineraries: {
+                              $push: [...response.plan.itineraries]
+                            }
+                          }
+                        }
                       }
+                    : {
+                        // Accommodate regular mode combination responses in the order they were requested
+                        // to ensure that the response order remains the same if doing the same search again.
+                        [action.payload.index]: {
+                          $set: response
+                        }
+                      }
+                  : {
+                      // If queries were made outside of mode combinations, just add the responses
+                      // in the order they are received (order may change if doing the same search again).
+                      $push: [response]
                     }
-                  : { $push: [response] }
             }
           },
           ui: {
@@ -353,55 +372,34 @@ function createOtpReducer(config) {
           }
         })
       case 'SET_PENDING_REQUESTS':
-        if (state.searches[searchId]) {
-          return update(state, {
-            searches: {
-              [searchId]: {
-                pending: { $set: action.payload?.pending }
-              }
-            }
-          })
-        }
         return update(state, {
           searches: {
             [searchId]: {
-              $set: {
-                pending: action.payload?.pending
-              }
+              pending: { $set: action.payload?.pending }
             }
           }
         })
       case 'SET_ACTIVE_ITINERARIES':
         const responseUpdate = {}
-        const responseSet = []
         Object.entries(action.payload.assignedItinerariesByResponse).forEach(
           ([responseIdx, responsePlanItineraries]) => {
-            const responsePart = {
+            responseUpdate[responseIdx] = {
               plan: {
-                itineraries: responsePlanItineraries
+                itineraries: Object.entries(responsePlanItineraries).reduce(
+                  (prev, [itinIdx, itin]) => {
+                    prev[itinIdx] = { $set: itin }
+                    return prev
+                  },
+                  {}
+                )
               }
             }
-            responseUpdate[responseIdx] = {
-              $set: responsePart
-            }
-            responseSet[responseIdx] = responsePart
           }
         )
-        if (state.searches[searchId]?.response) {
-          return update(state, {
-            searches: {
-              [searchId]: {
-                response: responseUpdate
-              }
-            }
-          })
-        }
         return update(state, {
           searches: {
             [searchId]: {
-              $set: {
-                response: responseSet
-              }
+              response: responseUpdate
             }
           }
         })

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -325,7 +325,14 @@ function createOtpReducer(config) {
           searches: {
             [searchId]: {
               pending: { $set: activeSearch?.pending - 1 },
-              response: { $push: [response] }
+              response:
+                action.payload.index !== undefined
+                  ? {
+                      [action.payload.index]: {
+                        $set: response
+                      }
+                    }
+                  : { $push: [response] }
             }
           },
           ui: {

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -353,30 +353,55 @@ function createOtpReducer(config) {
           }
         })
       case 'SET_PENDING_REQUESTS':
+        if (state.searches[searchId]) {
+          return update(state, {
+            searches: {
+              [searchId]: {
+                pending: { $set: action.payload?.pending }
+              }
+            }
+          })
+        }
         return update(state, {
           searches: {
             [searchId]: {
-              pending: { $set: action.payload?.pending }
+              $set: {
+                pending: action.payload?.pending
+              }
             }
           }
         })
       case 'SET_ACTIVE_ITINERARIES':
         const responseUpdate = {}
+        const responseSet = []
         Object.entries(action.payload.assignedItinerariesByResponse).forEach(
           ([responseIdx, responsePlanItineraries]) => {
-            responseUpdate[responseIdx] = {
+            const responsePart = {
               plan: {
-                itineraries: {
-                  $set: responsePlanItineraries
-                }
+                itineraries: responsePlanItineraries
               }
             }
+            responseUpdate[responseIdx] = {
+              $set: responsePart
+            }
+            responseSet[responseIdx] = responsePart
           }
         )
+        if (state.searches[searchId]?.response) {
+          return update(state, {
+            searches: {
+              [searchId]: {
+                response: responseUpdate
+              }
+            }
+          })
+        }
         return update(state, {
           searches: {
             [searchId]: {
-              response: responseUpdate
+              $set: {
+                response: responseSet
+              }
             }
           }
         })


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

Responses for the different mode combinations requested to OTP were stored in the order they are returned.
The order of the responses could change when performing the same search again.

This PR ensures that the responses are stored in the same order as the mode combinations sent to OTP,
and also preserves (and fixes some) itinerary searches functionality with the Field Trip module.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [na] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [na] Are all languages supported (Internationalization/Localization)?
- [na] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

