### PR TITLE
fix crash when applicableModeSettings is null

### DIFF
--- a/lib/components/form/call-taker/advanced-options.js
+++ b/lib/components/form/call-taker/advanced-options.js
@@ -224,7 +224,7 @@ class AdvancedOptions extends Component {
           }}
         >
           {/* Show the first mode setting */}
-          {applicableModeSettings.length >= 1 && (
+          {applicableModeSettings?.length >= 1 && (
             <ModeSettingRenderer
               onChange={this._setCustomModeSetting}
               setting={applicableModeSettings[0]}
@@ -264,7 +264,7 @@ class AdvancedOptions extends Component {
         </Suspense>
         <div style={{ paddingTop: '8px' }}>
           {/* Show the remaining items after the first */}
-          {applicableModeSettings.length > 1 &&
+          {applicableModeSettings?.length > 1 &&
             applicableModeSettings
               .slice(1)
               .map((ms) => (


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Since this isn't a typescript file we didn't detect this sooner, but applicableModeSetting can be null which causes a crash. We fix that here with the trusty null coalescing operator. 
