### PR TITLE
fix(apiV2): Pass batchId when calling GraphQL 'plan' endpoint

### DIFF
--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -103,7 +103,7 @@ function createGraphQLQueryAction(
   options
 ) {
   const fetchOptions = {
-    body: JSON.stringify({ query, variables }),
+    body: JSON.stringify({ batchId: options.batchId, query, variables }),
     headers: { 'Content-Type': 'application/json' },
     method: 'POST'
   }
@@ -1064,6 +1064,7 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
           },
           routingError,
           {
+            batchId: searchId,
             rewritePayload: (response, dispatch, getState) => {
               const itineraries = response.data?.plan?.itineraries
 


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

Works in conjunction with https://github.com/ibi-group/otp-middleware/pull/246.

This PR makes the UI pass a `batchId` parameter when making a call to the GraphQL plan endpoint, so that trip requests can be grouped as a single entry in the "Recent searches" list and in usage reports.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

