### PR TITLE
Prevent constant updating in nearby view

### DIFF
--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -137,21 +137,24 @@ class ResponsiveWebapp extends Component {
       }
     }
 
-    navigator.geolocation.watchPosition(
-      // On success
-      (position) => {
-        const shouldUpdate = this.positionShouldUpdate(position)
-        if (shouldUpdate) {
-          receivedPositionResponse({ position })
-        }
-      },
-      // On error
-      (error) => {
-        console.log('error in watchPosition', error)
-      },
-      // Options
-      { enableHighAccuracy: true }
-    )
+    if (isMobile()) {
+      navigator.geolocation.watchPosition(
+        // On success
+        (position) => {
+          const shouldUpdate = this.positionShouldUpdate(position)
+          if (shouldUpdate) {
+            receivedPositionResponse({ position })
+          }
+        },
+        // On error
+        (error) => {
+          console.log('error in watchPosition', error)
+        },
+        // Options
+        { enableHighAccuracy: true }
+      )
+    }
+
     // If the path changes (e.g., via a back button press) check whether the
     // main content needs to switch between, for example, a viewer and a search.
     if (!isEqual(location.pathname, prevProps.location.pathname)) {

--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -57,6 +57,7 @@ class ResponsiveWebapp extends Component {
 
   // Check if the position has changed enough to update the currentPosition
   // (prevent constant updates in nearby view)
+  // .001 works out to be about 94-300 ft depending on the longitude.
   positionShouldUpdate = (position) => {
     const { currentPosition } = this.props
     if (!currentPosition.coords) return true
@@ -137,6 +138,7 @@ class ResponsiveWebapp extends Component {
       }
     }
 
+    // Watch for position changing on mobile
     if (isMobile()) {
       navigator.geolocation.watchPosition(
         // On success
@@ -214,7 +216,6 @@ class ResponsiveWebapp extends Component {
     if (isMobile()) {
       // Test location availability on load
       getCurrentPosition(intl)
-      // Also, watch for changes in position on mobile
     }
     // Handle routing to a specific part of the app (e.g. stop viewer) on page
     // load. (This happens prior to routing request in case special routerId is

--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -55,6 +55,23 @@ class ResponsiveWebapp extends Component {
 
   /** Lifecycle methods **/
 
+  // Check if the position has changed enough to update the currentPosition
+  // (prevent constant updates in nearby view)
+  positionShouldUpdate = (position) => {
+    const { currentPosition } = this.props
+    if (!currentPosition.coords) return true
+    const latChanged =
+      Math.abs(
+        position?.coords?.latitude - currentPosition?.coords?.latitude
+      ) >= 0.001
+    const lonChanged =
+      Math.abs(
+        position?.coords?.longitude - currentPosition?.coords?.longitude
+      ) >= 0.001
+
+    return latChanged || lonChanged
+  }
+
   /* eslint-disable-next-line complexity */
   componentDidUpdate(prevProps) {
     const {
@@ -69,6 +86,7 @@ class ResponsiveWebapp extends Component {
       map,
       matchContentToUrl,
       query,
+      receivedPositionResponse,
       setLocationToCurrent,
       setMapCenter
     } = this.props
@@ -119,6 +137,21 @@ class ResponsiveWebapp extends Component {
       }
     }
 
+    navigator.geolocation.watchPosition(
+      // On success
+      (position) => {
+        const shouldUpdate = this.positionShouldUpdate(position)
+        if (shouldUpdate) {
+          receivedPositionResponse({ position })
+        }
+      },
+      // On error
+      (error) => {
+        console.log('error in watchPosition', error)
+      },
+      // Options
+      { enableHighAccuracy: true }
+    )
     // If the path changes (e.g., via a back button press) check whether the
     // main content needs to switch between, for example, a viewer and a search.
     if (!isEqual(location.pathname, prevProps.location.pathname)) {
@@ -154,7 +187,6 @@ class ResponsiveWebapp extends Component {
       map,
       matchContentToUrl,
       parseUrlQueryString,
-      receivedPositionResponse,
       setNetworkConnectionLost
     } = this.props
     // Add on back button press behavior.
@@ -180,18 +212,6 @@ class ResponsiveWebapp extends Component {
       // Test location availability on load
       getCurrentPosition(intl)
       // Also, watch for changes in position on mobile
-      navigator.geolocation.watchPosition(
-        // On success
-        (position) => {
-          receivedPositionResponse({ position })
-        },
-        // On error
-        (error) => {
-          console.log('error in watchPosition', error)
-        },
-        // Options
-        { enableHighAccuracy: true }
-      )
     }
     // Handle routing to a specific part of the app (e.g. stop viewer) on page
     // load. (This happens prior to routing request in case special routerId is
@@ -426,10 +446,12 @@ class RouterWrapperWithAuth0 extends Component {
 }
 
 const mapStateToWrapperProps = (state) => {
-  const { homeTimezone, map, persistence, reactRouter } = state.otp.config
+  const { homeTimezone, location, map, persistence, reactRouter } =
+    state.otp.config
   return {
     auth0Config: getAuth0Config(persistence),
     autoFly: map.autoFlyOnTripFormUpdate,
+    currentPosition: location?.currentPosition,
     defaultLocale: getDefaultLocale(state.otp.config, state.user.loggedInUser),
     homeTimezone,
     locale: state.otp.ui.locale,

--- a/lib/components/mobile/navigation-bar.js
+++ b/lib/components/mobile/navigation-bar.js
@@ -64,7 +64,7 @@ class MobileNavigationBar extends Component {
     const backButtonText = intl.formatMessage({ id: 'common.forms.back' })
 
     return (
-      <header>
+      <header style={{ height: '50px' }}>
         <Navbar className="mobile-navbar-container" fixedTop fluid>
           <Navbar.Header>
             <Navbar.Brand>

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -247,8 +247,6 @@ function NearbyView({
       </li>
     ))
 
-  console.log(nearbyItemList)
-
   useEffect(() => {
     if (!staleData) {
       setLoading(false)

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -22,6 +22,7 @@ import {
   Scrollable
 } from './styled'
 import FromToPicker from './from-to-picker'
+import InvisibleA11yLabel from '../../util/invisible-a11y-label'
 import RentalStation from './rental-station'
 import Stop from './stop'
 import Vehicle from './vehicle-rent'
@@ -246,6 +247,8 @@ function NearbyView({
       </li>
     ))
 
+  console.log(nearbyItemList)
+
   useEffect(() => {
     if (!staleData) {
       setLoading(false)
@@ -273,16 +276,16 @@ function NearbyView({
         />
       )}
       {nearby && (
-        <h3 style={{ opacity: 0, position: 'absolute' }}>
+        <InvisibleA11yLabel as="h3" style={{ position: 'absolute' }}>
           <FormattedMessage
             id="components.NearbyView.nearbyListIntro"
             values={{ count: nearby.length }}
           />
-        </h3>
+        </InvisibleA11yLabel>
       )}
       <NearbySidebarContainer
         className="base-color-bg"
-        style={{ marginTop: mobile ? '50px' : 0 }}
+        style={{ marginBottom: 0 }}
       >
         {/* This is used to scroll to top */}
         <div aria-hidden ref={firstItemRef} />

--- a/lib/components/viewers/nearby/styled.tsx
+++ b/lib/components/viewers/nearby/styled.tsx
@@ -18,6 +18,10 @@ export const NearbySidebarContainer = styled.ol`
   gap: 1em;
   padding: 0 1em;
   list-style: none;
+
+  @media (max-width: 768px) {
+    min-height: calc(100vh - 50px);
+  }
 `
 
 export const Card = styled.div`


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

Fixes constant rerendering of the nearby view by only updating `currentPosition` if the user moves .0001 lat/long away from their initial position. 

Is this the most efficient way to do this? Should this instead be set in the nearby view? Should we potentially calc the km distance between the two points instead, to make it more geographically consistent? Open to a lot of feedback on this 

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

