### PR TITLE
Small config and README changes for out-of-the-box use

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An example of an OTP-RR application is included in the repository. The example p
 
 To run, first clone the repo and install [yarn](https://yarnpkg.com/) if needed.
 
-Update `example-config.yml` with the needed API keys, and optionally, the OTP endpoint and initial map origin. (The default values are for a test server for Portland, OR.).
+Update `example-config.yml` with the needed API keys, and optionally, the OTP endpoint and initial map origin. (The default values are for a test server for Portland, OR.). See the comments at the head of the config file for further details.
 
 Install the dependencies and start a local instance using the following script:
 
@@ -41,6 +41,8 @@ env JS_CONFIG=my-custom-js.js CUSTOM_CSS=my-custom-css.css yarn build
 
 OTP-react-redux uses `react-intl` from the [`formatjs`](https://github.com/formatjs/formatjs) library for internationalization.
 Both `react-intl` and `formatjs` take advantage of native internationalization features provided by web browsers.
+
+The example application supports several different languages out of the box. It will first check the `lang` key in `window.localstorage` for ISO language codes such as `fr` or `es` matching files in the i18n directory, then fall back on the `navigator.language` that is typically configured via your web browser's settings, before finally falling back on the `localization: defaultLocale` item defined in `example-config.yml`.
 
 ### `i18n` Folder
 

--- a/example-config.yml
+++ b/example-config.yml
@@ -1,3 +1,10 @@
+# To use OTP-RR with your own OTP deployment, at a minimum you will need to set the
+# host and port under the api section (for example to http://localhost and 8080).
+# The v2 configuration item here refers to OTP 2.x, not a versioned API with base URLs
+# ending in v2. OTP v1 is no longer supported by OTP-RR, so leave this v2 item enabled.
+# The bare minimum additional things to configure are:
+# The initLat, initLon, and  baseLayers in the 'map' section below;
+# The apiKey, boundary, focus point, and baseUrl in the 'geocoder' section below.
 api:
   host: http://localhost
   # Path will be deprecated once the REST API is deprecated, which will be soon.
@@ -6,8 +13,8 @@ api:
   # If your OTP server is at a path other than "/otp" (usually due to a proxy)
   # Then you can set the OPTIONAL property basePath. The default is "/otp"
   basePath: /otp
-  port: 8001
-# v2: false
+  port: 8080
+  v2: true
 
 # Determines if the header brand should be clickable or not. If set to true, 
 # clicking the header brand will go back to the main trip planner page and wipe out any
@@ -164,9 +171,11 @@ map:
 # it is possible to leave out a geocoder config entirely. In that case only
 # GPS coordinates will be used when finding the origin/destination.
 
-# example config for a Pelias geocoder (https://pelias.io/)
+# Example config for a Pelias geocoder (https://pelias.io/).
+# Until you have deployed or subscribed to a geocoder service, a short-term temporary
+# geocoder test account can be obtained from the Pelias maintainers at geocode.earth.
 geocoder:
-  apiKey: MAPZEN_KEY
+  apiKey: PELIAS_API_KEY
   boundary:
     rect:
       minLon: -123.2034


### PR DESCRIPTION
I've recently been discussing OTP frontends with people evaluating components for new, large-scale OTP deployments. I've summarized the various frontend options in a PR to the main OTP docs: https://github.com/opentripplanner/OpenTripPlanner/pull/5679/files

Most people I talked to were under the impression that it would be very difficult to get any "real" (non-debug) UI up and running, and that it might take days of work by an experienced specialist. I took a chance tinkering with OTP-RR and after a few false starts, in the end it basically works out of the box with only a couple of changes to the default example config file.

Some simple ambiguities about indentation levels of settings and the meaning of "api: v2", as well as the internationalization behavior, made this seem much more complex than it actually is.

This PR proposes a few small changes to the config file and README that I believe will make this project immediately usable by most people getting started with OTP. This could really affect the perception and approachability of OTP among people evaluating it.

After realizing how straightforward this project now is to set up, I also think there's potential for OTP-RR to be considered the de facto stock frontend for OTP, and to be referred to as such in the documentation. At the time people began working on it, I recall OTP-RR being referred to as the new default frontend, and if I'm not mistaken there was an official steering committee decision to place these UI projects directly under the OpenTripPlanner organization (where they remain to this day).