### PR TITLE
feat: add network connection status to ui and redux

### DIFF
--- a/__tests__/reducers/__snapshots__/create-otp-reducer.js.snap
+++ b/__tests__/reducers/__snapshots__/create-otp-reducer.js.snap
@@ -83,6 +83,9 @@ Object {
   },
   "ui": Object {
     "diagramLeg": null,
+    "errors": Object {
+      "networkConnectionLost": false,
+    },
     "locale": null,
     "localizedMessages": null,
     "mainPanelContent": null,

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -183,6 +183,8 @@ components:
     closeMenu: Close Menu
     fieldTrip: Field Trip
     mailables: Mailables
+    networkConnectionLost: Network connection lost
+    networkConnectionRestored: Network connection restored
     openMenu: Open Menu
     skipNavigation: Skip navigation
   BackToTripPlanner:

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -194,6 +194,8 @@ components:
     closeMenu: Fermer le menu
     fieldTrip: Groupes scolaires
     mailables: Prêt-à-poster
+    networkConnectionLost: Erreur de connexion réseau
+    networkConnectionRestored: Connexion réseau restaurée
     openMenu: Ouvrir le menu
     skipNavigation: Sauter la navigation
   BackToTripPlanner:

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -47,6 +47,9 @@ const viewRoute = createAction('SET_VIEWED_ROUTE')
 export const toggleAutoRefresh = createAction('TOGGLE_AUTO_REFRESH')
 const settingItineraryView = createAction('SET_ITINERARY_VIEW')
 export const setPopupContent = createAction('SET_POPUP_CONTENT')
+export const setNetworkConnectionLost = createAction(
+  'SET_NETWORK_CONNECTION_LOST'
+)
 
 // This code-less action calls the reducer code
 // and thus resets the session timeout.

--- a/lib/components/app/app.css
+++ b/lib/components/app/app.css
@@ -108,6 +108,9 @@
   height: 100%;
   width: 100%;
 }
