### PR TITLE
Use query to set focus point

### DIFF
--- a/lib/components/form/connect-location-field.js
+++ b/lib/components/form/connect-location-field.js
@@ -80,17 +80,19 @@ export default function connectLocationField(
     }
 
     const geocoderConfig = config.geocoder
-    if (query.to) {
-      const { lat, lon } = query.to
-      geocoderConfig.focusPoint = { lat, lon }
-    }
-    if (query.from) {
-      const { lat, lon } = query.from
-      geocoderConfig.focusPoint = { lat, lon }
-    }
-    if (currentPosition?.coords) {
-      const { latitude: lat, longitude: lon } = currentPosition.coords
-      geocoderConfig.focusPoint = { lat, lon }
+    if (geocoderConfig) {
+      if (query.to && query.to?.lat && query.to?.lon) {
+        const { lat, lon } = query.to
+        geocoderConfig.focusPoint = { lat, lon }
+      }
+      if (query.from && query.from?.lat && query.from?.lon) {
+        const { lat, lon } = query.from
+        geocoderConfig.focusPoint = { lat, lon }
+      }
+      if (currentPosition?.coords) {
+        const { latitude: lat, longitude: lon } = currentPosition.coords
+        geocoderConfig.focusPoint = { lat, lon }
+      }
     }
 
     const stateToProps = {

--- a/lib/components/form/connect-location-field.js
+++ b/lib/components/form/connect-location-field.js
@@ -80,6 +80,14 @@ export default function connectLocationField(
     }
 
     const geocoderConfig = config.geocoder
+    if (query.to) {
+      const { lat, lon } = query.to
+      geocoderConfig.focusPoint = { lat, lon }
+    }
+    if (query.from) {
+      const { lat, lon } = query.from
+      geocoderConfig.focusPoint = { lat, lon }
+    }
     if (currentPosition?.coords) {
       const { latitude: lat, longitude: lon } = currentPosition.coords
       geocoderConfig.focusPoint = { lat, lon }


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
We use the `from` or `to` query to set the focus point for the other. helps users plan short trips (?)

<img width="427" alt="Screenshot 2024-03-20 at 12 12 13 PM" src="https://github.com/opentripplanner/otp-react-redux/assets/86619099/ec05c5b9-6d73-4f6d-a859-00a96a521f62">

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

