### PR TITLE
fix(DropdownOptions): Pass onChange to Field only when it exists

### DIFF
--- a/lib/components/user/common/dropdown-options.tsx
+++ b/lib/components/user/common/dropdown-options.tsx
@@ -28,20 +28,16 @@ export const Select = ({
     componentClass: 'select',
     defaultValue,
     id: name,
-    name
+    name,
+    onChange
   }
+  /* Passing an onChange will override Formik's onChange, so only pass if onChange exists. */
+  if (!onChange) delete fieldProps.onChange
   return (
     // <Field> is kept outside of <label> to accommodate layout in table/grid cells.
     <>
       {label && <label htmlFor={name}>{label}</label>}
-      {/* passing an onChange will override Formik's onChange, so only pass if onChange exists. */}
-      {onChange ? (
-        <Field {...fieldProps} onChange={onChange}>
-          {children}
-        </Field>
-      ) : (
-        <Field {...fieldProps}>{children}</Field>
-      )}
+      <Field {...fieldProps}>{children}</Field>
     </>
   )
 }

--- a/lib/components/user/common/dropdown-options.tsx
+++ b/lib/components/user/common/dropdown-options.tsx
@@ -22,22 +22,29 @@ export const Select = ({
   label,
   name,
   onChange
-}: SelectProps): JSX.Element => (
-  // <Field> is kept outside of <label> to accommodate layout in table/grid cells.
-  <>
-    {label && <label htmlFor={name}>{label}</label>}
-    <Field
-      as={Control}
-      componentClass="select"
-      defaultValue={defaultValue}
-      id={name}
-      name={name}
-      onChange={onChange}
-    >
-      {children}
-    </Field>
-  </>
-)
+}: SelectProps): JSX.Element => {
+  const fieldProps = {
+    as: Control,
+    componentClass: 'select',
+    defaultValue,
+    id: name,
+    name
+  }
+  return (
+    // <Field> is kept outside of <label> to accommodate layout in table/grid cells.
+    <>
+      {label && <label htmlFor={name}>{label}</label>}
+      {/* passing an onChange will override Formik's onChange, so only pass if onChange exists. */}
+      {onChange ? (
+        <Field {...fieldProps} onChange={onChange}>
+          {children}
+        </Field>
+      ) : (
+        <Field {...fieldProps}>{children}</Field>
+      )}
+    </>
+  )
+}
 
 interface OptionsPropsBase<T> {
   defaultValue?: T


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Fixes a bug in Trip Notifications Settings where an undefined `onChange` was overriding Formik `Field`'s inherent `onChange`, making it so users could not change their trip notification settings.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

