### PR TITLE
fix(apiV2): Don't perform query/UI changes on invalid mode selection

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true
+          ignore_words_list: MapPin
           # skip git, yarn, pixel test script and HAR file, and all i18n resources.
           # Also, the a11y test file has a false positive and the ignore list does not work
           # see https://github.com/opentripplanner/otp-react-redux/pull/436/checks?check_run_id=3369380014

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -1005,6 +1005,10 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
     // This is likely due to the fact that BICYCLE_RENT is treated as a transit submode.
     const combinations = modes ? [baseQuery] : generateCombinations(baseQuery)
 
+    if (combinations.length === 0) {
+      return RoutingQueryCallResult.INVALID_MODE_SELECTION
+    }
+
     dispatch(
       routingRequest({
         activeItinerary,
@@ -1171,9 +1175,7 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
       dispatch(updateOtpUrlParams(state, searchId))
     }
 
-    return combinations.length === 0
-      ? RoutingQueryCallResult.INVALID_MODE_SELECTION
-      : RoutingQueryCallResult.SUCCESS
+    return RoutingQueryCallResult.SUCCESS
   }
 }
 


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

With this PR, `routingQuery` exits early before performing any OTP calls if the mode selection is invalid.
If the UI was on search, it remains there. If UI had previous search results, those results continue to be shown.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

