### PR TITLE
Fix nearby stop popups

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -267,9 +267,6 @@ components:
     nonTransit: Alternative options
   DeleteUser:
     deleteMyAccount: Delete my account
-  EnhancedStopMarker:
-    stopID: "Stop ID:"
-    stopViewer: Stop Viewer
   ErrorMessage:
     header: Could Not Plan Trip
     warning: Warning

--- a/i18n/es.yml
+++ b/i18n/es.yml
@@ -30,20 +30,21 @@ actions:
       No se puede guardar el plan: este plan no se pudo guardar debido a la
       falta de capacidad en uno o más vehículos. Por favor, vuelva a planificar
       su viaje.
-    maxTripRequestsExceeded: Número de solicitudes de viaje superadas sin resultados
-      válidos
+    maxTripRequestsExceeded: Número de solicitudes de viaje superadas sin resultados válidos
     saveItinerariesError: "No se pudieron guardar los itinerarios: {err}"
     setDateError: "Error al establecer la fecha:"
     setGroupSizeError: "No se pudo establecer el tamaño del grupo:"
     setPaymentError: "Error al configurar la información de pago:"
     setRequestStatusError: "Error al establecer el estado de la solicitud:"
   location:
+    deniedAccessAlert: >
+      El acceso a tu ubicación está bloqueado.
+
+      Para utilizar tu ubicación actual, activa los permisos de ubicación desde
+      tu navegador y vuelve a cargar la página. 
     geolocationNotSupportedError: Su navegador no admite la geolocalización
     unknownPositionError: Error desconocido al obtener la posición
     userDeniedPermission: Usuario sin permiso
-    deniedAccessAlert: "El acceso a tu ubicación está bloqueado.\nPara utilizar tu
-      ubicación actual, activa los permisos de ubicación desde tu navegador y vuelve
-      a cargar la página. \n"
   map:
     currentLocation: (Ubicación actual)
   user:
@@ -51,11 +52,9 @@ actions:
     authTokenError: Error al obtener un token de autorización.
     confirmDeleteMonitoredTrip: ¿Desea eliminar este viaje?
     confirmDeletePlace: ¿Quiere eliminar este lugar?
-    emailVerificationResent: El mensaje de verificación de correo electrónico ha sido
-      reenviado.
+    emailVerificationResent: El mensaje de verificación de correo electrónico ha sido reenviado.
     genericError: "Se ha encontrado un error: {err}"
-    itineraryExistenceCheckFailed: Comprobación de errores para ver si el viaje seleccionado
-      es posible.
+    itineraryExistenceCheckFailed: Comprobación de errores para ver si el viaje seleccionado es posible.
     preferencesSaved: Sus preferencias se han guardado.
     smsInvalidCode: El código introducido no es válido. Por favor, inténtelo de nuevo.
     smsResendThrottled: >-
@@ -112,12 +111,12 @@ common:
     "yes": Sí
   itineraryDescriptions:
     calories: "{calories, number} kcal"
+    fareUnknown: No hay información de las tarifas
     noItineraryToDisplay: No hay itinerario que mostrar.
     relativeCo2: >
       {co2} de CO₂ en {isMore, select, true {más} other {menos} } que conducir
       solo
     transfers: "{transfers, plural, =0 {} one {# transferencia} other {# transferencias}}"
-    fareUnknown: No hay información de las tarifas
   linkOpensNewWindow: (Abre una nueva ventana)
   modes:
     bicycle_rent: Compartir bicicleta
@@ -178,8 +177,8 @@ components:
     tooManyPlaces: Se alcanzó el máximo de lugares intermedios
   AdvancedOptions:
     bannedRoutes: Seleccionar rutas prohibidas…
-    preferredRoutes: Seleccionar rutas preferidas…
     bikeTolerance: Tolerancia de las bicicletas
+    preferredRoutes: Seleccionar rutas preferidas…
     walkTolerance: Tolerancia al andar
   AfterSignInScreen:
     mainTitle: Redirigiendo…
@@ -241,8 +240,7 @@ components:
     destination: destino
     origin: origen
     planTripTooltip: Planificar viaje
