### PR TITLE
Fix unclickable itinerary

### DIFF
--- a/__tests__/util/ui.ts
+++ b/__tests__/util/ui.ts
@@ -11,15 +11,29 @@ describe('util > ui', () => {
         ItineraryView.LIST
       )
     })
-    it('returns a full itinerary view if URL contains ui_activeItinerary', () => {
+    it('returns a full itinerary view if URL contains ui_activeItinerary that is not -1', () => {
       expect(getItineraryView({ ui_activeItinerary: 2 })).toBe(
         ItineraryView.FULL
       )
     })
-    it('returns the specified view mode when set in URL', () => {
-      expect(getItineraryView({ ui_itineraryView: 'leg' })).toBe(
-        ItineraryView.LEG
+    it('returns an itinerary list view if URL contains ui_activeItinerary=-1 regardless of ui_itineraryView', () => {
+      expect(getItineraryView({ ui_activeItinerary: -1 })).toBe(
+        ItineraryView.LIST
       )
+      expect(
+        getItineraryView({
+          ui_activeItinerary: -1,
+          ui_itineraryView: ItineraryView.FULL
+        })
+      ).toBe(ItineraryView.LIST)
+    })
+    it('returns the specified view mode when set in URL', () => {
+      expect(
+        getItineraryView({
+          ui_activeItinerary: 0,
+          ui_itineraryView: ItineraryView.LEG
+        })
+      ).toBe(ItineraryView.LEG)
     })
   })
 })

--- a/__tests__/util/ui.ts
+++ b/__tests__/util/ui.ts
@@ -17,13 +17,16 @@ describe('util > ui', () => {
       )
     })
     it('returns an itinerary list view if URL contains ui_activeItinerary=-1 regardless of ui_itineraryView', () => {
-      expect(getItineraryView({ ui_activeItinerary: -1 })).toBe(
-        ItineraryView.LIST
-      )
       expect(
         getItineraryView({
           ui_activeItinerary: -1,
           ui_itineraryView: ItineraryView.FULL
+        })
+      ).toBe(ItineraryView.LIST)
+      expect(
+        getItineraryView({
+          ui_activeItinerary: -1,
+          ui_itineraryView: ItineraryView.LEG
         })
       ).toBe(ItineraryView.LIST)
     })

--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -137,6 +137,8 @@ export function updateOtpUrlParams(state, searchId) {
     params.ui_activeSearch = searchId
     // Assumes this is a new search and the active itinerary should be reset.
     params.ui_activeItinerary = -1
+    // At the same time, reset/delete the ui_itineraryView param.
+    params.ui_itineraryView = undefined
     if (config.itinerary?.showFirstResultByDefault) {
       dispatch(setVisibleItinerary({ index: 0 }))
     }

--- a/lib/util/ui.ts
+++ b/lib/util/ui.ts
@@ -110,6 +110,10 @@ export function getItineraryView({
   ui_itineraryView
 }: UrlParams): ItineraryView {
   return (
+    ((ui_activeItinerary === null ||
+      ui_activeItinerary === undefined ||
+      `${ui_activeItinerary}` === '-1') &&
+      ItineraryView.LIST) ||
     ui_itineraryView ||
     (isDefinedAndNotEqual(ui_activeItinerary, -1) && ItineraryView.FULL) ||
     ItineraryView.LIST


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR makes itineraries clickable, even if a `ui_itineraryView` URL parameter indicates otherwise.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

