### PR TITLE
Remove OTP1 Stop Time Filtering

### DIFF
--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -1252,6 +1252,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                         >
                           <injectIntl(PatternRow)
                             homeTimezone="America/Los_Angeles"
+                            key="TriMet:20:1:04"
                             pattern={
                               Object {
                                 "desc": "20 to Gresham Transit Center (TriMet:8199) from Beaverton Transit Center (TriMet:9978) express",
@@ -3924,6 +3925,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                           </p>
                           <injectIntl(PatternRow)
                             homeTimezone="America/Los_Angeles"
+                            key="TriMet:20:1:04"
                             pattern={
                               Object {
                                 "desc": "20 to Gresham Transit Center (TriMet:8199) from Beaverton Transit Center (TriMet:9978) express",
@@ -6031,6 +6033,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                           </p>
                           <injectIntl(PatternRow)
                             homeTimezone="America/Los_Angeles"
+                            key="TriMet:20:1:04"
                             pattern={
                               Object {
                                 "desc": "20 to Gresham Transit Center (TriMet:8199) from Beaverton Transit Center (TriMet:9978) express",
@@ -9803,6 +9806,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                           </p>
                           <injectIntl(PatternRow)
                             homeTimezone="America/Los_Angeles"
+                            key="TriMet:20:1:04"
                             pattern={
                               Object {
                                 "desc": "20 to Gresham Transit Center (TriMet:8199) from Beaverton Transit Center (TriMet:9978) express",
@@ -10642,6 +10646,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                           </p>
                           <injectIntl(PatternRow)
                             homeTimezone="America/Los_Angeles"
+                            key="TriMet:94:0:04"
                             pattern={
                               Object {
                                 "desc": "94 to SW Railroad & Washington (TriMet:3670) from W Burnside & SW 8th (TriMet:715)",
@@ -11467,6 +11472,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                           </injectIntl(PatternRow)>
                           <injectIntl(PatternRow)
                             homeTimezone="America/Los_Angeles"
+                            key="TriMet:94:0:02"
                             pattern={
                               Object {
                                 "desc": "94 to SW Pacific Hwy & Durham (TriMet:8644) from W Burnside & SW 8th (TriMet:715)",
@@ -12184,6 +12190,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                           </injectIntl(PatternRow)>
                           <injectIntl(PatternRow)
                             homeTimezone="America/Los_Angeles"
+                            key="TriMet:36:0:04"
                             pattern={
                               Object {
                                 "desc": "36 to Tualatin Park & Ride (TriMet:7879) from W Burnside & SW 8th (TriMet:715)",
@@ -16861,6 +16868,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                           </p>
                           <injectIntl(PatternRow)
                             homeTimezone="America/Los_Angeles"
+                            key="TriMet:20:1:04"
                             pattern={
                               Object {
                                 "desc": "20 to Gresham Transit Center (TriMet:8199) from Beaverton Transit Center (TriMet:9978) express",

--- a/lib/components/viewers/live-stop-times.tsx
+++ b/lib/components/viewers/live-stop-times.tsx
@@ -219,6 +219,7 @@ class LiveStopTimes extends Component<Props, State> {
                   this.renderDay(homeTimezone, time.day, now)}
                 <PatternRow
                   homeTimezone={homeTimezone}
+                  key={pattern.id}
                   pattern={pattern}
                   route={{
                     ...route,

--- a/lib/util/viewer.js
+++ b/lib/util/viewer.js
@@ -136,11 +136,8 @@ export function getStopTimesByPattern(stopData) {
           times: []
         }
       }
-      // Exclude the last stop, as the stop viewer doesn't show arrival times to a terminus stop.
-      const filteredTimes = times.filter(excludeLastStop)
 
-      stopTimesByPattern[id].times =
-        stopTimesByPattern[id].times.concat(filteredTimes)
+      stopTimesByPattern[id].times = stopTimesByPattern[id].times.concat(times)
     })
   }
   return stopTimesByPattern


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

When we switched to the new stop viewer, we forgot to remove a filter that was only relevant for the old stop viewer and OTP1. The result was no stop times appearing at the second to last stop! This PR removes this filter and fixes things.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

