### PR TITLE
Use brand colors in date-time-picker

### DIFF
--- a/lib/components/form/date-time-button.tsx
+++ b/lib/components/form/date-time-button.tsx
@@ -25,7 +25,7 @@ const ButtonWrapper = styled.span`
   position: relative;
 
   & > button {
-    background-color: var(--main-base-color, white);
+    background-color: var(--main-base-color, rgba(0, 0, 0, 0.5));
     border-radius: 5px;
     border: none;
     color: var(--main-color, white);

--- a/lib/components/form/date-time-button.tsx
+++ b/lib/components/form/date-time-button.tsx
@@ -25,8 +25,10 @@ const ButtonWrapper = styled.span`
   position: relative;
 
   & > button {
+    background-color: var(--main-base-color, white);
     border-radius: 5px;
     border: none;
+    color: var(--main-color, white);
     cursor: pointer;
     font-size: 12px;
     height: ${buttonPixels}px;

--- a/lib/components/form/styled.ts
+++ b/lib/components/form/styled.ts
@@ -27,7 +27,7 @@ const commonButtonCss = css`
     background-color: var(--main-base-color, rgb(173, 216, 230));
     border: 2px solid rgb(0, 0, 0);
     box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-    color: var(--main-color, black);
+    color: var(--main-color, white);
     font-weight: 600;
   }
 `

--- a/lib/components/form/styled.ts
+++ b/lib/components/form/styled.ts
@@ -24,9 +24,10 @@ const commonButtonCss = css`
   user-select: none;
 
   &.active {
-    background-color: rgb(173, 216, 230);
+    background-color: var(--main-base-color, rgb(173, 216, 230));
     border: 2px solid rgb(0, 0, 0);
     box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+    color: var(--main-color, black);
     font-weight: 600;
   }
 `


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

Small change to remove the basic whites and weird blues and instead use the brand colors! 

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

