### PR TITLE
fix(trip-basics-pane): remove ability to select days that the trip is…

### DIFF
--- a/lib/components/user/monitored-trip/trip-basics-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-basics-pane.tsx
@@ -180,9 +180,8 @@ const RenderAvailableDays = ({
               title={notAvailableText}
             >
               <Field
-                // Let users save an existing trip, even though it may not be available on some days.
                 // TODO: improve checking trip availability.
-                disabled={isDayDisabled && isCreating}
+                disabled={isDayDisabled}
                 id={day}
                 name={day}
                 type="checkbox"


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Expected: Editing an existing trip you should not be  able to select days/times that the trip does not run.

Actual: Editing an existing trip you can select days/times that the trip does not run and send notification on days when it is not selected

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

