### PR TITLE
fix sticky highlighted location

### DIFF
--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -183,26 +183,29 @@ function NearbyView({
     setHighlightedLocation(null)
   }, [setHighlightedLocation])
 
-  const nearbyItemList = nearby?.map((n: any) => (
-    <li
-      className={
-        (n.place.gtfsId ?? n.place.id) === entityId ? 'highlighted' : ''
-      }
-      key={n.place.id}
-    >
-      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
-      <div
-        onBlur={onMouseLeave}
-        onFocus={() => onMouseEnter(n.place)}
-        onMouseEnter={() => onMouseEnter(n.place)}
-        onMouseLeave={onMouseLeave}
-        /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
-        tabIndex={0}
+  const nearbyItemList =
+    nearby?.map &&
+    nearby?.map((n: any) => (
+      <li
+        className={
+          (n.place.gtfsId ?? n.place.id) === entityId ? 'highlighted' : ''
+        }
+        key={n.place.id}
       >
-        {getNearbyItem(n.place, onClickSetLocation)}
-      </div>
-    </li>
-  ))
+        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+        <div
+          onBlur={onMouseLeave}
+          onFocus={() => onMouseEnter(n.place)}
+          onMouseEnter={() => onMouseEnter(n.place)}
+          onMouseLeave={onMouseLeave}
+          /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
+          tabIndex={0}
+        >
+          {getNearbyItem(n.place, onClickSetLocation)}
+        </div>
+      </li>
+    ))
+
   useEffect(() => {
     setLoading(false)
   }, [nearby])

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -115,6 +115,13 @@ function NearbyView({
     setLocation(payload)
   }
 
+  // Make sure the highlighted location is cleaned up when leaving nearby
+  useEffect(() => {
+    return function cleanup() {
+      setHighlightedLocation(null)
+    }
+  })
+
   useEffect(() => {
     const listener = (e: any) => {
       if (e.geolocateSource) {


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Sometimes the highlighted location from nearby view would remain highlighted after leaving nearby view. It happened when clicking on a link in one of the cards, since the mouse-out handler never fired. We clean this up with a useEffect that ensures that the highlighted item is cleared when nearby view is unmounted.

Also fixes a crash when the OTP server is down.

