### PR TITLE
add `origColor` route color when route color is replaced

### DIFF
--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -101,8 +101,8 @@ exports[`components > viewers > stop viewer should render countdown times after 
         >
           <StopViewer
             autoRefreshStopTimes={true}
-            calendarMax="2024-12-31"
-            calendarMin="2023-01-01"
+            calendarMax="2025-12-31"
+            calendarMin="2024-01-01"
             enableFavoriteStops={false}
             favoriteStops={Array []}
             fetchStopInfo={[Function]}
@@ -1449,6 +1449,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                           "agencyName": "TriMet",
                                           "mode": "BUS",
                                           "onColoredBackground": true,
+                                          "origColor": undefined,
                                           "routeColor": undefined,
                                           "routeLongName": "Burnside/Stark",
                                           "routeShortName": "20",
@@ -2980,8 +2981,8 @@ exports[`components > viewers > stop viewer should render countdown times for st
         >
           <StopViewer
             autoRefreshStopTimes={true}
-            calendarMax="2024-12-31"
-            calendarMin="2023-01-01"
+            calendarMax="2025-12-31"
+            calendarMin="2024-01-01"
             enableFavoriteStops={false}
             favoriteStops={Array []}
             fetchStopInfo={[Function]}
@@ -4009,6 +4010,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                           "agencyName": "TriMet",
                                           "mode": "BUS",
                                           "onColoredBackground": true,
+                                          "origColor": undefined,
                                           "routeColor": undefined,
                                           "routeLongName": "Burnside/Stark",
                                           "routeShortName": "20",
@@ -4808,8 +4810,8 @@ exports[`components > viewers > stop viewer should render times after midnight w
         >
           <StopViewer
             autoRefreshStopTimes={true}
-            calendarMax="2024-12-31"
-            calendarMin="2023-01-01"
+            calendarMax="2025-12-31"
+            calendarMin="2024-01-01"
             enableFavoriteStops={false}
             favoriteStops={Array []}
             fetchStopInfo={[Function]}
@@ -6170,6 +6172,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                           "agencyName": "TriMet",
                                           "mode": "BUS",
                                           "onColoredBackground": true,
+                                          "origColor": undefined,
                                           "routeColor": undefined,
                                           "routeLongName": "Burnside/Stark",
                                           "routeShortName": "20",
@@ -7730,8 +7733,8 @@ exports[`components > viewers > stop viewer should render with OTP transit index
         >
           <StopViewer
             autoRefreshStopTimes={true}
-            calendarMax="2024-12-31"
-            calendarMin="2023-01-01"
+            calendarMax="2025-12-31"
+            calendarMin="2024-01-01"
             enableFavoriteStops={false}
             favoriteStops={Array []}
             fetchStopInfo={[Function]}
@@ -9864,6 +9867,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           "agencyName": "TriMet",
                                           "mode": "BUS",
                                           "onColoredBackground": true,
+                                          "origColor": undefined,
                                           "routeColor": undefined,
                                           "routeLongName": "Burnside/Stark",
                                           "routeShortName": "20",
@@ -10537,6 +10541,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           "agencyName": "TriMet",
                                           "mode": "BUS",
                                           "onColoredBackground": true,
+                                          "origColor": undefined,
                                           "routeColor": undefined,
                                           "routeLongName": "Pacific Hwy/Sherwood",
                                           "routeShortName": "94",
@@ -11160,6 +11165,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           "agencyName": "TriMet",
                                           "mode": "BUS",
                                           "onColoredBackground": true,
+                                          "origColor": undefined,
                                           "routeColor": undefined,
                                           "routeLongName": "Pacific Hwy/Sherwood",
                                           "routeShortName": "94",
@@ -11465,6 +11471,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           "agencyName": "TriMet",
                                           "mode": "BUS",
                                           "onColoredBackground": true,
+                                          "origColor": undefined,
                                           "routeColor": undefined,
                                           "routeLongName": "South Shore",
                                           "routeShortName": "36",
@@ -11934,6 +11941,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           "agencyName": "TriMet",
                                           "mode": "BUS",
                                           "onColoredBackground": true,
+                                          "origColor": undefined,
                                           "routeColor": undefined,
                                           "routeLongName": "Pacific Hwy/Sherwood",
                                           "routeShortName": "94",
@@ -12221,6 +12229,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           "agencyName": "TriMet",
                                           "mode": "BUS",
                                           "onColoredBackground": true,
+                                          "origColor": undefined,
                                           "routeColor": undefined,
                                           "routeLongName": "South Shore",
                                           "routeShortName": "36",
@@ -12522,6 +12531,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                           "agencyName": "TriMet",
                                           "mode": "BUS",
                                           "onColoredBackground": true,
+                                          "origColor": undefined,
                                           "routeColor": undefined,
                                           "routeLongName": "Pacific Hwy/Sherwood",
                                           "routeShortName": "94",
@@ -14778,8 +14788,8 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
         >
           <StopViewer
             autoRefreshStopTimes={true}
-            calendarMax="2024-12-31"
-            calendarMin="2023-01-01"
+            calendarMax="2025-12-31"
+            calendarMin="2024-01-01"
             enableFavoriteStops={false}
             favoriteStops={Array []}
             fetchStopInfo={[Function]}
@@ -16899,6 +16909,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                           "agencyName": "TriMet",
                                           "mode": "BUS",
                                           "onColoredBackground": true,
+                                          "origColor": undefined,
                                           "routeColor": undefined,
                                           "routeLongName": "Burnside/Stark",
                                           "routeShortName": "20",
@@ -19471,8 +19482,8 @@ exports[`components > viewers > stop viewer should render with initial stop id a
         >
           <StopViewer
             autoRefreshStopTimes={true}
-            calendarMax="2024-12-31"
-            calendarMin="2023-01-01"
+            calendarMax="2025-12-31"
+            calendarMin="2024-01-01"
             enableFavoriteStops={false}
             favoriteStops={Array []}
             fetchStopInfo={[Function]}

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -702,6 +702,18 @@ export const findRoute = (params) =>
                 stops: patternStops
               }
             })
+            newRoute.origColor = newRoute.color
+            newRoute.color = getRouteColorBasedOnSettings(
+              getRouteOperator(
+                {
+                  agencyId: newRoute?.agency?.id,
+                  id: newRoute?.route?.id
+                },
+                getState().otp.config.transitOperators
+              ),
+              { color: newRoute?.route?.color, mode: newRoute.mode }
+            ).split('#')?.[1]
+
             newRoute.patterns = routePatterns
             // TODO: avoid explicit behavior shift like this
             newRoute.v2 = true
@@ -753,8 +765,30 @@ export function findRoutes() {
             // To initialize the route viewer,
             // convert the routes array to a dictionary indexed by route ids.
             return routes.reduce((result, route) => {
-              const { agency, color, id, longName, mode, shortName, type } =
-                route
+              const {
+                agency,
+                color: origColor,
+                id,
+                longName,
+                mode,
+                shortName,
+                type
+              } = route
+              // Set color overrides if present
+              const color = getRouteColorBasedOnSettings(
+                getRouteOperator(
+                  {
+                    agencyId: route?.agency?.id,
+                    id: route?.route?.id
+                  },
+                  config.transitOperators
+                ),
+                {
+                  color: route?.route?.color,
+                  mode: route.mode
+                }
+              ).split('#')?.[1]
+
               result[id] = {
                 agencyId: agency.id,
                 agencyName: agency.name,
@@ -765,6 +799,7 @@ export function findRoutes() {
                   { id, mode },
                   config?.routeModeOverrides
                 ),
+                origColor,
                 shortName,
                 type,
                 v2: true
@@ -978,6 +1013,7 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
                     ?.map((leg) => {
                       return {
                         ...leg,
+                        origColor: leg?.route?.color,
                         route: {
                           ...leg.route,
                           color: getRouteColorBasedOnSettings(

--- a/lib/util/viewer.js
+++ b/lib/util/viewer.js
@@ -477,6 +477,7 @@ export function generateFakeLegForRouteRenderer(
     mode: getModeFromRoute(route),
     // Don't render top border when colors are mismatched
     onColoredBackground,
+    origColor: route.origColor,
     routeColor: route.color,
     routeLongName: route.longName,
     routeShortName: route.shortName,


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
We do a cool thing where we allow overriding the route color. This is useful, but there are cases when we might want the original one anyway, especially within a custom route renderer. This PR allows for this by appending an `origColor` field when the color is overwritten.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [X] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [X] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