-    validationMessage: "Por favor, defina los siguientes campos para planificar un
-      viaje: {issues}"
+    validationMessage: "Por favor, defina los siguientes campos para planificar un viaje: {issues}"
   BeforeSignInScreen:
     mainTitle: Iniciando sesión
     message: >
@@ -270,9 +268,6 @@ components:
     nonTransit: Alternativas
   DeleteUser:
     deleteMyAccount: Eliminar mi cuenta
-  EnhancedStopMarker:
-    stopID: "Parada:"
-    stopViewer: Visor de paradas
   ErrorMessage:
     header: No se pudo planificar el viaje
     warning: Advertencia
@@ -373,6 +368,48 @@ components:
   NotificationPrefsPane:
     noDeviceForPush: Regístrese con la aplicación móvil para acceder a esta configuración.
     notificationChannelPrompt: "Recibir notificaciones para sus viajes guardados por:"
+  OTP2ErrorRenderer:
+    LOCATION_NOT_FOUND:
+      body: >-
+        {inputFieldsCount, plural, =0 {} one {localización es} other
+        {localizaciones son}} no están cerca de ninguna calle.
+      header: No se puede acceder a la ubicación
+    NO_STOPS_IN_RANGE:
+      body: >-
+        {inputFieldsCount, plural, =0 {} one {ubicación es} other {ubicaciones
+        son}} no están cerca de ninguna parada del transporte.
+      header: Sin paradas cerca
+    NO_TRANSIT_CONNECTION:
+      body: >-
+        No se encontró ninguna conexión entre tu origen y destino en el día
+        seleccionado, utilizando los tipos de vehículos que seleccionaste.
+      header: Sin conexiones
+    NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW:
+      body: >-
+        Se encontró una conexión, pero estaba fuera de las opciones de la
+        búsqueda, intenta ajustar las opciones de la búsqueda, usando los tipos
+        de vehículos que seleccionaste.
+      header: Sin conexiones por el criterio de la búsqueda
+    OUTSIDE_BOUNDS:
+      body: >-
+        {inputFieldsCount, plural, =0 {} one {localización es} other
+        {localizaciones son}} no están en los límites del planificador de
+        viajes.
+      header: Ubicación fuera de los límites
+    OUTSIDE_SERVICE_PERIOD:
+      body: >-
+        La fecha específicada está fuera del rango de los datos disponibles para
+        la búsqueda de los viajes.
+      header: Fuera de plazo
+    SYSTEM_ERROR:
+      body: Se ha producido un error desconocido en la búsqueda.
+      header: Error en el planificador de los viajes
+    WALKING_BETTER_THAN_TRANSIT:
+      body: Puede completar esta ruta más rápido caminando.
+      header: El transporte público no es la forma más rápida de hacer este viaje
+    inputFields:
+      FROM: Procedencia
+      TO: Destino
   PhoneNumberEditor:
     changeNumber: Cambiar número de teléfono
     invalidCode: Introduzca 6 dígitos para el código de validación.
@@ -502,8 +539,7 @@ components:
     header: ¡La sesión está a punto de terminar!
     keepSession: Continuar sesión
   SimpleRealtimeAnnotation:
-    usingRealtimeInfo: Este viaje utiliza información de tráfico y retrasos en tiempo
-      real
+    usingRealtimeInfo: Este viaje utiliza información de tráfico y retrasos en tiempo real
   StackedPaneDisplay:
     savePreferences: Guardar preferencias
   StopScheduleTable:
@@ -566,19 +602,16 @@ components:
     travelingAt: Viajando a {milesPerHour}
     vehicleName: Vehículo {vehicleNumber}
   TripBasicsPane:
-    checkingItineraryExistence: Comprobación de la existencia de itinerarios para
-      cada día de la semana…
+    checkingItineraryExistence: Comprobación de la existencia de itinerarios para cada día de la semana…
     selectAtLeastOneDay: Por favor, seleccione al menos un día para el seguimiento.
     tripDaysPrompt: ¿Qué días hace este viaje?
