### PR TITLE
fix(nearby-view): don't flash stale data while loading new response

### DIFF
--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -482,7 +482,11 @@ export const fetchNearby = (position, radius) => {
           error.cause = payload.errors
           throw error
         }
-        return mergeSameStops(payload.data?.nearest?.edges)
+        return {
+          data: mergeSameStops(payload.data?.nearest?.edges),
+          lat,
+          lon
+        }
       }
     }
   )

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -75,7 +75,6 @@ function NearbyView({
   nearbyViewCoords,
   radius,
   setHighlightedLocation,
-  setLocation,
   setMainPanelContent,
   setViewedNearbyCoords,
   zoomToPlace
@@ -93,7 +92,7 @@ function NearbyView({
   }, [location, setHighlightedLocation])
 
   useEffect(() => {
-    const moveListener = (e: any) => {
+    const moveListener = (e: mapboxgl.EventData) => {
       if (e.geolocateSource) {
         setViewedNearbyCoords({
           lat: e.viewState.latitude,
@@ -102,7 +101,7 @@ function NearbyView({
       }
     }
 
-    const dragListener = (e: any) => {
+    const dragListener = (e: mapboxgl.EventData) => {
       const coords = {
         lat: e.viewState.latitude,
         lon: e.viewState.longitude
@@ -255,11 +254,13 @@ const mapStateToProps = (state: AppReduxState) => {
   const { nearbyViewCoords } = ui
   const { nearby } = transitIndex
   const { entityId } = state.router.location.query
+  const showNearby =
+    nearby?.lat === nearbyViewCoords.lat && nearby?.lon === nearbyViewCoords.lon
   return {
     entityId: entityId && decodeURIComponent(entityId),
     homeTimezone: config.homeTimezone,
     location: state.router.location.hash,
-    nearby,
+    nearby: showNearby ? nearby?.data : null,
     nearbyViewCoords,
     radius: config.nearbyView?.radius
   }


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Nearby view would show stale data from redux when loading a new location. This fixes that by storing the associated coordinates along with the nearby response in Redux, allowing us to hide the results if the coords don't match the URL coords. 
<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

