### PR TITLE
Support hiding mode icons in route viewer

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -414,6 +414,7 @@ itinerary:
 #       BUS: # Any OTP mode
 #         color: 00FF00 # HEX color without the # (like GTFS)
 #         textColor: FFFFFF # HEX color without the # (like GTFS)
+#     routeIcons: false # If set to false, no mode icons in the route viewer
 #   - feedId: TriMet
 #     agencyId: TRIMET
 #     name: TriMet

--- a/lib/components/viewers/RouteRow.js
+++ b/lib/components/viewers/RouteRow.js
@@ -176,7 +176,7 @@ export class RouteRow extends PureComponent {
         >
           <RouteDetailsContainer>
             <OperatorLogo operator={operator} />
-            {route.mode && (
+            {route.mode && operator.routeIcons !== false && (
               <ModeIconElement>
                 <ModeIcon
                   aria-label={getFormattedMode(

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -300,6 +300,7 @@ export interface ModeColorConfig {
 export interface TransitOperatorConfig extends TransitOperator {
   colorMode?: 'gtfs' | 'gtfs-softened' | 'disabled'
   modeColors?: Record<string, ModeColorConfig>
+  routeIcons?: boolean
 }
 
 /** Route Viewer config */


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Exciting new behavior allows operators to be configured to not show mode icons in a route row!

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

