### PR TITLE
Add alert tag on saved trips

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -513,6 +513,7 @@ components:
     tripNotFoundDescription: Sorry, the requested trip was not found.
     tripNotifications: Trip notifications
   SavedTripList:
+    alertTag: "{alert, plural, one {View one alert} other {View # alerts}}"
     fromTo: From {from} to {to}
     myTrips: My trips
     noSavedTrips: You have no saved trips

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -532,6 +532,7 @@ components:
     tripNotFoundDescription: Le trajet recherché est introuvable.
     tripNotifications: Notifications du trajet
   SavedTripList:
+    alertTag: "{alert, plural, one {Afficher une alerte} other {Afficher # alertes}}"
     fromTo: De {from} à {to}
     myTrips: Mes trajets
     noSavedTrips: Vous n'avez aucun trajet enregistré

--- a/lib/components/user/monitored-trip/saved-trip-list.js
+++ b/lib/components/user/monitored-trip/saved-trip-list.js
@@ -6,6 +6,7 @@ import { Pause } from '@styled-icons/fa-solid/Pause'
 import { PencilAlt } from '@styled-icons/fa-solid/PencilAlt'
 import { Play } from '@styled-icons/fa-solid/Play'
 import { Trash } from '@styled-icons/fa-solid/Trash'
+import { TriangleExclamation } from '@styled-icons/fa-solid/TriangleExclamation'
 import { withAuthenticationRequired } from '@auth0/auth0-react'
 import React, { Component } from 'react'
 
@@ -16,6 +17,7 @@ import { InlineLoading } from '../../narrative/loading'
 import {
   PageHeading,
   TripHeader,
+  TripPanelAlert,
   TripPanelFooter,
   TripPanelHeading
 } from '../styled'
@@ -27,6 +29,7 @@ import BackToTripPlanner from '../back-to-trip-planner'
 import PageTitle from '../../util/page-title'
 import withLoggedInUserSupport from '../with-logged-in-user-support'
 
