### PR TITLE
add new `alwaysShowBothTimes` option for batch ui

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -424,6 +424,8 @@ itinerary:
   #   - 'WALKTIME'
   #   - 'COST'
   #   - 'DEPARTURETIME'
+  # In the batch itinerary UI, this setting will always show both departure/arrival times
+  alwaysShowBothTimes: false
 
 # The transitOperators key is a list of transit operators that can be used to
 # order transit agencies when sorting by route. Also, this can optionally

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -114,6 +114,7 @@ common:
     noItineraryToDisplay: No itinerary to display.
     relativeCo2: |
       {co2} {isMore, select, true {more} other {less} } CO₂ than driving alone
+    timeStartEnd: "{start} – {end}"
     transfers: "{transfers, plural, =0 {} one {# transfer} other {# transfers}}"
   linkOpensNewWindow: (Opens new window)
   modes:

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -123,6 +123,7 @@ common:
     noItineraryToDisplay: Aucun trajet à afficher.
     relativeCo2: |
       {co2} de CO₂ en {isMore, select, true {plus} other {moins} } qu'en voiture
+    timeStartEnd: "{start} – {end}"
     transfers: >-
       {transfers, plural, =0 {} one {# correspondance} other {#
       correspondances}}

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -95,6 +95,17 @@ const ITINERARY_ATTRIBUTES = [
     id: 'arrivalTime',
     order: 1,
     render: (itinerary, options) => {
+      if (options.alwaysShowBothTimes) {
+        return (
+          <FormattedMessage
+            id="common.itineraryDescriptions.timeStartEnd"
+            values={{
+              end: <FormattedTime value={itinerary.endTime} />,
+              start: <FormattedTime value={itinerary.startTime} />
+            }}
+          />
+        )
+      }
       if (options.selection === 'ARRIVALTIME') {
         return <FormattedTime value={itinerary.endTime} />
       }
@@ -250,6 +261,7 @@ class DefaultItinerary extends NarrativeItinerary {
   render() {
     const {
       accessibilityScoreGradationMap,
+      alwaysShowBothTimes,
       co2Config,
       configCosts,
       defaultFareType,
@@ -287,6 +299,7 @@ class DefaultItinerary extends NarrativeItinerary {
     }
 
     const itineraryAttributeOptions = {
+      alwaysShowBothTimes,
       co2Config,
       configCosts,
       LegIcon
@@ -402,6 +415,7 @@ const mapStateToProps = (state, ownProps) => {
   return {
     accessibilityScoreGradationMap:
       state.otp.config.accessibilityScore?.gradationMap,
+    alwaysShowBothTimes: state.otp.config.itinerary?.alwaysShowBothTimes,
     co2Config: state.otp.config.co2,
     configCosts: state.otp.config.itinerary?.costs,
     defaultFareType: state.otp.config.itinerary?.defaultFareType || {

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -263,6 +263,7 @@ export interface ItineraryCostWeights {
 
 export interface ItineraryConfig {
   allowUserAlertCollapsing?: boolean
+  alwaysShowBothTimes?: boolean
   costs?: ItineraryCostConfig
   customBatchUiBackground?: boolean
   defaultFareType?: FareProductSelector


### PR DESCRIPTION
Adds a new setting to enable this behavior:
<img width="259" alt="Screenshot 2024-08-26 at 11 09 36 AM" src="https://github.com/user-attachments/assets/a7f04df1-e380-417c-934c-98f77c03c541">
