### PR TITLE
Fix colors in route viewer

### DIFF
--- a/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-viewer.js.snap
@@ -1437,7 +1437,7 @@ exports[`components > viewers > stop viewer should render countdown times after 
                                         title="20"
                                       >
                                         <span
-                                          className="sc-edoYdd ckpxJS"
+                                          className="sc-edoYdd hkZJFG"
                                           color="333333"
                                           style={
                                             Object {
@@ -3691,7 +3691,7 @@ exports[`components > viewers > stop viewer should render countdown times for st
                                         title="20"
                                       >
                                         <span
-                                          className="sc-edoYdd ckpxJS"
+                                          className="sc-edoYdd hkZJFG"
                                           color="333333"
                                           style={
                                             Object {
@@ -5846,7 +5846,7 @@ exports[`components > viewers > stop viewer should render times after midnight w
                                         title="20"
                                       >
                                         <span
-                                          className="sc-edoYdd ckpxJS"
+                                          className="sc-edoYdd hkZJFG"
                                           color="333333"
                                           style={
                                             Object {
@@ -9169,7 +9169,7 @@ exports[`components > viewers > stop viewer should render with OTP transit index
                                         title="36"
                                       >
                                         <span
-                                          className="sc-edoYdd ckpxJS"
+                                          className="sc-edoYdd hkZJFG"
                                           color="333333"
                                           style={
                                             Object {
@@ -13547,7 +13547,7 @@ exports[`components > viewers > stop viewer should render with TriMet transit in
                                         title="20"
                                       >
                                         <span
-                                          className="sc-edoYdd ckpxJS"
+                                          className="sc-edoYdd hkZJFG"
                                           color="333333"
                                           style={
                                             Object {

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -707,7 +707,7 @@ export const findRoute = (params) =>
               getRouteOperator(
                 {
                   agencyId: newRoute?.agency?.id,
-                  id: newRoute?.route?.id
+                  id: newRoute?.id
                 },
                 getState().otp.config.transitOperators
               ),
@@ -779,7 +779,7 @@ export function findRoutes() {
                 getRouteOperator(
                   {
                     agencyId: route?.agency?.id,
-                    id: route?.route?.id
+                    id: route?.id
                   },
                   config.transitOperators
                 ),

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -711,7 +711,7 @@ export const findRoute = (params) =>
                 },
                 getState().otp.config.transitOperators
               ),
-              { color: newRoute?.route?.color, mode: newRoute.mode }
+              { color: newRoute?.color, mode: newRoute.mode }
             ).split('#')?.[1]
 
             newRoute.patterns = routePatterns
@@ -784,7 +784,7 @@ export function findRoutes() {
                   config.transitOperators
                 ),
                 {
-                  color: route?.route?.color,
+                  color: route?.color,
                   mode: route.mode
                 }
               ).split('#')?.[1]

--- a/lib/components/narrative/metro/default-route-renderer.tsx
+++ b/lib/components/narrative/metro/default-route-renderer.tsx
@@ -36,7 +36,7 @@ const DefaultRouteRenderer = ({
   const routeTitle = leg.routeShortName || leg.routeLongName
   return (
     <Block
-      color={leg.origColor || '333333'}
+      color={leg.origColor || leg.routeColor || '333333'}
       isOnColoredBackground={leg.onColoredBackground}
       style={style}
       title={routeTitle}

--- a/lib/components/narrative/metro/default-route-renderer.tsx
+++ b/lib/components/narrative/metro/default-route-renderer.tsx
@@ -25,7 +25,7 @@ const Block = styled.span<{ color: string; isOnColoredBackground?: boolean }>`
 `
 
 export type RouteRendererProps = {
-  leg: Leg & { onColoredBackground?: boolean; origColor?: string }
+  leg: Leg & { onColoredBackground?: boolean }
   style?: CSSProperties
 }
 
@@ -36,7 +36,7 @@ const DefaultRouteRenderer = ({
   const routeTitle = leg.routeShortName || leg.routeLongName
   return (
     <Block
-      color={leg.origColor || leg.routeColor || '333333'}
+      color={leg.routeColor || '333333'}
       isOnColoredBackground={leg.onColoredBackground}
       style={style}
       title={routeTitle}

--- a/lib/components/narrative/metro/default-route-renderer.tsx
+++ b/lib/components/narrative/metro/default-route-renderer.tsx
@@ -26,7 +26,7 @@ const Block = styled.span<{ color: string; isOnColoredBackground?: boolean }>`
 `
 
 export type RouteRendererProps = {
-  leg: Leg & { onColoredBackground?: boolean }
+  leg: Leg & { onColoredBackground?: boolean; origColor: string }
   style?: CSSProperties
 }
 
@@ -37,7 +37,7 @@ const DefaultRouteRenderer = ({
   const routeTitle = leg.routeShortName || leg.routeLongName
   return (
     <Block
-      color={leg.routeColor || '333333'}
+      color={leg.origColor || '333333'}
       isOnColoredBackground={leg.onColoredBackground}
       style={style}
       title={routeTitle}

--- a/lib/components/narrative/metro/default-route-renderer.tsx
+++ b/lib/components/narrative/metro/default-route-renderer.tsx
@@ -7,7 +7,6 @@ const Block = styled.span<{ color: string; isOnColoredBackground?: boolean }>`
   border-radius: 5px;
   border-top: 5px solid #${(props) => props.color};
   display: inline-block;
-  margin-top: -2px;
   padding: 3px 7px;
   /* Below is for route names that are too long: cut-off and show ellipsis. */
   max-width: 150px;

--- a/lib/util/accessibility-routing.js
+++ b/lib/util/accessibility-routing.js
@@ -3,7 +3,8 @@
  */
 export const itineraryHasAccessibilityScore = (itinerary) => {
   return (
-    // If accessibility score is 0, we still want to return true
+    // If accessibility score is 0, we still want to return true so use the -1 to
+    // make sure all scores are returned even if they're 0.
     itinerary.accessibilityScore !== null && itinerary.accessibilityScore > -1
   )
 }


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

Fixing regression that is causing all route colors in route viewer to be set to #333333

Also took off a couple of pixels that were causing a weird crop on some routes with long names.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

| Before | After |
|--------|-------|
|![image](https://github.com/opentripplanner/otp-react-redux/assets/115499534/bbb5920a-0ad7-4036-a3bb-3b363a5b6672)|![image](https://github.com/opentripplanner/otp-react-redux/assets/115499534/61b5f017-6d53-448c-bc48-a6df789d2d55)|

