### PR TITLE
Further tweaks to config and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ To run, first clone the repo and install [yarn](https://yarnpkg.com/) if needed.
 
 Update `example-config.yml` with the needed API keys, and optionally, the OTP endpoint and initial map origin. (The default values are for a test server for Portland, OR.). See the comments at the head of the config file for further details.
 
-Install the dependencies and start a local instance using the following script:
+Install the dependencies and start a local development server using the following script:
 
 ```bash
 yarn start
 ```
+
+The port on which the development server listens can be configured in `.env`.
 
 Should you want to maintain multiple configuration files, OTP-RR can be made to use a custom config file by using environment variables. Other environment variables also exist. `CUSTOM_CSS` can be used to point to a css file to inject, and `JS_CONFIG` can be used to point to a `config.js` file to override the one shipped with OTP-RR.
 
@@ -29,7 +31,7 @@ env YAML_CONFIG=/absolute/path/to/config.yml yarn start
 
 ## Deploying the UI
 
-Build the js/css bundle by running `yarn build`. The build will appear in the `dist/` directory).
+Build a production js/css bundle by running `yarn build`. The build will appear in the `dist/` directory). It consists entirely of static files and can be served by a simple static web server or CDN.
 
 The same environment variables which affect the behavior of `yarn start` also affect `yarn build`. Running the following command builds OTP-RR with customized js and css:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ env JS_CONFIG=my-custom-js.js CUSTOM_CSS=my-custom-css.css yarn build
 OTP-react-redux uses `react-intl` from the [`formatjs`](https://github.com/formatjs/formatjs) library for internationalization.
 Both `react-intl` and `formatjs` take advantage of native internationalization features provided by web browsers.
 
-The example application supports several different languages out of the box. It will first check the `lang` key in `window.localstorage` for ISO language codes such as `fr` or `es` matching files in the i18n directory, then fall back on the `navigator.language` that is typically configured via your web browser's settings, before finally falling back on the `localization: defaultLocale` item defined in `example-config.yml`.
+The example application supports several different languages out of the box, but language selection must be enabled. See the `language` section of the YAML config. Once enabled, the application will first check the `lang` key in `window.localstorage` for ISO language codes such as `fr` or `es` matching files in the i18n directory, then fall back on the `navigator.language` that is typically configured via your web browser's settings, before finally falling back on the `localization: defaultLocale` item defined in `example-config.yml`.
 
 ### `i18n` Folder
 

--- a/example-config.yml
+++ b/example-config.yml
@@ -524,16 +524,21 @@ itinerary:
 #     optionFilter: secondTarget # This button is rendered to the left of the itinerary filter in the batch and metro UIs
 #     sidebarLink: testTarget # this button is rendered in the sidebar
 
-### Language section to override strings.
+### Uncommenting the language section below will enable internationalization as a whole.
+### Defining a language here (a nested section whose name is an ISO language code corresponding to
+### a file in the i18n directory) will make that language available programmatically, and will also
+### cause it to be visible in the LocaleSelector component. Each language must have at least a
+### "name" property defined to be valid. Only this name property is needed for a language to function.
+### The LocaleSelector component, which provides a dropdown for the user to change their locale, will
+### only be rendered in the UI if more than one valid language is included in the language section.
+###
+### Language strings may also be optionally overridden here.
 ### Strings can be set globally for all languages (e.g. for strings that are brands/nouns,
 ### e.g. TriMet's "TransitTracker") or by language.
 ### The nested structure should be the same as the language files under the i18n folder.
 ### You can also customize OTP error messages for itinerary searches based on OTP HTTP codes.
 ### A separate message can be set for each language or locale if necessary.
 ### Languages defined may be region-specific (e.g. en-US) or language-specific (e.g. es, kr)
-### The LocaleSelector component, which provides a dropdown for the user to change their locale, will
-### only be rendered if more than one valid language (all languages must have "name" defined) is included
-### in the language config.
 
 # language:
 #   allLanguages

--- a/example-config.yml
+++ b/example-config.yml
@@ -2,9 +2,11 @@
 # host and port under the api section (for example to http://localhost and 8080).
 # The v2 configuration item here refers to OTP 2.x, not a versioned API with base URLs
 # ending in v2. OTP v1 is no longer supported by OTP-RR, so leave this v2 item enabled.
-# The bare minimum additional things to configure are:
-# The initLat, initLon, and  baseLayers in the 'map' section below;
-# The apiKey, boundary, focus point, and baseUrl in the 'geocoder' section below.
+# The bare minimum additional things to configure in sections below are:
+# The initLat, initLon, and  baseLayers in the 'map' section;
+# The apiKey, boundary, focus point, and baseUrl in the 'geocoder' section;
+# All locally relevant modes of transport in the 'modes: transitModes' section;
+# If needed, any language codes and names in the 'language' section.
 api:
   host: http://localhost
   # Path will be deprecated once the REST API is deprecated, which will be soon.
@@ -264,11 +266,19 @@ modes:
       # most notably in the enhanced stop viewer bubble
       color: blue
     - mode: TRAM
+      # For each GTFS mode, you can customize the label displayed in the UI.
       label: MAX & Streetcar
     - mode: RAIL
       label: WES
     - mode: GONDOLA
       label: Aerial Tram
+    ## Additional modes added here will be visible in the mode selector in the UI.
+    ## Modes that are not configured here will never be enabled in requests, so if
+    ## your network has subways or ferries be sure they are present here.
+    - mode: SUBWAY
+      label: Subway
+    - mode: FERRY
+      label: Ferry
 
   # Potentially deprecated
   accessModes:


### PR DESCRIPTION
This is a follow-up to #1138 after figuring out a few more details on configuration and deployment.

Although all modes are selected by default, only the modes present in the UI are sent in the request. This does not include subway or ferry in the example configuration. In places where these modes exist, the resulting itineraries will look "broken" (always using buses instead of subways), and it's not immediately apparent that other modes need to be added or how to do so. I added some explanation on this, as well as subway and ferry modes. These can be commented out in the example YAML if it causes any problem, as their use is explained in other new comments.

The comments on i18n in my previous PR were not complete - I eventually realized i18n does not exactly work out of the box and has to be enabled in the config. The comments on the language section in the config begin by saying the section serves to override strings (rather than to enable languages). Further down it does say that the UI element for selecting languages will only appear if languages are defined in this section, but I eventually realized the languages are not even available for activation by navigator.language unless configured here. I have tried to make this clearer in the config comments.

I also added a few words to the instructions for starting a server and performing a production build.

All of my statements here are inferred from experimenting with OTP-RR while deploying it in an evaluation situation, so please correct me if I've reached any incorrect conclusions.
 
Aside: I noticed that the dev branch is not protected. It looks like the current workflow is for dev to always be updated from pull requests, so protection against direct pushes should probably be enabled on dev.
