### PR TITLE
fix(responsive-webapp): prevent error in safari positioning

### DIFF
--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -180,10 +180,7 @@ class ResponsiveWebapp extends Component {
       navigator.geolocation.watchPosition(
         // On success
         (position) => {
-          // This object cloning is required to be allowed to read the position info twice
-          // on webkit browsers.
-          // See https://github.com/opentripplanner/otp-react-redux/pull/697 for details
-          receivedPositionResponse({ position: { ...position } })
+          receivedPositionResponse({ position })
         },
         // On error
         (error) => {

--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -353,7 +353,6 @@ class DefaultMap extends Component {
             visible
           />
           <GeolocateControl
-            enableHighAccuracy
             onGeolocate={() => {
               getCurrentPosition(intl)
             }}

--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -353,6 +353,7 @@ class DefaultMap extends Component {
             visible
           />
           <GeolocateControl
+            enableHighAccuracy
             onGeolocate={() => {
               getCurrentPosition(intl)
             }}


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Fix bug where current location was returning an error on mobile safari browsers. NOTE that this reverts https://github.com/opentripplanner/otp-react-redux/pull/697. I tested for the bug outlined in that PR, and could not reproduce any issues. Could be related to a webkit update? 

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

