### PR TITLE
Prevent flashing "Verified" when sending number for verification

### DIFF
--- a/lib/components/user/phone-number-editor.tsx
+++ b/lib/components/user/phone-number-editor.tsx
@@ -247,9 +247,11 @@ class PhoneNumberEditor extends Component<Props, State> {
                   <FormattedMessage id="components.PhoneNumberEditor.pending" />
                 </BsLabel>
               ) : (
-                <BsLabel style={{ background: 'green' }}>
-                  <FormattedMessage id="components.PhoneNumberEditor.verified" />
-                </BsLabel>
+                phoneNumberVerified && (
+                  <BsLabel style={{ background: 'green' }}>
+                    <FormattedMessage id="components.PhoneNumberEditor.verified" />
+                  </BsLabel>
+                )
               )}
               <InvisibleA11yLabel>)</InvisibleA11yLabel>
               <button


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->

## Description

After submitting a phone number for verification, "Verified" was briefly, but incorrectly flashed before the correct "Pending" status. This PR fixes that.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

