### PR TITLE
fix(route-viewer): Cleanup duplicate headsign filtering

### DIFF
--- a/lib/components/viewers/route-details.tsx
+++ b/lib/components/viewers/route-details.tsx
@@ -92,13 +92,15 @@ class RouteDetails extends Component<Props> {
           lastStop: pat.stops?.[pat.stops?.length - 1]?.name
         })
       )
-      // Address duplicate headsigns. Replaces duplicate headsigns with the last stop name
+      // Address duplicate headsigns.
       .reduce((prev: PatternSummary[], cur) => {
         const amended = prev
         const alreadyExistingIndex = prev.findIndex(
           (h) => h.headsign === cur.headsign
         )
-        // If the item we're replacing has less geometry, amend the headsign to be more helpful
+        // If the headsign is a duplicate, and the last stop of the pattern is not the headsign,
+        // amend the headsign with the last stop name in parenthesis.
+        // e.g. "Headsign (Last Stop)"
         if (
           alreadyExistingIndex >= 0 &&
           cur.lastStop &&
@@ -116,13 +118,14 @@ class RouteDetails extends Component<Props> {
               { id: 'components.RouteDetails.headsignTo' },
               { ...amended[0] }
             )
+            amended.push(cur)
+            return amended
           }
         }
 
-        // This resolves the edge case where two patterns with the same headsign are
-        // getting filterted out. This resolves that
+        // With all remaining duplicate headsigns, only keep the pattern with the
+        // longest geometry.
         if (alreadyExistingIndex >= 0) {
-          // Only replace if new pattern has greater geometry
           if (
             amended[alreadyExistingIndex].geometryLength < cur.geometryLength
           ) {


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Fixes bug that was causing one headsign to show up in cases where there are only two headsigns on a pattern and both headsigns have the same name.

Also updates some of the comments for clarity.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

