### PR TITLE
add option to use arrival time in nearby view

### DIFF
--- a/__tests__/components/viewers/__snapshots__/nearby-view.js.snap
+++ b/__tests__/components/viewers/__snapshots__/nearby-view.js.snap
@@ -11860,6 +11860,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -12021,6 +12022,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -12182,6 +12184,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -12676,6 +12679,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -12837,6 +12841,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -12993,6 +12998,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -13422,6 +13428,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -13583,6 +13590,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -13739,6 +13747,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -18231,6 +18240,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -18387,6 +18397,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -18543,6 +18554,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -18920,6 +18932,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -19414,6 +19427,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -19570,6 +19584,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -19726,6 +19741,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -28359,6 +28375,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -28520,6 +28537,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -28681,6 +28699,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -29188,6 +29207,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -29349,6 +29369,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -29505,6 +29526,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -29939,6 +29961,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -30095,6 +30118,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -30251,6 +30275,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -30628,6 +30653,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -37280,6 +37306,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -37441,6 +37468,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -37597,6 +37625,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -38091,6 +38120,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -38247,6 +38277,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -38403,6 +38434,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -38780,6 +38812,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -45610,6 +45643,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -45771,6 +45805,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -45932,6 +45967,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -53209,6 +53245,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -53365,6 +53402,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -53521,6 +53559,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -53950,6 +53989,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -54111,6 +54151,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -54267,6 +54308,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -54696,6 +54738,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -54852,6 +54895,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -55008,6 +55052,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -55502,6 +55547,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -55658,6 +55704,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -55814,6 +55861,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -56243,6 +56291,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -56399,6 +56448,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -56555,6 +56605,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -56958,6 +57009,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -57114,6 +57166,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -57270,6 +57323,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -64269,6 +64323,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -64430,6 +64485,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -64591,6 +64647,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -65085,6 +65142,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -65246,6 +65304,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -65402,6 +65461,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -65831,6 +65891,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -65992,6 +66053,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"
@@ -66148,6 +66210,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         },
                                                       }
                                                     }
+                                                    useArrivalTime={false}
                                                   >
                                                     <div
                                                       className="percy-hide"

--- a/example-config.yml
+++ b/example-config.yml
@@ -677,6 +677,8 @@ itinerary:
 # sessionTimeoutSeconds: 180
 
 # nearbyView:
+### Setting to use arrival time instead of departure time in the nearby view.
+#   useArrivalTime: true
 ### Setting to hide stops with no depatures in the nearby view.
 #   hideEmptyStops: true
 ### What radius should the nearby query get results within? (in meters)

--- a/lib/components/viewers/stop-time-cell.tsx
+++ b/lib/components/viewers/stop-time-cell.tsx
@@ -36,6 +36,8 @@ type Props = {
   onlyShowCountdownForRealtime?: boolean
   /** A stopTime object as received from a transit index API */
   stopTime: Time
+  /** Whether to use arrival time instead of departure time */
+  useArrivalTime?: boolean
 }
 
 /**
@@ -46,7 +48,8 @@ type Props = {
 const StopTimeCell = ({
   homeTimezone = getUserTimezone(),
   onlyShowCountdownForRealtime,
-  stopTime
+  stopTime,
+  useArrivalTime
 }: Props): JSX.Element => {
   const intl = useIntl()
 
@@ -72,7 +75,7 @@ const StopTimeCell = ({
   // Determine whether to show departure as countdown (e.g. "5 min") or as HH:mm
   // time, using realtime updates if available.
   const secondsUntilDeparture = Math.round(
-    getSecondsUntilDeparture(stopTime, false)
+    getSecondsUntilDeparture(stopTime, false, useArrivalTime)
   )
   // Determine if vehicle arrives after midnight in order to advance the day of
   // the week when showing arrival time/day.
@@ -151,7 +154,8 @@ const StopTimeCell = ({
 const mapStateToProps = (state: AppReduxState) => {
   return {
     onlyShowCountdownForRealtime:
-      state.otp.config?.itinerary?.onlyShowCountdownForRealtime || false
+      state.otp.config?.itinerary?.onlyShowCountdownForRealtime || false,
+    useArrivalTime: state.otp.config?.nearbyView?.useArrivalTime || false
   }
 }
 

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -73,6 +73,7 @@ export type NearbyViewConfig = {
   hideEmptyStops?: boolean
   radius?: number
   showShadowDotOnMapDrag?: boolean
+  useArrivalTime?: boolean
   useRouteViewSort?: boolean
 }
 

--- a/lib/util/viewer.js
+++ b/lib/util/viewer.js
@@ -18,13 +18,16 @@ export function getSecondsUntilDeparture(
   useSchedule,
   useArrivalTime
 ) {
-  const time = useSchedule
-    ? useArrivalTime
+  let time
+  if (useSchedule) {
+    time = useArrivalTime
       ? stopTime.scheduledArrival
       : stopTime.scheduledDeparture
-    : useArrivalTime
-    ? stopTime.realtimeArrival
-    : stopTime.realtimeDeparture
+  } else {
+    time = useArrivalTime
+      ? stopTime.realtimeArrival
+      : stopTime.realtimeDeparture
+  }
 
   return time + stopTime.serviceDay - Date.now() / 1000
 }

--- a/lib/util/viewer.js
+++ b/lib/util/viewer.js
@@ -13,12 +13,20 @@ import { isBlank } from './ui'
  * Computes the seconds until departure for a given stop time,
  * based either on the scheduled or the realtime departure time.
  */
-export function getSecondsUntilDeparture(stopTime, useSchedule) {
-  const departureTime = useSchedule
-    ? stopTime.scheduledDeparture
+export function getSecondsUntilDeparture(
+  stopTime,
+  useSchedule,
+  useArrivalTime
+) {
+  const time = useSchedule
+    ? useArrivalTime
+      ? stopTime.scheduledArrival
+      : stopTime.scheduledDeparture
+    : useArrivalTime
+    ? stopTime.realtimeArrival
     : stopTime.realtimeDeparture
 
-  return departureTime + stopTime.serviceDay - Date.now() / 1000
+  return time + stopTime.serviceDay - Date.now() / 1000
 }
 
 export function getRouteIdForPattern(pattern) {


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Adds configuration option to use the arrival time rather than departure time in Nearby View and other places where the patternrow is used.