-    tripIsAvailableOnDaysIndicated: Su viaje está disponible en los días de la semana
-      indicados anteriormente.
+    tripIsAvailableOnDaysIndicated: Su viaje está disponible en los días de la semana indicados anteriormente.
     tripNamePrompt: "Por favor, indique un nombre para este viaje:"
     tripNotAvailableOnDay: El viaje no está disponible el {repeatedDay}
     unsavedChangesExistingTrip: >-
       Todavía no ha guardado su viaje. Si abandona la página, los cambios se
       perderán.
-    unsavedChangesNewTrip: Todavía no ha guardado su nuevo viaje. Si abandona la página,
-      se perderá.
+    unsavedChangesNewTrip: Todavía no ha guardado su nuevo viaje. Si abandona la página, se perderá.
   TripNotificationsPane:
     advancedSettings: Configuración avanzada
     altRouteRecommended: Se recomienda una ruta alternativa o un punto de transferencia
@@ -738,41 +771,6 @@ components:
     switcher: Botón de cambio
   WelcomeScreen:
     prompt: ¿A donde quiere ir?
-  OTP2ErrorRenderer:
-    SYSTEM_ERROR:
-      header: Error en el planificador de los viajes
-      body: Se ha producido un error desconocido en la búsqueda.
-    LOCATION_NOT_FOUND:
-      body: '{inputFieldsCount, plural, =0 {} one {localización es} other {localizaciones
-        son}} no están cerca de ninguna calle.'
-      header: No se puede acceder a la ubicación
-    NO_STOPS_IN_RANGE:
-      header: Sin paradas cerca
-      body: '{inputFieldsCount, plural, =0 {} one {ubicación es} other {ubicaciones
-        son}} no están cerca de ninguna parada del transporte.'
-    NO_TRANSIT_CONNECTION:
-      body: No se encontró ninguna conexión entre tu origen y destino en el día seleccionado,
-        utilizando los tipos de vehículos que seleccionaste.
-      header: Sin conexiones
-    inputFields:
-      FROM: Procedencia
-      TO: Destino
-    WALKING_BETTER_THAN_TRANSIT:
-      body: Puede completar esta ruta más rápido caminando.
-      header: El transporte público no es la forma más rápida de hacer este viaje
-    OUTSIDE_SERVICE_PERIOD:
-      header: Fuera de plazo
-      body: La fecha específicada está fuera del rango de los datos disponibles para
-        la búsqueda de los viajes.
-    OUTSIDE_BOUNDS:
-      header: Ubicación fuera de los límites
-      body: '{inputFieldsCount, plural, =0 {} one {localización es} other {localizaciones
-        son}} no están en los límites del planificador de viajes.'
-    NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW:
-      body: Se encontró una conexión, pero estaba fuera de las opciones de la búsqueda,
-        intenta ajustar las opciones de la búsqueda, usando los tipos de vehículos
-        que seleccionaste.
-      header: Sin conexiones por el criterio de la búsqueda
 config:
   accessModes:
     bicycle: Tránsito + Bicicleta Personal

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -2,8 +2,7 @@ _id: fr
 _name: Exemple de traduction pour OTP-react-redux en français
 actions:
   callTaker:
-    callQuerySaveError: "Erreur lors de l'enregistrement des requêtes pour l'appel
-      : {err}"
+    callQuerySaveError: "Erreur lors de l'enregistrement des requêtes pour l'appel : {err}"
     callSaveError: "Impossible d'enregistrer l'appel : {err}"
     checkSessionError: "Erreur durant la session d'authentification : {err}"
     couldNotFindCallError: >-
@@ -18,11 +17,9 @@ actions:
         true {aller}
         other {retour}
       } planifié préalablement pour cette demande. Voulez-vous continuer ?
-    deleteItinerariesError: "Erreur lors de la suppression du trajet pour le groupe
-      :"
+    deleteItinerariesError: "Erreur lors de la suppression du trajet pour le groupe :"
     deleteNoteError: "Erreur lors de la suppression d'une note sur le groupe :"
-    editSubmitterNotesError: "Erreur lors de la modification des notes du demandeur
-      :"
+    editSubmitterNotesError: "Erreur lors de la modification des notes du demandeur :"
     fetchFieldTripError: "Erreur de chargement du groupe scolaire : {err}"
     fetchFieldTripsError: "Erreur lors du chargement des groupes scolaires : {err}"
     fetchTripsForDateError: >-
