### PR TITLE
Clarify error message in cases where phone number is not verified

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -431,6 +431,9 @@ components:
       minutes).
     verified: Verified
     verify: Verify
+    verifySms: >-
+      Please complete the verification process in order to set up SMS
+      notifications.
   Place:
     deleteThisPlace: Delete this place
     enterAlert: >

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -444,7 +444,7 @@ components:
     requestNewCode: Envoyer un nouveau code
     sendVerificationText: Envoyer le SMS de vérification
     smsConsent: >
-      En donnant votre numéro téléphone, vous acceptez de recevoir des SMS de
+      En donnant votre numéro de téléphone, vous acceptez de recevoir des SMS de
       vérification et de suivi de vos trajets. Frais applicables selon votre
       opérateur téléphonique.
     verificationCode: "Code de vérification :"
@@ -453,6 +453,9 @@ components:
       code ci-dessous (le code expire après 10 minutes).
     verified: Vérifié
     verify: Vérifier
+    verifySms: >-
+      Veuillez effectuer la vérification de votre numéro de téléphone afin de
+      recevoir des notifications par SMS.
   Place:
     deleteThisPlace: Supprimer ce lieu
     enterAlert: >

--- a/lib/components/user/standard-panes.tsx
+++ b/lib/components/user/standard-panes.tsx
@@ -38,7 +38,7 @@ const standardPanes: Record<string, PaneProps> = {
   notifications: {
     getInvalidMessage: (intl: IntlShape) =>
       intl.formatMessage({
-        id: 'components.PhoneNumberEditor.invalidPhone'
+        id: 'components.PhoneNumberEditor.verifySms'
       }),
     id: 'notifications',
     isInvalid: ({


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

Creates a new error message to display to users during the account creation process, in cases where they have selected SMS notifications but not yet verified their phone number.

This fixes an issue users noticed where if they have entered their phone numbers but not selected "send verification text". the error "please enter a valid phone number" does not make sense.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

