### PR TITLE
Location Switch if Autoplan False

### DIFF
--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -266,7 +266,9 @@ export function clearLocation(payload) {
 
 export function switchLocations() {
   return async function (dispatch, getState) {
-    const { from, to } = getState().otp.currentQuery
+    const state = getState()
+    const autoPlan = state.otp.config.autoPlan
+    const { from, to } = state.otp.currentQuery
     // First, reverse the locations.
     await dispatch(
       settingLocation({
@@ -280,7 +282,9 @@ export function switchLocations() {
         locationType: 'to'
       })
     )
-    // Then kick off a routing query (if the query is invalid, search will abort).
-    return dispatch(routingQuery())
+    //  If autoPlan is enabled, kick off a routing query (if the query is invalid, search will abort).
+    if (autoPlan) {
+      return dispatch(routingQuery())
+    }
   }
 }


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

 In instances where autoPlan is false, using the location switch button shouldn’t trigger a new search. This adds a check for if autoplan is enabled before the trip query is dispatched.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

