### PR TITLE
Fix route viewer crash Part 2

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -186,16 +186,18 @@ export function setViewedStop(payload, viewer = 'nearby') {
   return function (dispatch, getState) {
     // payload.stopId may be undefined, which is ok as will be ignored by getPathFromParts
     // redirect to the nearby view if we want to view this stop in the nearby view
-    if (viewer === 'nearby') {
-      if (payload?.lat && payload?.lon) {
-        dispatch(setViewedNearbyCoords(payload))
+    if (payload) {
+      if (viewer === 'nearby') {
+        if (payload?.lat && payload?.lon) {
+          dispatch(setViewedNearbyCoords(payload))
+        } else {
+          dispatch(fetchNearbyFromStopId(payload?.stopId))
+        }
       } else {
-        dispatch(fetchNearbyFromStopId(payload?.stopId))
+        dispatch(viewStop(payload))
+        const path = getPathFromParts('schedule', payload?.stopId)
+        dispatch(routeTo(path))
       }
-    } else {
-      dispatch(viewStop(payload))
-      const path = getPathFromParts('schedule', payload?.stopId)
-      if (payload) dispatch(routeTo(path))
     }
   }
 }


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
@nukeador found a serious flaw in our new schedule view code. This PR implements a version of their fix. The route viewer doesn't throw errors anymore, and route viewer deep-linking is supported again.

Closes #1167
<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

