### PR TITLE
Only call stopTimes if we don't already have the data

### DIFF
--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -506,12 +506,9 @@ export const fetchNearby = (position, radius, currentServiceWeek) => {
 export const findStopTimesForStop = (params) =>
   function (dispatch, getState) {
     // If the stop is already in the store, don't fetch it again, unless we are forcing a refetch
-    if (
-      !params.forceFetch &&
-      getState().otp.transitIndex.stops[params.stopId]
-    ) {
+    if (!params.forceFetch && getState().otp.transitIndex.stops[params.stopId])
       return
-    }
+
     dispatch(fetchingStopTimesForStop(params))
     const { date, stopId } = params
     const timeZone = getState().otp.config.homeTimezone

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -505,6 +505,13 @@ export const fetchNearby = (position, radius, currentServiceWeek) => {
 
 export const findStopTimesForStop = (params) =>
   function (dispatch, getState) {
+    // If the stop is already in the store, don't fetch it again, unless we are forcing a refetch
+    if (
+      !params.forceFetch &&
+      getState().otp.transitIndex.stops[params.stopId]
+    ) {
+      return
+    }
     dispatch(fetchingStopTimesForStop(params))
     const { date, stopId } = params
     const timeZone = getState().otp.config.homeTimezone

--- a/lib/components/viewers/stop-schedule-viewer.tsx
+++ b/lib/components/viewers/stop-schedule-viewer.tsx
@@ -33,7 +33,11 @@ import TimezoneWarning from './timezone-warning'
 interface Props {
   calendarMax: string
   calendarMin: string
-  findStopTimesForStop: (arg: { date: string; stopId: string }) => void
+  findStopTimesForStop: (arg: {
+    date: string
+    forceFetch?: boolean
+    stopId: string
+  }) => void
   hideBackButton?: boolean
   homeTimezone: string
   intl: IntlShape
@@ -137,7 +141,7 @@ class StopScheduleViewer extends Component<Props, State> {
   _findStopTimesForDate = (date: string) => {
     const { findStopTimesForStop, stopId } = this.props
     if (stopId) {
-      findStopTimesForStop({ date, stopId })
+      findStopTimesForStop({ date, forceFetch: true, stopId })
     }
   }
 


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Fixes a bug where interaction with `setViewedRoute` was causing the `findStopTimesForStop` and subsequent response to fire forever. This should only fire when the stop information isn't already there. Also adds a `forceFetch` param for the stop schedule viewer, so that if you're trying to look at different schedule days, it will update the info with the new day.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