+.otp .navbar {
+  z-index: 25;
+}
 
 /** These changes kick in when the map is hidden. These rules ensure that the entire "sidebar"
     (which at this point fills the entire screen) scrolls as a single unit.

--- a/lib/components/app/desktop-nav.tsx
+++ b/lib/components/app/desktop-nav.tsx
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
+import { FormattedMessage, useIntl } from 'react-intl'
 import { isMobile } from '@opentripplanner/core-utils/lib/ui'
 import { Nav, Navbar } from 'react-bootstrap'
-import { useIntl } from 'react-intl'
 import React from 'react'
 import styled from 'styled-components'
 
@@ -120,8 +120,6 @@ const DesktopNav = ({
       id: `config.popups.${popupTarget}`
     })
 
-  console.log(networkConnectionLost)
-
   return (
     <header>
       <Navbar fluid inverse>
@@ -171,6 +169,13 @@ const DesktopNav = ({
           </StyledNav>
         </Navbar.Header>
       </Navbar>
+      <InvisibleA11yLabel aria-live="assertive" role="status">
+        {networkConnectionLost ? (
+          <FormattedMessage id="components.AppMenu.networkConnectionLost" />
+        ) : (
+          <FormattedMessage id="components.AppMenu.networkConnectionRestored" />
+        )}
+      </InvisibleA11yLabel>
       <NetworkConnectionBanner networkConnectionLost={networkConnectionLost} />
     </header>
   )

--- a/lib/components/app/desktop-nav.tsx
+++ b/lib/components/app/desktop-nav.tsx
@@ -13,6 +13,7 @@ import { DEFAULT_APP_TITLE } from '../../util/constants'
 import InvisibleA11yLabel from '../util/invisible-a11y-label'
 import NavLoginButtonAuth0 from '../user/nav-login-button-auth0'
 
+import { NetworkConnectionBanner } from './network-connection-banner'
 import AppMenu, { Icon } from './app-menu'
 import LocaleSelector from './locale-selector'
 import NavbarItem from './nav-item'
@@ -63,6 +64,7 @@ const NavItemOnLargeScreens = styled(NavbarItem)`
 // Typscript TODO: otpConfig type
 export type Props = {
   locale: string
+  networkConnectionLost: boolean
   otpConfig: AppConfig
   popupTarget?: string
   setPopupContent: (url: string) => void
@@ -83,6 +85,7 @@ export type Props = {
  */
 const DesktopNav = ({
   locale,
+  networkConnectionLost,
   otpConfig,
   popupTarget,
   setPopupContent
@@ -116,6 +119,8 @@ const DesktopNav = ({
     intl.formatMessage({
       id: `config.popups.${popupTarget}`
     })
+
+  console.log(networkConnectionLost)
 
   return (
     <header>
@@ -166,6 +171,7 @@ const DesktopNav = ({
           </StyledNav>
         </Navbar.Header>
       </Navbar>
+      <NetworkConnectionBanner networkConnectionLost={networkConnectionLost} />
     </header>
   )
 }
@@ -173,8 +179,10 @@ const DesktopNav = ({
 // connect to the redux store
 const mapStateToProps = (state: AppReduxState) => {
   const { config: otpConfig } = state.otp
+  const { networkConnectionLost } = state.otp.ui.errors
   return {
     locale: state.otp.ui.locale,
+    networkConnectionLost,
     otpConfig,
     popupTarget: otpConfig.popups?.launchers?.toolbar
   }

--- a/lib/components/app/desktop-nav.tsx
+++ b/lib/components/app/desktop-nav.tsx
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
-import { FormattedMessage, useIntl } from 'react-intl'
 import { isMobile } from '@opentripplanner/core-utils/lib/ui'
 import { Nav, Navbar } from 'react-bootstrap'
+import { useIntl } from 'react-intl'
 import React from 'react'
 import styled from 'styled-components'
 
@@ -169,13 +169,6 @@ const DesktopNav = ({
           </StyledNav>
         </Navbar.Header>
       </Navbar>
-      <InvisibleA11yLabel aria-live="assertive" role="status">
-        {networkConnectionLost ? (
-          <FormattedMessage id="components.AppMenu.networkConnectionLost" />
-        ) : (
-          <FormattedMessage id="components.AppMenu.networkConnectionRestored" />
-        )}
-      </InvisibleA11yLabel>
       <NetworkConnectionBanner networkConnectionLost={networkConnectionLost} />
     </header>
   )

--- a/lib/components/app/network-connection-banner.tsx
+++ b/lib/components/app/network-connection-banner.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import { RED_ON_WHITE } from '../util/colors'
 
 const containerClassname = 'network-connection-banner'
-const timeout = 200
+const timeout = 250
 
 const TransitionStyles = styled.div`
   .${containerClassname} {
@@ -20,7 +20,12 @@ const TransitionStyles = styled.div`
     text-align: center;
     top: 50px;
     width: 100%;
-    z-index: 1;
+    // When banner is fully loaded, set z-index higher than nav so we're not seeing the nav border.
+    z-index: 26;
+
+    @media (max-width: 768px) {
+      border: 0;
+    }
   }
   .${containerClassname}-enter {
     opacity: 0;
@@ -34,11 +39,13 @@ const TransitionStyles = styled.div`
   .${containerClassname}-exit {
     opacity: 1;
     transform: translateY(0);
+    z-index: 20;
   }
   .${containerClassname}-exit-active {
     opacity: 0;
     transform: translateY(-100%);
     transition: opacity ${timeout}ms ease-in, transform ${timeout}ms ease-in;
+    z-index: 20;
   }
 `
 export const NetworkConnectionLostBanner = styled.div``
@@ -62,13 +69,9 @@ export const NetworkConnectionBanner = ({
               aria-live="assertive"
               className={containerClassname}
               ref={connectionLostBannerRef}
-              role="status"
+              role="alert"
             >
-              {networkConnectionLost ? (
-                <FormattedMessage id="components.AppMenu.networkConnectionLost" />
-              ) : (
-                <FormattedMessage id="components.AppMenu.networkConnectionRestored" />
-              )}
+              <FormattedMessage id="components.AppMenu.networkConnectionLost" />
             </NetworkConnectionLostBanner>
           </CSSTransition>
         )}

--- a/lib/components/app/network-connection-banner.tsx
+++ b/lib/components/app/network-connection-banner.tsx
@@ -1,0 +1,78 @@
+import { CSSTransition, TransitionGroup } from 'react-transition-group'
+import { FormattedMessage } from 'react-intl'
+import React, { useRef } from 'react'
+import styled from 'styled-components'
+
+import { RED_ON_WHITE } from '../util/colors'
+
+const containerClassname = 'network-connection-banner'
+const timeout = 200
+
+const TransitionStyles = styled.div`
+  .${containerClassname} {
+    background: ${RED_ON_WHITE};
+    border-left: 1px solid #e7e7e7;
+    border-right: 1px solid #e7e7e7;
+    color: #fff;
+    font-weight: 600;
+    padding: 5px;
+    position: absolute;
+    text-align: center;
+    top: 50px;
+    width: 100%;
+    z-index: 1;
+  }
+  .${containerClassname}-enter {
+    opacity: 0;
+    transform: translateY(-100%);
+  }
+  .${containerClassname}-enter-active {
+    opacity: 1;
+    transform: translateY(0);
+    transition: opacity ${timeout}ms ease-in;
+  }
+  .${containerClassname}-exit {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  .${containerClassname}-exit-active {
+    opacity: 0;
+    transform: translateY(-100%);
+    transition: opacity ${timeout}ms ease-in, transform ${timeout}ms ease-in;
+  }
+`
+export const NetworkConnectionLostBanner = styled.div``
+
+export const NetworkConnectionBanner = ({
+  networkConnectionLost
+}: {
+  networkConnectionLost: boolean
+}): JSX.Element => {
+  const connectionLostBannerRef = useRef<HTMLDivElement>(null)
+  return (
+    <TransitionStyles>
+      <TransitionGroup style={{ display: 'content' }}>
+        {networkConnectionLost && (
+          <CSSTransition
+            classNames={containerClassname}
+            nodeRef={connectionLostBannerRef}
+            timeout={timeout}
+          >
+            <NetworkConnectionLostBanner
+              aria-live="assertive"
+              className={containerClassname}
+              ref={connectionLostBannerRef}
+              role="status"
+            >
+              {networkConnectionLost ? (
+                <FormattedMessage id="components.AppMenu.networkConnectionLost" />
+              ) : (
+                <FormattedMessage id="components.AppMenu.networkConnectionRestored" />
+              )}
+            </NetworkConnectionLostBanner>
+          </CSSTransition>
+        )}
+      </TransitionGroup>
+    </TransitionStyles>
+  )
+}

--- a/lib/components/app/network-connection-banner.tsx
+++ b/lib/components/app/network-connection-banner.tsx
@@ -4,6 +4,7 @@ import React, { useRef } from 'react'
 import styled from 'styled-components'
 
 import { RED_ON_WHITE } from '../util/colors'
+import InvisibleA11yLabel from '../util/invisible-a11y-label'
 
 const containerClassname = 'network-connection-banner'
 const timeout = 250
@@ -48,7 +49,6 @@ const TransitionStyles = styled.div`
     z-index: 20;
   }
 `
-export const NetworkConnectionLostBanner = styled.div``
 
 export const NetworkConnectionBanner = ({
   networkConnectionLost
@@ -58,6 +58,13 @@ export const NetworkConnectionBanner = ({
   const connectionLostBannerRef = useRef<HTMLDivElement>(null)
   return (
     <TransitionStyles>
+      <InvisibleA11yLabel aria-live="assertive" role="status">
+        {networkConnectionLost ? (
+          <FormattedMessage id="components.AppMenu.networkConnectionLost" />
+        ) : (
+          <FormattedMessage id="components.AppMenu.networkConnectionRestored" />
+        )}
+      </InvisibleA11yLabel>
       <TransitionGroup style={{ display: 'content' }}>
         {networkConnectionLost && (
           <CSSTransition
@@ -65,14 +72,9 @@ export const NetworkConnectionBanner = ({
             nodeRef={connectionLostBannerRef}
             timeout={timeout}
           >
-            <NetworkConnectionLostBanner
-              aria-live="assertive"
-              className={containerClassname}
-              ref={connectionLostBannerRef}
-              role="alert"
-            >
+            <div className={containerClassname} ref={connectionLostBannerRef}>
               <FormattedMessage id="components.AppMenu.networkConnectionLost" />
-            </NetworkConnectionLostBanner>
+            </div>
           </CSSTransition>
         )}
       </TransitionGroup>

--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -154,10 +154,13 @@ class ResponsiveWebapp extends Component {
       map,
       matchContentToUrl,
       parseUrlQueryString,
-      receivedPositionResponse
+      receivedPositionResponse,
+      setNetworkConnectionLost
     } = this.props
     // Add on back button press behavior.
     window.addEventListener('popstate', handleBackButtonPress)
+    window.addEventListener('online', () => setNetworkConnectionLost(false))
+    window.addEventListener('offline', () => setNetworkConnectionLost(true))
 
     // If a URL is detected without hash routing (e.g., http://localhost:9966?sessionId=test),
     // window.location.search will have a value. In this case, we need to redirect to the URL root with the
@@ -441,6 +444,7 @@ const mapStateToWrapperProps = (state) => {
 const mapWrapperDispatchToProps = {
   processSignIn: authActions.processSignIn,
   setLocale: uiActions.setLocale,
+  setNetworkConnectionLost: uiActions.setNetworkConnectionLost,
   showAccessTokenError: authActions.showAccessTokenError,
   showLoginError: authActions.showLoginError
 }

--- a/lib/components/mobile/batch-search-screen.tsx
+++ b/lib/components/mobile/batch-search-screen.tsx
@@ -40,8 +40,9 @@ const MobileSearchSettings = styled.div<{
   top: 50px;
   transition: ${(props) => `all ${props.transitionDuration}ms ease`};
   transition-delay: ${(props) => props.transitionDelay}ms;
-  /* Must appear under the 'hamburger' dropdown which has z-index of 1000. */
-  z-index: 999;
+  /* Must appear under the 'hamburger' dropdown which has z-index of 1000, and the "network lost"
+    banner which has a z-index of 10 */
+  z-index: 9;
 `
 
 interface Props {

--- a/lib/components/mobile/navigation-bar.js
+++ b/lib/components/mobile/navigation-bar.js
@@ -9,6 +9,7 @@ import * as uiActions from '../../actions/ui'
 import { accountLinks, getAuth0Config } from '../../util/auth'
 import { ComponentContext } from '../../util/contexts'
 import { injectIntl } from 'react-intl'
+import { NetworkConnectionBanner } from '../app/network-connection-banner'
 import { StyledIconWrapper } from '../util/styledIcon'
 import AppMenu from '../app/app-menu'
 import LocaleSelector from '../app/locale-selector'
@@ -32,6 +33,7 @@ class MobileNavigationBar extends Component {
     headerText: PropTypes.string,
     intl: PropTypes.object,
     locale: PropTypes.string,
+    networkConnectionLost: PropTypes.bool,
     onBackClicked: PropTypes.func,
     setMobileScreen: PropTypes.func,
     showBackButton: PropTypes.bool
@@ -55,6 +57,7 @@ class MobileNavigationBar extends Component {
       headerText,
       intl,
       locale,
+      networkConnectionLost,
       showBackButton
     } = this.props
 
@@ -111,6 +114,9 @@ class MobileNavigationBar extends Component {
             )}
           </MobileBar>
         </Navbar>
+        <NetworkConnectionBanner
+          networkConnectionLost={networkConnectionLost}
+        />
       </header>
     )
   }
@@ -123,7 +129,8 @@ const mapStateToProps = (state) => {
     auth0Config: getAuth0Config(state.otp.config.persistence),
     configLanguages: state.otp.config.language,
     extraMenuItems: state.otp?.config?.extraMenuItems,
-    locale: state.otp.ui.locale
+    locale: state.otp.ui.locale,
+    networkConnectionLost: state.otp.ui.errors.networkConnectionLost
   }
 }
 

--- a/lib/components/mobile/navigation-bar.js
+++ b/lib/components/mobile/navigation-bar.js
@@ -1,6 +1,6 @@
 import { ArrowLeft } from '@styled-icons/fa-solid/ArrowLeft'
 import { connect } from 'react-redux'
-import { FormattedMessage, injectIntl } from 'react-intl'
+import { injectIntl } from 'react-intl'
 import { Navbar } from 'react-bootstrap'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
@@ -12,7 +12,6 @@ import { ComponentContext } from '../../util/contexts'
 import { NetworkConnectionBanner } from '../app/network-connection-banner'
 import { StyledIconWrapper } from '../util/styledIcon'
 import AppMenu from '../app/app-menu'
-import InvisibleA11yLabel from '../util/invisible-a11y-label'
 import LocaleSelector from '../app/locale-selector'
 import NavLoginButtonAuth0 from '../../components/user/nav-login-button-auth0'
 import PageTitle from '../util/page-title'
@@ -115,13 +114,6 @@ class MobileNavigationBar extends Component {
             )}
           </MobileBar>
         </Navbar>
-        <InvisibleA11yLabel aria-live="assertive" role="status">
-          {networkConnectionLost ? (
-            <FormattedMessage id="components.AppMenu.networkConnectionLost" />
-          ) : (
-            <FormattedMessage id="components.AppMenu.networkConnectionRestored" />
-          )}
-        </InvisibleA11yLabel>
         <NetworkConnectionBanner
           networkConnectionLost={networkConnectionLost}
         />

--- a/lib/components/mobile/navigation-bar.js
+++ b/lib/components/mobile/navigation-bar.js
@@ -1,5 +1,6 @@
 import { ArrowLeft } from '@styled-icons/fa-solid/ArrowLeft'
 import { connect } from 'react-redux'
+import { FormattedMessage, injectIntl } from 'react-intl'
 import { Navbar } from 'react-bootstrap'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
@@ -8,10 +9,10 @@ import styled from 'styled-components'
 import * as uiActions from '../../actions/ui'
 import { accountLinks, getAuth0Config } from '../../util/auth'
 import { ComponentContext } from '../../util/contexts'
-import { injectIntl } from 'react-intl'
 import { NetworkConnectionBanner } from '../app/network-connection-banner'
 import { StyledIconWrapper } from '../util/styledIcon'
 import AppMenu from '../app/app-menu'
+import InvisibleA11yLabel from '../util/invisible-a11y-label'
 import LocaleSelector from '../app/locale-selector'
 import NavLoginButtonAuth0 from '../../components/user/nav-login-button-auth0'
 import PageTitle from '../util/page-title'
@@ -114,6 +115,13 @@ class MobileNavigationBar extends Component {
             )}
           </MobileBar>
         </Navbar>
+        <InvisibleA11yLabel aria-live="assertive" role="status">
+          {networkConnectionLost ? (
+            <FormattedMessage id="components.AppMenu.networkConnectionLost" />
+          ) : (
+            <FormattedMessage id="components.AppMenu.networkConnectionRestored" />
+          )}
+        </InvisibleA11yLabel>
         <NetworkConnectionBanner
           networkConnectionLost={networkConnectionLost}
         />

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -225,6 +225,9 @@ export function getInitialState(userDefinedConfig) {
     },
     ui: {
       diagramLeg: null,
+      errors: {
+        networkConnectionLost: !navigator.onLine
+      },
       locale: null,
       localizedMessages: null,
       mainPanelContent: null,
@@ -1105,6 +1108,15 @@ function createOtpReducer(config) {
               url: {
                 $set: target?.url
               }
+            }
+          }
+        })
+      case 'SET_NETWORK_CONNECTION_LOST':
+        console.log(action.payload)
+        return update(state, {
+          ui: {
+            errors: {
+              networkConnectionLost: { $set: action.payload }
             }
           }
         })

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -1112,7 +1112,6 @@ function createOtpReducer(config) {
           }
         })
       case 'SET_NETWORK_CONNECTION_LOST':
-        console.log(action.payload)
         return update(state, {
           ui: {
             errors: {


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Creates a UI status bar and an invisible status region for screen readers that announces when the browser connection has been lost. 


<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Web | Mobile |
|--------|-------|
|![image](https://github.com/user-attachments/assets/40ef5a82-185c-47ca-9217-d58a4e9da54c)|![image](https://github.com/user-attachments/assets/87dee30d-466f-48ad-92a6-c707a509b2df)|