@@ -46,8 +43,7 @@ actions:
 
       Pour utiliser votre emplacement actuel, permettez-en l'accès depuis votre
       navigateur, et ouvrez de nouveau cette page.
-    geolocationNotSupportedError: La géolocalisation n'est pas prise en charge par
-      votre navigateur.
+    geolocationNotSupportedError: La géolocalisation n'est pas prise en charge par votre navigateur.
     unknownPositionError: Erreur inconnue lors de la détection de votre emplacement.
     userDeniedPermission: Refusé par l'utilisateur
   map:
@@ -61,8 +57,7 @@ actions:
       Le message de vérification de votre adresse e-mail a été envoyé de
       nouveau.
     genericError: "Une erreur s'est produite : {err}"
-    itineraryExistenceCheckFailed: Erreur lors de la vérification de la validité du
-      trajet choisi.
+    itineraryExistenceCheckFailed: Erreur lors de la vérification de la validité du trajet choisi.
     preferencesSaved: Vos préférences ont été enregistrées.
     smsInvalidCode: Le code saisi est incorrect. Veuillez réessayer.
     smsResendThrottled: >-
@@ -285,9 +280,6 @@ components:
     nonTransit: Alternatives
   DeleteUser:
     deleteMyAccount: Supprimer mon compte
-  EnhancedStopMarker:
-    stopID: Arrêt nº
-    stopViewer: Info arrêt
   ErrorMessage:
     header: Impossible de planifier le trajet
     warning: Attention
@@ -351,10 +343,8 @@ components:
     header: Options de recherche
   NarrativeItinerariesHeader:
     changeSortDir: Changer l'ordre de tri
-    howToFindResults: Pour afficher les résultats, utilisez l'en-tête Trajets trouvés
-      plus bas.
-    itinerariesFound: "{itineraryNum, plural, one {# trajet trouvé} other {# trajets
-      trouvés} }"
+    howToFindResults: Pour afficher les résultats, utilisez l'en-tête Trajets trouvés plus bas.
+    itinerariesFound: "{itineraryNum, plural, one {# trajet trouvé} other {# trajets trouvés} }"
     numIssues: "{issueNum, plural, one {# problème} other {# problèmes} }"
     resultsSortedBy: >-
       Résultats triés par {sortSelected}. Pour modifier l'ordre, utilisez le
@@ -421,7 +411,8 @@ components:
       header: Echec de la recherche
     WALKING_BETTER_THAN_TRANSIT:
       body: >-
-        Vous pouvez effectuer ce trajet plus rapidement sans prendre les transports.
+        Vous pouvez effectuer ce trajet plus rapidement sans prendre les
+        transports.
       header: Moins rapide en transports
     inputFields:
       FROM: point de départ
@@ -666,8 +657,7 @@ components:
       unknownState: État du trajet inconnu
       untogglePause: Reprendre
     inactive:
-      description: Reprenez le suivi pour obtenir des dernières conditions de votre
-        trajet.
+      description: Reprenez le suivi pour obtenir des dernières conditions de votre trajet.
       heading: Suivi suspendu
     nextTripNotPossible:
       description: >
@@ -686,8 +676,7 @@ components:
         déterminées.
       heading: Conditions du trajet indéterminées
     snoozed:
-      description: Reprenez le suivi pour obtenir des dernières conditions de votre
-        trajet.
+      description: Reprenez le suivi pour obtenir des dernières conditions de votre trajet.
       heading: Suivi suspendu jusqu'à demain
     upcoming:
       nextTripBegins: >-

--- a/i18n/ko.yml
+++ b/i18n/ko.yml
@@ -240,9 +240,6 @@ components:
     multiModeSummary: "{accessMode} + {transitMode}"
   DeleteUser:
     deleteMyAccount: 내 계정 삭제
-  EnhancedStopMarker:
-    stopID: "정류장 ID:"
-    stopViewer: 정류장 뷰어
   ErrorMessage:
     header: 트립을 계획할 수 없음
     warning: 경고

--- a/i18n/nb_NO.yml
+++ b/i18n/nb_NO.yml
@@ -74,9 +74,6 @@ components:
     now: Nå
   DeleteUser:
     deleteMyAccount: Slett kontoen min
