### PR TITLE
fix(nearby-view): Avoid blank nearby view on mobile

### DIFF
--- a/__tests__/components/viewers/__snapshots__/nearby-view.js.snap
+++ b/__tests__/components/viewers/__snapshots__/nearby-view.js.snap
@@ -31,6 +31,7 @@ exports[`components > viewers > nearby view renders nothing on a blank page 1`] 
             "fetching": false,
           }
         }
+        defaultLatLon={null}
         fetchNearby={[Function]}
         homeTimezone="America/Los_Angeles"
         nearby={Array []}
@@ -146,6 +147,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
             "fetching": false,
           }
         }
+        defaultLatLon={null}
         fetchNearby={[Function]}
         homeTimezone="America/Los_Angeles"
         nearby={

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -34,6 +34,7 @@ type CurrentPosition = { coords?: { latitude: number; longitude: number } }
 
 type Props = {
   currentPosition?: CurrentPosition
+  defaultLatLon: LatLonObj
   displayedCoords?: LatLonObj
   entityId?: string
   fetchNearby: (latLon: LatLonObj, radius?: number) => void
@@ -73,7 +74,8 @@ const getNearbyItem = (place: any) => {
 function getNearbyCoordsFromUrlOrLocationOrMapCenter(
   coordsFromUrl?: LatLonObj,
   currentPosition?: CurrentPosition,
-  map?: MapRef
+  map?: MapRef,
+  defaultLatLon?: LatLonObj
 ): LatLonObj | null {
   if (coordsFromUrl) {
     return coordsFromUrl
@@ -92,11 +94,15 @@ function getNearbyCoordsFromUrlOrLocationOrMapCenter(
   if (mapCoords) {
     return mapCoords
   }
+  if (defaultLatLon) {
+    return defaultLatLon
+  }
   return null
 }
 
 function NearbyView({
   currentPosition,
+  defaultLatLon,
   displayedCoords,
   entityId,
   fetchNearby,
@@ -119,7 +125,8 @@ function NearbyView({
       getNearbyCoordsFromUrlOrLocationOrMapCenter(
         nearbyViewCoords,
         currentPosition,
-        map
+        map,
+        defaultLatLon
       ),
     [nearbyViewCoords, currentPosition, map]
   )
@@ -283,12 +290,15 @@ function NearbyView({
 
 const mapStateToProps = (state: AppReduxState) => {
   const { config, location, transitIndex, ui } = state.otp
+  const { initLat, initLon } = state.otp.config.map
   const { nearbyViewCoords } = ui
   const { nearby } = transitIndex
   const { entityId } = state.router.location.query
   const { currentPosition } = location
+  const defaultLatLon = { lat: initLat || 0, lon: initLon || 0 }
   return {
     currentPosition,
+    defaultLatLon,
     displayedCoords: nearby?.coords,
     entityId: entityId && decodeURIComponent(entityId),
     homeTimezone: config.homeTimezone,

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -34,7 +34,7 @@ type CurrentPosition = { coords?: { latitude: number; longitude: number } }
 
 type Props = {
   currentPosition?: CurrentPosition
-  defaultLatLon: LatLonObj
+  defaultLatLon: LatLonObj | null
   displayedCoords?: LatLonObj
   entityId?: string
   fetchNearby: (latLon: LatLonObj, radius?: number) => void
@@ -75,7 +75,7 @@ function getNearbyCoordsFromUrlOrLocationOrMapCenter(
   coordsFromUrl?: LatLonObj,
   currentPosition?: CurrentPosition,
   map?: MapRef,
-  defaultLatLon?: LatLonObj
+  defaultLatLon?: LatLonObj | null
 ): LatLonObj | null {
   if (coordsFromUrl) {
     return coordsFromUrl
@@ -295,7 +295,8 @@ const mapStateToProps = (state: AppReduxState) => {
   const { nearby } = transitIndex
   const { entityId } = state.router.location.query
   const { currentPosition } = location
-  const defaultLatLon = { lat: map?.initLat || 0, lon: map?.initLon || 0 }
+  const defaultLatLon =
+    map?.initLat && map?.initLon ? { lat: map.initLat, lon: map.initLon } : null
   return {
     currentPosition,
     defaultLatLon,

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -290,12 +290,12 @@ function NearbyView({
 
 const mapStateToProps = (state: AppReduxState) => {
   const { config, location, transitIndex, ui } = state.otp
-  const { initLat, initLon } = state.otp.config.map
+  const { map } = state.otp.config
   const { nearbyViewCoords } = ui
   const { nearby } = transitIndex
   const { entityId } = state.router.location.query
   const { currentPosition } = location
-  const defaultLatLon = { lat: initLat || 0, lon: initLon || 0 }
+  const defaultLatLon = { lat: map?.initLat || 0, lon: map?.initLon || 0 }
   return {
     currentPosition,
     defaultLatLon,


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

Fixes a bug where, on mobile when user had denied geolocation, a blank page was being displayed due to lack of coordinates. This was happening because the desktop fallback (using the map center as the nearby point) required rendering a map, and mobile does not. Instead, now we pass the `initLon` and `initLat` from the config.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

