### PR TITLE
fix: check transitLeg on leg

### DIFF
--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -445,7 +445,9 @@ class NarrativeItineraries extends Component {
         })
 
         // Identify whether an itinerary uses transit & sort into appropriate bucket
-        const transitLegs = cur.legs.filter((leg) => isTransit(leg.mode))
+        const transitLegs = cur.legs.filter(
+          (leg) => isTransit(leg.mode) | leg.transitLeg
+        )
 
         const modeContainer =
           transitLegs.length > 0 ? modeItinMap.multi : modeItinMap.single


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

Checks `leg.transitLeg` as a fallback for `isTransit` (prevents `routeModeOverrides` from being missed as transit trips.)

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