-  EnhancedStopMarker:
-    stopID: "Stopp-ID:"
-    stopViewer: Stopp-viser
   ErrorMessage:
     header: Kunne ikke planlegge tur
     warning: Advarsel

--- a/i18n/vi.yml
+++ b/i18n/vi.yml
@@ -250,9 +250,6 @@ components:
     multiModeSummary: "{accessMode} + {transitMode}"
   DeleteUser:
     deleteMyAccount: Xóa tài khoản của tôi
-  EnhancedStopMarker:
-    stopID: Điểm dừng số
-    stopViewer: Xem điểm dừng
   ErrorMessage:
     header: Không thể lên kế hoạch cho chuyến đi
     warning: Cảnh báo

--- a/i18n/zh.yml
+++ b/i18n/zh.yml
@@ -240,9 +240,6 @@ components:
     multiModeSummary: "{accessMode} + {transitMode}"
   DeleteUser:
     deleteMyAccount: 删除我的账户
-  EnhancedStopMarker:
-    stopID: "车站 ID:"
-    stopViewer: 车站查看器
   ErrorMessage:
     header: 无法计划行程
     warning: 警告

--- a/lib/components/map/connected-park-and-ride-overlay.tsx
+++ b/lib/components/map/connected-park-and-ride-overlay.tsx
@@ -5,6 +5,7 @@ import React, { useEffect } from 'react'
 
 import { parkAndRideQuery } from '../../actions/api'
 import { setLocation } from '../../actions/map'
