### PR TITLE
fix(FavoritePlaceScreen): Clone user place before setting up the screen.

### DIFF
--- a/lib/components/user/places/favorite-place-screen.js
+++ b/lib/components/user/places/favorite-place-screen.js
@@ -117,7 +117,8 @@ class FavoritePlaceScreen extends Component {
     const { pendingSave } = this.state
     // Get the places as shown (and not as retrieved from db), so that the index passed from URL applies
     // (indexes 0 and 1 are for Home and Work locations).
-    const place = this._getPlaceToEdit(loggedInUser)
+    // Clone the place to avoid improper state mutation in the lines below.
+    const place = clone(this._getPlaceToEdit(loggedInUser))
     // For <input> controls, the value must be at least ''.
     if (place?.name === null) {
       place.name = ''
@@ -154,7 +155,7 @@ class FavoritePlaceScreen extends Component {
           id: 'components.SubNav.myAccount'
         }) : '']} />
         <Formik
-          initialValues={clone(place)}
+          initialValues={place}
           onSubmit={this._handleSave}
           validateOnBlur
           // Avoid validating on change as it is annoying. Validating on blur is enough.


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

Component `FavoritePlaceScreen` improperly mutates user-saved locations in the redux state.
This PR fixes that.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

