### PR TITLE
Replace previous trip with monitored trip in planNewTripFromMonitoredTrip

### DIFF
--- a/lib/actions/user.js
+++ b/lib/actions/user.js
@@ -654,9 +654,8 @@ export function planNewTripFromMonitoredTrip(monitoredTrip) {
     const newQuery = planParamsToQuery(qs.parse(monitoredTrip.queryParams))
     newQuery.date = getCurrentDate(getState().otp.config.homeTimezone)
 
+    dispatch(routeTo('/', ''))
     dispatch(setQueryParam(newQuery))
-
-    dispatch(routeTo('/'))
 
     // This prevents some kind of race condition whose origin I can't figure
     // out. Unless this is called after redux catches up with routing to the '/'


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Fixes issue where clicking the "plan new trip" button on a monitored trip would not clear out the current trip before running a search. 

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

