### PR TITLE
More nearby fixes

### DIFF
--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -87,7 +87,6 @@ class ResponsiveWebapp extends Component {
       map,
       matchContentToUrl,
       query,
-      receivedPositionResponse,
       setLocationToCurrent,
       setMapCenter
     } = this.props
@@ -138,25 +137,6 @@ class ResponsiveWebapp extends Component {
       }
     }
 
-    // Watch for position changing on mobile
-    if (isMobile()) {
-      navigator.geolocation.watchPosition(
-        // On success
-        (position) => {
-          const shouldUpdate = this.positionShouldUpdate(position)
-          if (shouldUpdate) {
-            receivedPositionResponse({ position })
-          }
-        },
-        // On error
-        (error) => {
-          console.log('error in watchPosition', error)
-        },
-        // Options
-        { enableHighAccuracy: true }
-      )
-    }
-
     // If the path changes (e.g., via a back button press) check whether the
     // main content needs to switch between, for example, a viewer and a search.
     if (!isEqual(location.pathname, prevProps.location.pathname)) {
@@ -192,6 +172,7 @@ class ResponsiveWebapp extends Component {
       map,
       matchContentToUrl,
       parseUrlQueryString,
+      receivedPositionResponse,
       setNetworkConnectionLost
     } = this.props
     // Add on back button press behavior.
@@ -216,6 +197,21 @@ class ResponsiveWebapp extends Component {
     if (isMobile()) {
       // Test location availability on load
       getCurrentPosition(intl)
+      // Watch for position changing on mobile
+      navigator.geolocation.watchPosition(
+        // On success
+        (position) => {
+          if (this.positionShouldUpdate(position)) {
+            receivedPositionResponse({ position })
+          }
+        },
+        // On error
+        (error) => {
+          console.log('error in watchPosition', error)
+        },
+        // Options
+        { enableHighAccuracy: true }
+      )
     }
     // Handle routing to a specific part of the app (e.g. stop viewer) on page
     // load. (This happens prior to routing request in case special routerId is

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 import { FormattedMessage, useIntl } from 'react-intl'
 import { Location } from '@opentripplanner/types'
 import { MapRef, useMap } from 'react-map-gl'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import * as apiActions from '../../../actions/api'
 import * as mapActions from '../../../actions/map'
@@ -128,7 +128,6 @@ function NearbyView({
   const map = useMap().default
   const intl = useIntl()
   const [loading, setLoading] = useState(true)
-  const firstItemRef = useRef<HTMLDivElement>(null)
   const finalNearbyCoords = useMemo(
     () =>
       getNearbyCoordsFromUrlOrLocationOrMapCenter(
@@ -180,9 +179,11 @@ function NearbyView({
   }, [map, setViewedNearbyCoords, setHighlightedLocation])
 
   useEffect(() => {
-    if (typeof firstItemRef.current?.scrollIntoView === 'function') {
-      firstItemRef.current?.scrollIntoView({ behavior: 'smooth' })
-    }
+    window.scrollTo({
+      behavior: 'smooth',
+      left: 0,
+      top: 0
+    })
     if (finalNearbyCoords) {
       fetchNearby(finalNearbyCoords, radius, currentServiceWeek)
       setLoading(true)
@@ -250,6 +251,11 @@ function NearbyView({
   useEffect(() => {
     if (!staleData) {
       setLoading(false)
+    } else if (staleData) {
+      // If there's stale data, fetch again
+      setLoading(true)
+      finalNearbyCoords &&
+        fetchNearby(finalNearbyCoords, radius, currentServiceWeek)
     }
   }, [nearby, staleData])
 
@@ -285,8 +291,6 @@ function NearbyView({
         className="base-color-bg"
         style={{ marginBottom: 0 }}
       >
-        {/* This is used to scroll to top */}
-        <div aria-hidden ref={firstItemRef} />
         {loading && (
           <FloatingLoadingIndicator>
             <Loading extraSmall />

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -240,7 +240,7 @@ function NearbyView({
   const filteredNearby = nearby?.filter((n: any) => {
     if (n.place.__typename === 'Stop' && nearbyViewConfig?.hideEmptyStops) {
       const patternArray = patternArrayforStops(n.place, routeSortComparator)
-      if (patternArray?.length === 0) return false
+      return !(patternArray?.length === 0)
     }
     return true
   })

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -2,6 +2,7 @@ import { connect } from 'react-redux'
 import { FormattedMessage, useIntl } from 'react-intl'
 import { Location } from '@opentripplanner/types'
 import { MapRef, useMap } from 'react-map-gl'
+import coreUtils from '@opentripplanner/core-utils'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import * as apiActions from '../../../actions/api'
@@ -9,27 +10,17 @@ import * as mapActions from '../../../actions/map'
 import * as uiActions from '../../../actions/ui'
 import { AppReduxState } from '../../../util/state-types'
 import { getCurrentServiceWeek } from '../../../util/current-service-week'
+import { NearbyViewConfig } from '../../../util/config-types'
 import {
   PatternStopTime,
   SetLocationHandler,
   ZoomToPlaceHandler
 } from '../../util/types'
-import coreUtils from '@opentripplanner/core-utils'
-
-import { NearbyViewConfig } from '../../../util/config-types'
-
-import FromToPicker from './from-to-picker'
 import InvisibleA11yLabel from '../../util/invisible-a11y-label'
 import Loading from '../../narrative/loading'
 import MobileContainer from '../../mobile/container'
 import MobileNavigationBar from '../../mobile/navigation-bar'
 import PageTitle from '../../util/page-title'
-
-import RentalStation from './rental-station'
-import Stop, { fullTimestamp, patternArrayforStops } from './stop'
-import Vehicle from './vehicle-rent'
-import VehicleParking from './vehicle-parking'
-
 import VehiclePositionRetriever from '../vehicle-position-retriever'
 
 import {
@@ -37,6 +28,11 @@ import {
   NearbySidebarContainer,
   Scrollable
 } from './styled'
+import FromToPicker from './from-to-picker'
+import RentalStation from './rental-station'
+import Stop, { fullTimestamp, patternArrayforStops } from './stop'
+import Vehicle from './vehicle-rent'
+import VehicleParking from './vehicle-parking'
 
 const AUTO_REFRESH_INTERVAL = 15000000
 

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -55,6 +55,7 @@ type Props = {
   hideBackButton?: boolean
   location: string
   mobile?: boolean
+  // Todo: type nearby results
   nearby: any
   nearbyViewConfig?: NearbyViewConfig
   nearbyViewCoords?: LatLonObj

--- a/lib/components/viewers/nearby/styled.tsx
+++ b/lib/components/viewers/nearby/styled.tsx
@@ -19,6 +19,10 @@ export const NearbySidebarContainer = styled.ol`
   padding: 0 1em;
   list-style: none;
 
+  & > li:last-of-type {
+    margin-bottom: 2em;
+  }
+
   @media (max-width: 768px) {
     min-height: calc(100vh - 50px);
   }

--- a/lib/components/viewers/nearby/styled.tsx
+++ b/lib/components/viewers/nearby/styled.tsx
@@ -20,7 +20,11 @@ export const NearbySidebarContainer = styled.ol`
   list-style: none;
 
   & > li:last-of-type {
-    margin-bottom: 2em;
+    margin-bottom: 1em;
+  }
+
+  & > li:first-of-type {
+    margin-top: 1em;
   }
 
   @media (max-width: 768px) {


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
- Update styling to avoid padding on `ol`
- Move `watchPosition` back to `componentDidMount` (putting it in `componentDidUpdate` was causing a new `watchPosition` to fire whenever the component updated and it was a nightmare
- Update the scroll on Nearby View (the previous handling of scrolling was causing the "nothing nearby" message to be out of frame on some browsers)
- If `hideEmptyStops` is enabled, remove the empty stop from the nearby list instead of just rendering a blank `li`! This was causing an issue where the nearby view would be blank with no error message in areas where the only stop nearby was empty.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

