### PR TITLE
Add configurable strict mode to itinerary filter

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -310,6 +310,9 @@ itinerary:
   # Whether the plan first/previous/next/last buttons should be shown along with
   # plan trip itineraries.
   showPlanFirstLastButtons: false
+  # Filters out trips returned by OTP by default, unless specifically requested.
+  # e.g. filters out walk-only itineraries if user has not explicitly asked for them.
+  strictItineraryFiltering: false
   # Whether to render route names and colors in the blocks inside
   # the batch ui rows
   renderRouteNamesInBlocks: true

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -45,7 +45,8 @@ import { RoutingQueryCallResult } from './api-constants'
 import { setItineraryView } from './ui'
 import { zoomToPlace } from './map'
 
-const { generateCombinations, generateOtp2Query } = coreUtils.queryGen
+const { generateCombinations, generateOtp2Query, SIMPLIFICATIONS } =
+  coreUtils.queryGen
 const { getTripOptionsFromQuery, getUrlParams } = coreUtils.query
 const { convertGraphQLResponseToLegacy } = coreUtils.itinerary
 const { randId } = coreUtils.storage
@@ -824,6 +825,8 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
       config?.modes?.initialState?.enabledModeButtons ||
       {}
 
+    const strictModes = config?.itinerary?.strictItineraryFiltering
+
     // Filter mode definitions based on active mode keys
     const activeModeButtons = config.modes?.modeButtons.filter((mb) =>
       activeModeKeys.includes(mb.key)
@@ -920,11 +923,28 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
           routingError,
           {
             rewritePayload: (response, dispatch, getState) => {
-              const withCollapsedShortNames =
-                response.data?.plan?.itineraries?.map((itin) => ({
+              const itineraries = response.data?.plan?.itineraries
+              const activeModeStrings = activeModes.map(
+                (am) => SIMPLIFICATIONS[am.mode]
+              )
+              let filteredItineraries
+
+              if (strictModes) {
+                filteredItineraries = itineraries.filter((itin) =>
+                  itin.legs.some((leg) =>
+                    activeModeStrings.includes(SIMPLIFICATIONS[leg.mode])
+                  )
+                )
+              } else {
+                filteredItineraries = itineraries
+              }
+
+              const withCollapsedShortNames = filteredItineraries.map(
+                (itin) => ({
                   ...itin,
                   legs: itin.legs?.map(convertGraphQLResponseToLegacy)
-                }))
+                })
+              )
 
               /* It is possible for a NO_TRANSIT_CONNECTION error to be
                 returned even if trips were returned, since it is on a mode-by-mode basis.

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -930,7 +930,7 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
                 (am) => SIMPLIFICATIONS[am.mode]
               )
 
-              let filteredItineraries
+              let filteredItineraries = itineraries
               // If "strictItineraryFiltering" is enabled, only return itineraries that contain at least one explicitly requested mode...
               if (strictModes) {
                 filteredItineraries = itineraries.filter((itin) =>
@@ -939,8 +939,6 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
                   )
                 )
                 // ... Otherwise return all itineraries.
-              } else {
-                filteredItineraries = itineraries
               }
 
               // Filter itineraries to collapse short names and hide unnecessary errors.

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -924,17 +924,21 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
           {
             rewritePayload: (response, dispatch, getState) => {
               const itineraries = response.data?.plan?.itineraries
+
+              // Convert user-selected transit modes from mode selector into modes recognized by OTP.
               const activeModeStrings = activeModes.map(
                 (am) => SIMPLIFICATIONS[am.mode]
               )
-              let filteredItineraries
 
+              let filteredItineraries
+              // If "strictItineraryFiltering" is enabled, only return itineraries that contain at least one explicitly requested mode...
               if (strictModes) {
                 filteredItineraries = itineraries.filter((itin) =>
                   itin.legs.some((leg) =>
                     activeModeStrings.includes(SIMPLIFICATIONS[leg.mode])
                   )
                 )
+                // ... Otherwise return all itineraries.
               } else {
                 filteredItineraries = itineraries
               }

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -939,6 +939,7 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
                 filteredItineraries = itineraries
               }
 
+              // Filter itineraries to collapse short names and hide unnecessary errors.
               const withCollapsedShortNames = filteredItineraries.map(
                 (itin) => ({
                   ...itin,


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

Adds support for a config item that will filter itineraries based on exactly what modes the user has selected (eliminates walk itineraries being shown by default if user did not specifically select a walk mode)

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [n/a] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [n/a] Are all languages supported (Internationalization/Localization)?
- [n/a] Are appropriate Typescript types implemented?

@daniel-heppner-ibigroup also wrote this and I forgot to put him in the commit!!!