+import getRenderData from './trip-status-rendering-strategies'
 import TripSummaryPane from './trip-summary-pane'
 
 /**
@@ -72,9 +75,10 @@ class TripListItem extends Component {
   }
 
   render() {
-    const { trip } = this.props
+    const { renderData, trip } = this.props
     const { itinerary } = trip
     const { legs } = itinerary
+    const alerts = renderData.alerts
     // Assuming the monitored itinerary has at least one leg:
     // - get the 'from' location of the first leg,
     // - get the 'to' location of the last leg.
@@ -83,6 +87,16 @@ class TripListItem extends Component {
     return (
       <Panel>
         <TripPanelHeading>
+          {alerts && alerts.length > 0 && (
+            <TripPanelAlert onClick={this._handleEditTrip}>
+              <IconWithText Icon={TriangleExclamation}>
+                <FormattedMessage
+                  id="components.SavedTripList.alertTag"
+                  values={{ alert: alerts.length }}
+                />
+              </IconWithText>
+            </TripPanelAlert>
+          )}
           <Panel.Title>
             <TripHeader>{trip.tripName}</TripHeader>
             <small>
@@ -145,6 +159,16 @@ class TripListItem extends Component {
 }
 
 // connect to the redux store
+const itemMapStateToProps = (state, ownProps) => {
+  const { trip } = ownProps
+  const renderData = getRenderData({
+    monitoredTrip: trip
+  })
+
+  return {
+    renderData
+  }
+}
 
 const itemMapDispatchToProps = {
   confirmAndDeleteUserMonitoredTrip:
@@ -153,7 +177,7 @@ const itemMapDispatchToProps = {
   togglePauseTrip: userActions.togglePauseTrip
 }
 const ConnectedTripListItem = connect(
-  null,
+  itemMapStateToProps,
   itemMapDispatchToProps
 )(injectIntl(TripListItem))
 

--- a/lib/components/user/monitored-trip/saved-trip-list.tsx
+++ b/lib/components/user/monitored-trip/saved-trip-list.tsx
@@ -99,7 +99,7 @@ class TripListItem extends Component<ItemProps, ItemState> {
     const { renderData, trip } = this.props
     const { itinerary } = trip
     const { legs } = itinerary
-    const alerts = renderData.alerts
+    const { alerts } = renderData
     // Assuming the monitored itinerary has at least one leg:
     // - get the 'from' location of the first leg,
     // - get the 'to' location of the last leg.

--- a/lib/components/user/monitored-trip/saved-trip-list.tsx
+++ b/lib/components/user/monitored-trip/saved-trip-list.tsx
@@ -36,6 +36,7 @@ import TripSummaryPane from './trip-summary-pane'
 interface ItemProps {
   confirmAndDeleteUserMonitoredTrip: (id: string, intl: IntlShape) => void
   intl: IntlShape
+  renderData: any
   routeTo: (url: any) => void
   togglePauseTrip: (trip: MonitoredTrip, intl: IntlShape) => void
   trip: MonitoredTrip
@@ -179,7 +180,7 @@ class TripListItem extends Component<ItemProps, ItemState> {
 }
 
 // connect to the redux store
-const itemMapStateToProps = (state, ownProps) => {
+const itemMapStateToProps = (ownProps: ItemProps) => {
   const { trip } = ownProps
   const renderData = getRenderData({
     monitoredTrip: trip

--- a/lib/components/user/styled.ts
+++ b/lib/components/user/styled.ts
@@ -1,4 +1,4 @@
-import { Panel } from 'react-bootstrap'
+import { Button, Panel } from 'react-bootstrap'
 import styled, { css } from 'styled-components'
 
 export const PageHeading = styled.h2`
@@ -46,6 +46,22 @@ export const TripHeader = styled.h3`
 
 export const TripPanelHeading = styled(Panel.Heading)`
   background-color: white !important;
+`
+
+export const TripPanelAlert = styled(Button)`
+  border: none;
+  color: red;
+  cursor: pointer;
+  float: right;
+  text-decoration: underline;
+
+  :hover,
+  :focus,
+  :active {
+    background-color: transparent;
+    color: #d9534f;
+    text-decoration: underline;
+  }
 `
 
 export const TripPanelFooter = styled(Panel.Footer)`

--- a/lib/components/user/styled.ts
+++ b/lib/components/user/styled.ts
@@ -1,6 +1,8 @@
 import { Button, Panel } from 'react-bootstrap'
 import styled, { css } from 'styled-components'
 
+import { RED_ON_WHITE } from '../util/colors'
+
 export const PageHeading = styled.h2`
   margin: 10px 0px 45px 0px;
 `
@@ -48,16 +50,15 @@ export const TripPanelHeading = styled(Panel.Heading)`
   background-color: white !important;
 `
 
-export const TripPanelAlert = styled(Button)`
+export const TripPanelAlert = styled.a`
   border: none;
-  color: red;
+  color: ${RED_ON_WHITE};
   cursor: pointer;
   float: right;
   text-decoration: underline;
 
-  :hover,
-  :focus,
-  :active {
+  :hover {
+    opacity: 90%,
     background-color: transparent;
     color: #d9534f;
     text-decoration: underline;

--- a/lib/components/user/styled.ts
+++ b/lib/components/user/styled.ts
@@ -51,17 +51,14 @@ export const TripPanelHeading = styled(Panel.Heading)`
 `
 
 export const TripPanelAlert = styled.a`
-  border: none;
   color: ${RED_ON_WHITE};
   cursor: pointer;
   float: right;
   text-decoration: underline;
-
-  :hover {
-    opacity: 90%,
+  &:hover {
     background-color: transparent;
-    color: #d9534f;
-    text-decoration: underline;
+    color: ${RED_ON_WHITE};
+    opacity: 80%;
   }
 `
 


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
It's not intuitive that alerts are shown in the edit button on saved trips. An alert notif/tag is shown as a seperate component. This is the first iteration before we change more styling

<img width="798" alt="image" src="https://github.com/opentripplanner/otp-react-redux/assets/62163307/24ec8517-aa81-44f2-b328-015e558c9cff">


<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

Q: Should I be using `LinkWithQuery` rather than button?
Which red colours are appropriate for this?
