### PR TITLE
fix: don't use the old otp-ui query param framework

### DIFF
--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -17,7 +17,7 @@ import v2Actions from './apiV2'
 
 if (typeof fetch === 'undefined') require('isomorphic-fetch')
 
-const { getRoutingParams, getUrlParams } = coreUtils.query
+const { getUrlParams } = coreUtils.query
 
 // Generic API actions
 
@@ -118,9 +118,7 @@ export function setUrlSearch(params, replaceCurrent = false) {
  * is set correctly. Leaves any other existing URL parameters (e.g., UI) unchanged.
  */
 export function updateOtpUrlParams(state, searchId) {
-  const { config, currentQuery } = state.otp
   // Get updated OTP params from current query.
-  const otpParams = getRoutingParams(config, currentQuery, true)
   return function (dispatch, getState) {
     const params = {}
     // Get all URL params and ensure non-routing params (UI, sessionId) remain
@@ -139,7 +137,7 @@ export function updateOtpUrlParams(state, searchId) {
     // At the same time, reset/delete the ui_itineraryView param.
     params.ui_itineraryView = undefined
     // Merge in the provided OTP params and update the URL.
-    dispatch(setUrlSearch(Object.assign(params, otpParams)))
+    dispatch(setUrlSearch(params))
   }
 }
 


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
There was a really subtle bug where in instances where the query didn't succeed, any query parameters that come from otp-ui's list of query parameters would overwrite the parameters set in the UI in the url search string. 

This PR removes that functionality entirely, since I don't think it's needed anymore with the new mode selector. 

There *could* be some edge case or config I can't checked that breaks with this, so it should require a lot of testing.