+import { SetLocationHandler } from '../util/types'
 
 type ParkAndRideParams = {
   maxTransitDistance?: number
@@ -14,11 +15,7 @@ type Props = ParkAndRideParams & {
   keyboard?: boolean
   parkAndRideLocations?: { name: string; x: number; y: number }[]
   parkAndRideQuery: (params: ParkAndRideParams) => void
-  setLocation: (location: {
-    location: Location
-    locationType: string
-    reverseGeocode: boolean
-  }) => void
+  setLocation: SetLocationHandler
 }
 
 function ConnectedParkAndRideOverlay(props: Props): JSX.Element {

--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -47,6 +47,12 @@ const MapContainer = styled.div`
   * {
     box-sizing: unset;
   }
+
+  .maplibregl-popup-content,
+  .mapboxgl-popup-content {
+    border-radius: 10px;
+    box-shadow: 0 3px 14px 4px rgb(0 0 0 / 20%);
+  }
 `
 /**
  * Get the configured display names for the specified company ids.

--- a/lib/components/map/enhanced-stop-marker.js
+++ b/lib/components/map/enhanced-stop-marker.js
@@ -81,6 +81,18 @@ class EnhancedStopMarker extends Component {
     this.setLocation('to')
   }
 
+  onMarkerClick = (e) => {
+    // Make a copy because getElementsByClassName returns a live collection.
+    const elements = Array.from(
+      document.getElementsByClassName('maplibregl-popup-close-button')
+    )
+    elements.forEach((el) => {
+      if (el.parentElement.firstChild.firstChild.id !== 'enh-stop-popup') {
+        el.click()
+      }
+    })
+  }
+
   setLocation(locationType) {
     const { setLocation, stop } = this.props
     const { lat, lon, name } = stop
@@ -108,22 +120,11 @@ class EnhancedStopMarker extends Component {
     const { ModeIcon } = this.context
     const stopIcon = mode ? <ModeIcon mode={mode} /> : <MapMarker size={32} />
 
-    const icon = (
-      <BaseStopIcon
-        active={id === activeStopId}
-        mainColor={color}
-        // Show actual stop name on hover for easy identification.
-        title={getStopName(stop)}
-      >
-        {stopIcon}
-      </BaseStopIcon>
-    )
-
     return (
       <MarkerWithPopup
         popupContents={
           activeStopId !== stop.id && (
-            <BaseMapStyled.MapOverlayPopup>
+            <BaseMapStyled.MapOverlayPopup id="enh-stop-popup">
               <BaseMapStyled.PopupTitle>{name}</BaseMapStyled.PopupTitle>
               <BaseMapStyled.PopupRow>
                 <span>
@@ -152,7 +153,15 @@ class EnhancedStopMarker extends Component {
         }
         position={[lat, lon]}
       >
-        {icon}
+        <BaseStopIcon
+          active={id === activeStopId}
+          mainColor={color}
+          onClick={this.onMarkerClick}
+          // Show actual stop name on hover for easy identification.
+          title={getStopName(stop)}
+        >
+          {stopIcon}
+        </BaseStopIcon>
       </MarkerWithPopup>
     )
   }

--- a/lib/components/map/enhanced-stop-marker.js
+++ b/lib/components/map/enhanced-stop-marker.js
@@ -5,12 +5,10 @@ import {
   MarkerWithPopup
 } from '@opentripplanner/base-map'
 import { connect } from 'react-redux'
-import { FormattedMessage } from 'react-intl'
 import { MapMarker } from '@styled-icons/fa-solid/MapMarker'
-import { Styled as MapPopupStyled } from '@opentripplanner/map-popup'
 import coreUtils from '@opentripplanner/core-utils'
-import FromToLocationPicker from '@opentripplanner/from-to-location-picker'
 import React, { Component } from 'react'
+import StopPopup from '@opentripplanner/map-popup'
 import styled from 'styled-components'
 import tinycolor from 'tinycolor2'
 
@@ -18,8 +16,6 @@ import * as mapActions from '../../actions/map'
 import * as uiActions from '../../actions/ui'
 import { ComponentContext } from '../../util/contexts'
 import { getModeFromStop, getStopName } from '../../util/viewer'
-
-const { ViewStopButton } = MapPopupStyled
 
 const iconPixels = 32
 const iconPadding = 5
@@ -70,19 +66,6 @@ const activeContentId = 'enh-stop-popup'
 class EnhancedStopMarker extends Component {
   static contextType = ComponentContext
 
-  onClickView = () => {
-    const { setViewedStop, stop } = this.props
-    setViewedStop({ stopId: stop.id })
-  }
-
-  onFromClick = () => {
-    this.setLocation('from')
-  }
-
-  onToClick = () => {
-    this.setLocation('to')
-  }
-
   onMarkerClick = (e) => {
     // Make a copy because getElementsByClassName returns a live collection.
     const elements = Array.from(
@@ -101,20 +84,16 @@ class EnhancedStopMarker extends Component {
     })
   }
 
-  setLocation(locationType) {
-    const { setLocation, stop } = this.props
-    const { lat, lon, name } = stop
-    setLocation({
-      location: { lat, lon, name },
-      locationType,
-      reverseGeocode: false
-    })
-  }
-
   render() {
-    const { activeStopId, highlight, languageConfig, modeColors, stop } =
-      this.props
-    const { id, lat, lon, name } = stop
+    const {
+      activeStopId,
+      highlight,
+      modeColors,
+      setLocation,
+      setViewedStop,
+      stop
+    } = this.props
+    const { id, lat, lon } = stop
     const displayedStopId = coreUtils.itinerary.getDisplayedStopId(stop)
     if (!displayedStopId) return null
 
@@ -133,29 +112,11 @@ class EnhancedStopMarker extends Component {
         popupContents={
           activeStopId !== stop.id && (
             <BaseMapStyled.MapOverlayPopup id={activeContentId}>
-              <BaseMapStyled.PopupTitle>{name}</BaseMapStyled.PopupTitle>
-              <BaseMapStyled.PopupRow>
-                <span>
-                  <b>
-                    <FormattedMessage id="components.EnhancedStopMarker.stopID" />
-                  </b>{' '}
-                  {displayedStopId}
-                </span>
-                <ViewStopButton onClick={this.onClickView}>
-                  {languageConfig.stopViewer || (
-                    <FormattedMessage id="components.EnhancedStopMarker.stopViewer" />
-                  )}
-                </ViewStopButton>
-              </BaseMapStyled.PopupRow>
-
-              {/* The 'Set as [from/to]' ButtonGroup */}
-              <BaseMapStyled.PopupRow>
-                <FromToLocationPicker
-                  label
-                  onFromClick={this.onFromClick}
-                  onToClick={this.onToClick}
-                />
-              </BaseMapStyled.PopupRow>
+              <StopPopup
+                entity={stop}
+                setLocation={setLocation}
+                setViewedStop={setViewedStop}
+              />
             </BaseMapStyled.MapOverlayPopup>
           )
         }
