### PR TITLE
fix(verify-email-pane): Force update email_verified

### DIFF
--- a/lib/components/user/verify-email-pane.tsx
+++ b/lib/components/user/verify-email-pane.tsx
@@ -19,14 +19,18 @@ interface Props {
  * This component contains the prompt for the user to verify their email address.
  * It also contains a button that lets the user finish account setup.
  *
- * (One way to make sure the parent page fetches the latest email verification status
- * is to simply reload the page.)
+ * (To force the user to update, logout and refresh the page - the user should
+ * automatically get logged back in)
  */
 const VerifyEmailPane = ({ resendVerificationEmail, routeTo }: Props) => {
   const intl = useIntl()
   const emailVerified = useAuth0().user?.email_verified
+  const logout = useAuth0().logout
 
-  const handleEmailVerified = useCallback(() => window.location.reload(), [])
+  const handleEmailVerified = useCallback(() => {
+    logout()
+    window.location.reload()
+  }, [])
 
   const handleResend = useCallback(() => {
     resendVerificationEmail(intl)


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Fixes a bug where `user.email_verified` was not being updated on refresh, which was causing users to get stuck in the sign up flow. 

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

