### PR TITLE
fix: Remove unneeded word wrap for itin times.

### DIFF
--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -5,7 +5,8 @@ import {
   LegDescriptionHeadsignPrefix,
   PlaceName as PlaceNameWrapper,
   PlaceRowWrapper,
-  PlaceSubheader
+  PlaceSubheader,
+  TimeColumn
 } from '@opentripplanner/itinerary-body/lib/styled'
 import { PlaceName } from '@opentripplanner/itinerary-body/lib/otp-react-redux'
 import clone from 'clone'
@@ -52,6 +53,9 @@ const StyledItineraryBody = styled(ItineraryBody)`
   }
   ${PlaceRowWrapper} {
     max-width: inherit;
+  }
+  ${TimeColumn} {
+    white-space: nowrap;
   }
 `
 

--- a/lib/components/narrative/metro/metro-itinerary.tsx
+++ b/lib/components/narrative/metro/metro-itinerary.tsx
@@ -75,7 +75,6 @@ const ItineraryDetails = styled.ul`
   margin: 0;
   overflow: hidden;
   padding: 0;
-  width: 90%;
 `
 const PrimaryInfo = styled.li`
   color: #000000cc;


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR removes some unneeded word wrap for leg times (those starting from 10 to 12am/pm in the itinerary body) and trip durations in the itinerary summary.

Closes #982, a duplicate

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

