### PR TITLE
Add Plan Trip Button to Advanced Mode Settings Page

### DIFF
--- a/lib/components/app/batch-routing-panel.tsx
+++ b/lib/components/app/batch-routing-panel.tsx
@@ -2,7 +2,6 @@ import { connect } from 'react-redux'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import { FormattedMessage, injectIntl, IntlShape } from 'react-intl'
 import React, { Component, FormEvent } from 'react'
-import toast from 'react-hot-toast'
 
 import {
   advancedPanelClassName,
@@ -67,8 +66,6 @@ class BatchRoutingPanel extends Component<Props> {
   }
 
   handleCloseAdvanceSettings = () => {
-    const { intl } = this.props
-    toast.success(intl.formatMessage({ id: 'actions.user.preferencesSaved' }))
     this.setState({ showAdvancedModeSettings: false })
   }
 

--- a/lib/components/app/batch-routing-panel.tsx
+++ b/lib/components/app/batch-routing-panel.tsx
@@ -1,15 +1,8 @@
 import { connect } from 'react-redux'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import { FormattedMessage, injectIntl, IntlShape } from 'react-intl'
-
-import { getActiveSearch, getShowUserSettings } from '../../util/state'
-import { getPersistenceMode } from '../../util/user'
-import AdvancedSettingsPanel from '../form/advanced-settings-panel'
-import BatchSettings from '../form/batch-settings'
-import InvisibleA11yLabel from '../util/invisible-a11y-label'
-import LocationField from '../form/connected-location-field'
-import NarrativeItineraries from '../narrative/narrative-itineraries'
 import React, { Component, FormEvent } from 'react'
+import toast from 'react-hot-toast'
 
 import {
   advancedPanelClassName,
@@ -17,10 +10,14 @@ import {
   transitionDuration,
   TransitionStyles
 } from '../form/styled'
+import { getActiveSearch, getShowUserSettings } from '../../util/state'
+import { getPersistenceMode } from '../../util/user'
+import AdvancedSettingsPanel from '../form/advanced-settings-panel'
+import BatchSettings from '../form/batch-settings'
+import InvisibleA11yLabel from '../util/invisible-a11y-label'
+import LocationField from '../form/connected-location-field'
+import NarrativeItineraries from '../narrative/narrative-itineraries'
 import SwitchButton from '../form/switch-button'
-
-import toast from 'react-hot-toast'
-
 import UserSettings from '../form/user-settings'
 import ViewerContainer from '../viewers/viewer-container'
 

--- a/lib/components/app/batch-routing-panel.tsx
+++ b/lib/components/app/batch-routing-panel.tsx
@@ -18,6 +18,9 @@ import {
   TransitionStyles
 } from '../form/styled'
 import SwitchButton from '../form/switch-button'
+
+import toast from 'react-hot-toast'
+
 import UserSettings from '../form/user-settings'
 import ViewerContainer from '../viewers/viewer-container'
 
@@ -67,6 +70,8 @@ class BatchRoutingPanel extends Component<Props> {
   }
 
   handleCloseAdvanceSettings = () => {
+    const { intl } = this.props
+    toast.success(intl.formatMessage({ id: 'actions.user.preferencesSaved' }))
     this.setState({ showAdvancedModeSettings: false })
   }
 
@@ -113,6 +118,7 @@ class BatchRoutingPanel extends Component<Props> {
                   <AdvancedSettingsPanel
                     closeAdvancedSettings={this.handleCloseAdvanceSettings}
                     innerRef={this._advancedSettingRef}
+                    onPlanTripClick={this.handlePlanTripClick}
                   />
                 </CSSTransition>
               )}

--- a/lib/components/form/advanced-settings-panel.tsx
+++ b/lib/components/form/advanced-settings-panel.tsx
@@ -82,7 +82,7 @@ const PlanTripButton = styled.button`
   gap: 0.5em;
   background-color: var(--main-base-color, ${blue[900]});
   border: 0;
-  width: 45%;
+  width: 47%;
   height: 51px;
   color: white;
   font-weight: 700;

--- a/lib/components/form/advanced-settings-panel.tsx
+++ b/lib/components/form/advanced-settings-panel.tsx
@@ -24,9 +24,6 @@ import { AppReduxState } from '../../util/state-types'
 import { blue, getBaseColor } from '../util/colors'
 import { ComponentContext } from '../../util/contexts'
 import { generateModeSettingValues } from '../../util/api'
-
-import { setModeButtonEnabled } from './batch-settings'
-import { styledCheckboxCss } from './styled'
 import PageTitle from '../util/page-title'
 
 import {
@@ -38,6 +35,8 @@ import {
   populateSettingWithIcon,
   setModeButton
 } from './util'
+import { setModeButtonEnabled } from './batch-settings'
+import { styledCheckboxCss } from './styled'
 
 const PanelOverlay = styled.div`
   height: 100%;

--- a/lib/components/form/advanced-settings-panel.tsx
+++ b/lib/components/form/advanced-settings-panel.tsx
@@ -7,21 +7,22 @@ import { Close } from '@styled-icons/fa-solid'
 import { connect } from 'react-redux'
 import { decodeQueryParams, DelimitedArrayParam } from 'serialize-query-params'
 import { FormattedMessage, useIntl } from 'react-intl'
-import { Search } from '@styled-icons/fa-solid/Search'
-
-import { generateModeSettingValues } from '../../util/api'
 import {
   ModeButtonDefinition,
   ModeSetting,
   ModeSettingValues
 } from '@opentripplanner/types'
-
-import PageTitle from '../util/page-title'
-
+import { Search } from '@styled-icons/fa-solid/Search'
 import React, { RefObject, useContext } from 'react'
+import styled from 'styled-components'
 
 import * as apiActions from '../../actions/api'
 import * as formActions from '../../actions/form'
+import { AppReduxState } from '../../util/state-types'
+import { blue, getBaseColor } from '../util/colors'
+import { ComponentContext } from '../../util/contexts'
+import { generateModeSettingValues } from '../../util/api'
+import PageTitle from '../util/page-title'
 
 import {
   addCustomSettingLabels,
@@ -32,13 +33,7 @@ import {
   populateSettingWithIcon,
   setModeButton
 } from './util'
-import { AppReduxState } from '../../util/state-types'
 import { setModeButtonEnabled } from './batch-settings'
-
-import { blue, getBaseColor } from '../util/colors'
-import { ComponentContext } from '../../util/contexts'
-
-import styled from 'styled-components'
 
 const baseColor = getBaseColor()
 const accentColor = baseColor || blue[900]

--- a/lib/components/form/advanced-settings-panel.tsx
+++ b/lib/components/form/advanced-settings-panel.tsx
@@ -1,23 +1,15 @@
-import * as apiActions from '../../actions/api'
-import * as formActions from '../../actions/form'
 import {
   addSettingsToButton,
   AdvancedModeSubsettingsContainer,
   populateSettingWithValue
 } from '@opentripplanner/trip-form'
-import { AppReduxState } from '../../util/state-types'
-import { blue, getBaseColor } from '../util/colors'
-
 import { Close } from '@styled-icons/fa-solid'
-
-import { ComponentContext } from '../../util/contexts'
-
 import { connect } from 'react-redux'
 import { decodeQueryParams, DelimitedArrayParam } from 'serialize-query-params'
 import { FormattedMessage, useIntl } from 'react-intl'
+import { Search } from '@styled-icons/fa-solid/Search'
 
 import { generateModeSettingValues } from '../../util/api'
-
 import {
   ModeButtonDefinition,
   ModeSetting,
@@ -28,20 +20,30 @@ import PageTitle from '../util/page-title'
 
 import React, { RefObject, useContext } from 'react'
 
+import * as apiActions from '../../actions/api'
+import * as formActions from '../../actions/form'
+
 import {
   addCustomSettingLabels,
   addModeButtonIcon,
+  alertUserTripPlan,
   onSettingsUpdate,
   pipe,
   populateSettingWithIcon,
   setModeButton
 } from './util'
+import { AppReduxState } from '../../util/state-types'
 import { setModeButtonEnabled } from './batch-settings'
+
+import { blue, getBaseColor } from '../util/colors'
+import { ComponentContext } from '../../util/contexts'
 
 import styled from 'styled-components'
 
+const baseColor = getBaseColor()
+const accentColor = baseColor || blue[900]
+
 const PanelOverlay = styled.div`
-  background-color: #fff;
   height: 100%;
   left: 0;
   padding: 1.5em;
@@ -69,24 +71,52 @@ const Subheader = styled.h2`
   font-weight: 700;
   margin: 1em 0;
 `
-const baseColor = getBaseColor()
-const accentColor = baseColor || blue[900]
+
+const PlanTripButton = styled.button`
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  gap: 0.5em;
+  background-color: ${baseColor};
+  border: 0;
+  width: 45%;
+  height: 51px;
+  color: white;
+  font-weight: 700;
+`
+
+const ReturnToTripPlanButton = styled(PlanTripButton)`
+  border: 2px solid ${baseColor};
+  background-color: white;
+  color: ${baseColor};
+`
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-top: 2em;
+`
 
 const AdvancedSettingsPanel = ({
   closeAdvancedSettings,
+  currentQuery,
   enabledModeButtons,
   innerRef,
   modeButtonOptions,
   modeSettingDefinitions,
   modeSettingValues,
+  onPlanTripClick,
+  routingQuery,
   setQueryParam
 }: {
   closeAdvancedSettings: () => void
+  currentQuery: any
   enabledModeButtons: string[]
   innerRef: RefObject<HTMLDivElement>
   modeButtonOptions: ModeButtonDefinition[]
   modeSettingDefinitions: ModeSetting[]
   modeSettingValues: ModeSettingValues
+  onPlanTripClick: () => void
+  routingQuery: () => void
   setQueryParam: (evt: any) => void
 }): JSX.Element => {
   const intl = useIntl()
@@ -99,6 +129,11 @@ const AdvancedSettingsPanel = ({
 
   // @ts-expect-error Context not typed
   const { ModeIcon } = useContext(ComponentContext)
+
+  const planTrip = () => {
+    alertUserTripPlan(intl, currentQuery, onPlanTripClick, routingQuery)
+    closeAdvancedSettings()
+  }
 
   const processedModeSettings = modeSettingDefinitions.map(
     pipe(
@@ -155,6 +190,15 @@ const AdvancedSettingsPanel = ({
           onSettingsUpdate(setQueryParam)
         )}
       />
+      <ButtonContainer>
+        <ReturnToTripPlanButton onClick={closeAdvancedSettings}>
+          Back to Trip Plan
+        </ReturnToTripPlanButton>
+        <PlanTripButton onClick={planTrip}>
+          <Search size={18} />
+          <FormattedMessage id="components.BatchSettings.planTripTooltip" />
+        </PlanTripButton>
+      </ButtonContainer>
     </PanelOverlay>
   )
 }

--- a/lib/components/form/advanced-settings-panel.tsx
+++ b/lib/components/form/advanced-settings-panel.tsx
@@ -39,9 +39,6 @@ import {
   setModeButton
 } from './util'
 
-const baseColor = getBaseColor()
-const accentColor = baseColor || blue[900]
-
 const PanelOverlay = styled.div`
   height: 100%;
   left: 0;
@@ -83,7 +80,7 @@ const PlanTripButton = styled.button`
   display: flex;
   justify-content: center;
   gap: 0.5em;
-  background-color: ${baseColor};
+  background-color: var(--main-base-color, ${blue[900]});
   border: 0;
   width: 45%;
   height: 51px;
@@ -92,9 +89,9 @@ const PlanTripButton = styled.button`
 `
 
 const ReturnToTripPlanButton = styled(PlanTripButton)`
-  border: 2px solid ${baseColor};
+  border: 2px solid var(--main-base-color, ${blue[900]});
   background-color: white;
-  color: ${baseColor};
+  color: var(--main-base-color, ${blue[900]});
 `
 const ButtonContainer = styled.div`
   display: flex;
@@ -125,6 +122,9 @@ const AdvancedSettingsPanel = ({
   routingQuery: () => void
   setQueryParam: (evt: any) => void
 }): JSX.Element => {
+  const baseColor = getBaseColor()
+  const accentColor = baseColor || blue[900]
+
   const intl = useIntl()
   const closeButtonText = intl.formatMessage({
     id: 'components.BatchSearchScreen.closeAdvancedPreferences'

--- a/lib/components/form/advanced-settings-panel.tsx
+++ b/lib/components/form/advanced-settings-panel.tsx
@@ -25,6 +25,7 @@ import { blue, getBaseColor } from '../util/colors'
 import { ComponentContext } from '../../util/contexts'
 import { generateModeSettingValues } from '../../util/api'
 import PageTitle from '../util/page-title'
+import toast from 'react-hot-toast'
 
 import {
   addCustomSettingLabels,
@@ -140,6 +141,11 @@ const AdvancedSettingsPanel = ({
     closeAdvancedSettings()
   }
 
+  const closeAndAnnounce = () => {
+    closeAdvancedSettings()
+    toast.success(intl.formatMessage({ id: 'actions.user.preferencesSaved' }))
+  }
+
   const processSettings = (settings: ModeSetting[]) =>
     settings.map(
       pipe(
@@ -178,7 +184,7 @@ const AdvancedSettingsPanel = ({
         <h1 className="header-text">{headerText}</h1>
         <CloseButton
           aria-label={closeButtonText}
-          onClick={closeAdvancedSettings}
+          onClick={closeAndAnnounce}
           title={closeButtonText}
         >
           <Close size={22} />
@@ -212,7 +218,7 @@ const AdvancedSettingsPanel = ({
         )}
       />
       <ButtonContainer>
-        <ReturnToTripPlanButton onClick={closeAdvancedSettings}>
+        <ReturnToTripPlanButton onClick={closeAndAnnounce}>
           Back to Trip Plan
         </ReturnToTripPlanButton>
         <PlanTripButton onClick={planTrip}>

--- a/lib/components/form/batch-settings.tsx
+++ b/lib/components/form/batch-settings.tsx
@@ -4,11 +4,7 @@ import {
   populateSettingWithValue
 } from '@opentripplanner/trip-form'
 import { connect } from 'react-redux'
-import {
-  decodeQueryParams,
-  DelimitedArrayParam,
-  encodeQueryParams
-} from 'use-query-params'
+import { decodeQueryParams } from 'use-query-params'
 import {
   ModeButtonDefinition,
   ModeSetting,
@@ -25,12 +21,12 @@ import { ComponentContext } from '../../util/contexts'
 import { generateModeSettingValues } from '../../util/api'
 import { getActiveSearch, hasValidLocation } from '../../util/state'
 import { getBaseColor, getDarkenedBaseColor } from '../util/colors'
-import { RoutingQueryCallResult } from '../../actions/api-constants'
 import { StyledIconWrapper } from '../util/styledIcon'
 
 import {
   addCustomSettingLabels,
   addModeButtonIcon,
+  alertUserTripPlan,
   modesQueryParamConfig,
   onSettingsUpdate,
   pipe,
@@ -117,47 +113,8 @@ function BatchSettings({
   )
 
   const _planTrip = useCallback(() => {
-    // Check for any validation issues in query.
-    const issues = []
-    if (!hasValidLocation(currentQuery, 'from')) {
-      issues.push(intl.formatMessage({ id: 'components.BatchSettings.origin' }))
-    }
-    if (!hasValidLocation(currentQuery, 'to')) {
-      issues.push(
-        intl.formatMessage({ id: 'components.BatchSettings.destination' })
-      )
-    }
-    onPlanTripClick && onPlanTripClick()
-    if (issues.length > 0) {
-      // TODO: replace with less obtrusive validation.
-      window.alert(
-        intl.formatMessage(
-          { id: 'components.BatchSettings.validationMessage' },
-          { issues: intl.formatList(issues, { type: 'conjunction' }) }
-        )
-      )
-      return
-    }
-
-    // Plan trip.
-    updateQueryTimeIfLeavingNow()
-    const routingQueryResult = routingQuery()
-
-    // If mode combination is not valid (i.e. produced no query), alert the user.
-    if (routingQueryResult === RoutingQueryCallResult.INVALID_MODE_SELECTION) {
-      window.alert(
-        intl.formatMessage({
-          id: 'components.BatchSettings.invalidModeSelection'
-        })
-      )
-    }
-  }, [
-    currentQuery,
-    intl,
-    onPlanTripClick,
-    routingQuery,
-    updateQueryTimeIfLeavingNow
-  ])
+    alertUserTripPlan(intl, currentQuery, onPlanTripClick, routingQuery)
+  }, [currentQuery, intl, onPlanTripClick, routingQuery])
 
   /**
    * Check whether the mode selector is showing a popup.

--- a/lib/components/form/styled.ts
+++ b/lib/components/form/styled.ts
@@ -1,4 +1,4 @@
-import { blue, getBaseColor, grey } from '../util/colors'
+import { blue, grey } from '../util/colors'
 import {
   DateTimeSelector,
   SettingsSelectorPanel,
@@ -235,7 +235,6 @@ export const StyledLocationField = styled(LocationField)`
 export const advancedPanelClassName = 'advanced-panel'
 export const mainPanelClassName = 'main-panel'
 export const transitionDuration = prefersReducedMotion ? 0 : 175
-const baseColor = getBaseColor()
 
 const wipeOffset = 7
 
@@ -339,7 +338,7 @@ export const styledCheckboxCss = css`
 
     &:checked + label {
       &::after {
-        background-color: ${baseColor || blue[700]};
+        background-color: var(--main-base-color, ${blue[700]});
         ${toggleTransition};
       }
 

--- a/lib/components/form/util.tsx
+++ b/lib/components/form/util.tsx
@@ -74,13 +74,13 @@ export const setModeButton =
   }
 
 export const alertUserTripPlan = (
-  intl,
-  currentQuery,
-  onPlanTripClick,
-  routingQuery
-) => {
+  intl: IntlShape,
+  currentQuery: any,
+  onPlanTripClick: () => void,
+  routingQuery: () => any
+): void => {
   // Check for any validation issues in query.
-  const issues = []
+  const issues: string[] = []
   if (!hasValidLocation(currentQuery, 'from')) {
     issues.push(intl.formatMessage({ id: 'components.BatchSettings.origin' }))
   }
@@ -89,7 +89,7 @@ export const alertUserTripPlan = (
       intl.formatMessage({ id: 'components.BatchSettings.destination' })
     )
   }
-  onPlanTripClick && onPlanTripClick()
+  onPlanTripClick()
   if (issues.length > 0) {
     // TODO: replace with less obtrusive validation.
     window.alert(

--- a/lib/components/mobile/batch-search-screen.tsx
+++ b/lib/components/mobile/batch-search-screen.tsx
@@ -1,6 +1,8 @@
 import { connect } from 'react-redux'
+import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import { injectIntl, IntlShape } from 'react-intl'
 import React, { Component } from 'react'
+import toast from 'react-hot-toast'
 
 import * as uiActions from '../../actions/ui'
 import {
@@ -9,8 +11,6 @@ import {
   transitionDuration,
   TransitionStyles
 } from '../form/styled'
-import { CSSTransition, TransitionGroup } from 'react-transition-group'
-
 import { MobileScreens } from '../../actions/ui-constants'
 import AdvancedSettingsPanel from '../form/advanced-settings-panel'
 import BatchSettings from '../form/batch-settings'
@@ -20,8 +20,6 @@ import SwitchButton from '../form/switch-button'
 
 import MobileContainer from './container'
 import MobileNavigationBar from './navigation-bar'
-
-import toast from 'react-hot-toast'
 
 const { SET_FROM_LOCATION, SET_TO_LOCATION } = MobileScreens
 

--- a/lib/components/mobile/batch-search-screen.tsx
+++ b/lib/components/mobile/batch-search-screen.tsx
@@ -21,6 +21,8 @@ import SwitchButton from '../form/switch-button'
 import MobileContainer from './container'
 import MobileNavigationBar from './navigation-bar'
 
+import toast from 'react-hot-toast'
+
 const { SET_FROM_LOCATION, SET_TO_LOCATION } = MobileScreens
 
 interface Props {
@@ -51,7 +53,9 @@ class BatchSearchScreen extends Component<Props> {
   }
 
   handleCloseAdvanceSettings = () => {
+    const { intl } = this.props
     this.setState({ showAdvancedModeSettings: false })
+    toast.success(intl.formatMessage({ id: 'actions.user.preferencesSaved' }))
   }
 
   render() {
@@ -117,6 +121,7 @@ class BatchSearchScreen extends Component<Props> {
                     <AdvancedSettingsPanel
                       closeAdvancedSettings={this.handleCloseAdvanceSettings}
                       innerRef={this._advancedSettingRef}
+                      onPlanTripClick={this.handlePlanTripClick}
                     />
                   </CSSTransition>
                 )}

--- a/lib/components/mobile/batch-search-screen.tsx
+++ b/lib/components/mobile/batch-search-screen.tsx
@@ -51,9 +51,7 @@ class BatchSearchScreen extends Component<Props> {
   }
 
   handleCloseAdvanceSettings = () => {
-    const { intl } = this.props
     this.setState({ showAdvancedModeSettings: false })
-    toast.success(intl.formatMessage({ id: 'actions.user.preferencesSaved' }))
   }
 
   render() {


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
- Adds 'back' and "plan trip" buttons to the advanced trip form
- Moves around some of the planQuery logic to allow it to be accessed by the advanced trip form
- Adds a toast notification when the advanced settings close, indicating to the user that the settings have been saved

<img width="374" alt="image" src="https://github.com/opentripplanner/otp-react-redux/assets/115499534/948fa7b2-6a7f-4547-b979-4eaad9f76702">


<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

