### PR TITLE
Apply mode overrides to stop viewer

### DIFF
--- a/lib/components/map/enhanced-stop-marker.tsx
+++ b/lib/components/map/enhanced-stop-marker.tsx
@@ -13,6 +13,7 @@ import tinycolor from 'tinycolor2'
 
 import * as mapActions from '../../actions/map'
 import * as uiActions from '../../actions/ui'
+import { AppConfig } from '../../util/config-types'
 import { AppReduxState } from '../../util/state-types'
 import { ComponentContext } from '../../util/contexts'
 import { getModeFromStop, getStopName } from '../../util/viewer'
@@ -28,6 +29,7 @@ interface Props extends OwnProps {
   activeStopId?: string
   highlight: boolean
   modeColors: ModeColors
+  overrideConfig: AppConfig
   setLocation: SetLocationHandler
   setViewedStop: SetViewedStopHandler
 }
@@ -116,6 +118,7 @@ class EnhancedStopMarker extends Component<Props> {
       activeStopId,
       highlight,
       modeColors,
+      overrideConfig,
       setLocation,
       setViewedStop,
       stop
@@ -124,7 +127,7 @@ class EnhancedStopMarker extends Component<Props> {
     const displayedStopId = coreUtils.itinerary.getDisplayedStopId(stop)
     if (!displayedStopId) return null
 
-    const mode = getModeFromStop(stop)
+    const mode = getModeFromStop(stop, overrideConfig)
     let color = modeColors && modeColors[mode] ? modeColors[mode] : '#121212'
     if (highlight) {
       // Generates a pretty variant of the color
@@ -174,7 +177,8 @@ const mapStateToProps = (state: AppReduxState, ownProps: OwnProps) => {
   return {
     activeStopId: state.otp.ui.viewedStop?.stopId,
     highlight: highlightedStop === ownProps.stop.id,
-    modeColors
+    modeColors,
+    overrideConfig: state.otp.config?.routeModeOverrides
   }
 }
 

--- a/lib/util/viewer.js
+++ b/lib/util/viewer.js
@@ -4,6 +4,7 @@ import { getMostReadableTextColor } from '@opentripplanner/core-utils/lib/route'
 import coreUtils from '@opentripplanner/core-utils'
 import tinycolor from 'tinycolor2'
 
+import { checkForRouteModeOverride } from './config'
 import { getOperatorAndRoute } from './state'
 import { isBlank } from './ui'
 
@@ -189,8 +190,15 @@ export function getModeFromRoute(route) {
  * In the case of a stop with multiple modes, this method will look at the most
  * frequently occurring mode and return that one.
  */
-export const getModeFromStop = (stop) => {
-  const modes = [...new Set(stop.routes?.map(getModeFromRoute))]
+export const getModeFromStop = (stop, overrideConfig) => {
+  const modes = [
+    ...new Set(
+      stop.routes?.map((route) =>
+        checkForRouteModeOverride(route, overrideConfig)
+      )
+    )
+  ]
+
   if (modes.length === 1) {
     return modes[0]
   }


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

Custom `routeModeOverrides` were not being passed to the `StopViewerOverlay`! This fixes that.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