@@ -187,7 +148,6 @@ const mapStateToProps = (state, ownProps) => {
   return {
     activeStopId: state.otp.ui.viewedStop?.stopId,
     highlight: highlightedStop === ownProps.stop.id,
-    languageConfig: state.otp.config.language,
     modeColors
   }
 }

--- a/lib/components/map/enhanced-stop-marker.js
+++ b/lib/components/map/enhanced-stop-marker.js
@@ -65,6 +65,8 @@ const BaseStopIcon = styled.div`
   }
 `
 
+const activeContentId = 'enh-stop-popup'
+
 class EnhancedStopMarker extends Component {
   static contextType = ComponentContext
 
@@ -86,8 +88,14 @@ class EnhancedStopMarker extends Component {
     const elements = Array.from(
       document.getElementsByClassName('maplibregl-popup-close-button')
     )
+    // HACK: If an OTP2 tile stop is right underneath the marker, the tile event handler in OTP-UI
+    // will fire before this one, and the popup from the regular stop layer will appear
+    // (even if we render the StopViewerOverlay after the OTP2 overlays in DefaultMap),
+    // so there will be two (duplicate) stop popups.
+    // We want to show the popup for the enhanced marker instead of the one from the tile handler
+    // because the stop marker has a much larger UI surface than the circle from the tile layer.
     elements.forEach((el) => {
-      if (el.parentElement.firstChild.firstChild.id !== 'enh-stop-popup') {
+      if (el.parentElement.firstChild.firstChild.id !== activeContentId) {
         el.click()
       }
     })
@@ -124,7 +132,7 @@ class EnhancedStopMarker extends Component {
       <MarkerWithPopup
         popupContents={
           activeStopId !== stop.id && (
-            <BaseMapStyled.MapOverlayPopup id="enh-stop-popup">
+            <BaseMapStyled.MapOverlayPopup id={activeContentId}>
               <BaseMapStyled.PopupTitle>{name}</BaseMapStyled.PopupTitle>
               <BaseMapStyled.PopupRow>
                 <span>

--- a/lib/components/map/enhanced-stop-marker.tsx
+++ b/lib/components/map/enhanced-stop-marker.tsx
@@ -3,8 +3,8 @@ import {
   MarkerWithPopup
 } from '@opentripplanner/base-map'
 import { connect } from 'react-redux'
-import { Location, Stop } from '@opentripplanner/types'
 import { MapMarker } from '@styled-icons/fa-solid/MapMarker'
+import { Stop } from '@opentripplanner/types'
 import coreUtils from '@opentripplanner/core-utils'
 import React, { Component } from 'react'
 import StopPopup from '@opentripplanner/map-popup'
@@ -14,7 +14,11 @@ import tinycolor from 'tinycolor2'
 import * as mapActions from '../../actions/map'
 import * as uiActions from '../../actions/ui'
 import { ComponentContext } from '../../util/contexts'
-import { ConfiguredTransitMode, SetViewedStopHandler } from '../util/types'
+import {
+  ConfiguredTransitMode,
+  SetLocationHandler,
+  SetViewedStopHandler
+} from '../util/types'
 import { getModeFromStop, getStopName } from '../../util/viewer'
 
 interface OwnProps {
@@ -27,7 +31,7 @@ interface Props extends OwnProps {
   activeStopId?: string
   highlight: boolean
   modeColors: ModeColors
-  setLocation: (location: { location: Location; locationType: string }) => void
+  setLocation: SetLocationHandler
   setViewedStop: SetViewedStopHandler
 }
 

--- a/lib/components/map/point-popup.tsx
+++ b/lib/components/map/point-popup.tsx
@@ -11,6 +11,7 @@ import type { Location } from '@opentripplanner/types'
 import * as mapActions from '../../actions/map'
 import { Icon } from '../util/styledIcon'
 import { renderCoordinates } from '../../util/i18n'
+import { SetLocationHandler } from '../util/types'
 
 const PopupTitleWrapper = styled.div`
   align-items: flex-start;
@@ -34,7 +35,7 @@ const ZoomButton = styled.button`
 type Props = {
   clearMapPopupLocation: () => void
   mapPopupLocation: Location
-  setLocation: (arg: unknown) => void
+  setLocation: SetLocationHandler
   zoomToPlace: (
     map?: MapRef,
     place?: { lat: number; lon: number },

--- a/lib/components/mobile/stop-viewer.tsx
+++ b/lib/components/mobile/stop-viewer.tsx
@@ -3,6 +3,7 @@ import { useIntl } from 'react-intl'
 import React, { useCallback } from 'react'
 
 import * as uiActions from '../../actions/ui'
+import { SetViewedStopHandler } from '../util/types'
 import DefaultMap from '../map/default-map'
 import StopViewer from '../viewers/stop-viewer'
 
@@ -10,7 +11,7 @@ import MobileContainer from './container'
 import MobileNavigationBar from './navigation-bar'
 
 interface Props {
-  setViewedStop: (payload: { stopId: string } | null) => void
+  setViewedStop: SetViewedStopHandler
 }
 
 const MobileStopViewer = ({ setViewedStop }: Props) => {

--- a/lib/components/narrative/line-itin/connected-transit-leg-subheader.tsx
+++ b/lib/components/narrative/line-itin/connected-transit-leg-subheader.tsx
@@ -4,15 +4,16 @@ import React, { Component } from 'react'
 import TransitLegSubheader from '@opentripplanner/itinerary-body/lib/otp-react-redux/transit-leg-subheader'
 
 import { setMainPanelContent, setViewedStop } from '../../../actions/ui'
+import { SetViewedStopHandler } from '../../util/types'
 
 interface Props {
   leg: Leg
   setMainPanelContent: (content: number | null) => void
-  setViewedStop: (payload: { stopId: string }) => void
+  setViewedStop: SetViewedStopHandler
 }
 
 class ConnectedTransitLegSubheader extends Component<Props> {
-  onClick = (payload: { stopId: string }) => {
+  onClick: SetViewedStopHandler = (payload) => {
     const { setMainPanelContent, setViewedStop } = this.props
     setMainPanelContent(null)
     setViewedStop(payload)

--- a/lib/components/util/types.ts
+++ b/lib/components/util/types.ts
@@ -93,3 +93,10 @@ export interface ViewedRouteObject extends Route {
 export type SetViewedRouteHandler = (route?: ViewedRouteState) => void
 
 export type SetViewedStopHandler = (payload: { stopId: string }) => void
+
+export interface ConfiguredTransitMode {
+  color?: string
+  label?: string
+  mode: string
+  showWheelchairSetting?: boolean
+}

--- a/lib/components/util/types.ts
+++ b/lib/components/util/types.ts
@@ -92,7 +92,7 @@ export interface ViewedRouteObject extends Route {
 
 export type SetViewedRouteHandler = (route?: ViewedRouteState) => void
 
-export type SetViewedStopHandler = (payload: { stopId: string }) => void
+export type SetViewedStopHandler = (payload: { stopId: string } | null) => void
 
 export interface ConfiguredTransitMode {
   color?: string

--- a/lib/components/util/types.ts
+++ b/lib/components/util/types.ts
@@ -1,4 +1,4 @@
-import { Route } from '@opentripplanner/types'
+import { MapLocationActionArg, Route } from '@opentripplanner/types'
 
 // TYPESCRIPT TODO: move this to a larger shared types file, preferably within otp-ui
 export interface StopData {
@@ -93,6 +93,8 @@ export interface ViewedRouteObject extends Route {
 export type SetViewedRouteHandler = (route?: ViewedRouteState) => void
 
 export type SetViewedStopHandler = (payload: { stopId: string } | null) => void
+
+export type SetLocationHandler = (payload: MapLocationActionArg) => void
 
 export interface ConfiguredTransitMode {
   color?: string


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR fixes an issue where two stop info popups can be shown for the same stop when clicking the nearby stops on the map, and unifies styling of the stop popups.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [na] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

