### PR TITLE
fix(base-renderer): remove OTP1 compatability conversion

### DIFF
--- a/lib/components/user/monitored-trip/trip-status-rendering-strategies/base-renderer.js
+++ b/lib/components/user/monitored-trip/trip-status-rendering-strategies/base-renderer.js
@@ -5,18 +5,6 @@ import React from 'react'
 import FormattedDuration from '../../../util/formatted-duration'
 
 /**
- * Helper function that changes alert timestamps from milliseconds to seconds
- * for display using the alerts body component from itinerary-body.
- */
-function withAlertTimestampsInSeconds(alert) {
-  return {
-    ...alert,
-    effectiveEndDate: alert.effectiveEndDate / 1000,
-    effectiveStartDate: alert.effectiveStartDate / 1000
-  }
-}
-
-/**
  * Calculate commonly-used pieces of data used to render the trip status
  * component. The monitoredTrip param can be undefined.
  */
@@ -63,9 +51,7 @@ export default function baseRenderer(monitoredTrip) {
 
   // Set some alert data if the matching itinerary exists.
   // (Convert alert timestamps in milliseconds to seconds for display using alerts body.)
-  data.alerts = data.matchingItinerary?.alerts?.map(
-    withAlertTimestampsInSeconds
-  )
+  data.alerts = data.matchingItinerary?.alerts
   data.hasMoreThanOneAlert = !!(data.alerts?.length > 0)
   data.shouldRenderAlerts = data.hasMoreThanOneAlert
 


### PR DESCRIPTION
The alert view was accounting for the OTP1 compatibility itinerary-body used to maintain. That compatibility has now been removed. As a result, we now no longer need to convert data to OTP1 format