### PR TITLE
Mobility profile for Calltaker

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -321,6 +321,7 @@ components:
         mobility scooter: Mobility scooter
         none: No assistive device
         service animal: Service animal
+        some limitations: Some mobility limitations
         stroller: Stroller
         wheeled walker: Wheeled walker
         white cane: White cane

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -336,6 +336,7 @@ components:
         mobility scooter: Scooter électrique
         none: Aucun
         service animal: Animal de service
+        some limitations: Mobilité partiellement limitée
         stroller: Poussette
         wheeled walker: Déambulateur à roues
         white cane: Canne blanche

--- a/lib/components/app/call-taker-panel.js
+++ b/lib/components/app/call-taker-panel.js
@@ -160,6 +160,7 @@ class CallTakerPanel extends Component {
       currentQuery,
       fieldTripVisible,
       groupSize,
+      hasMobilityProfile,
       intl,
       mainPanelContent,
       maxGroupSize,
@@ -169,8 +170,7 @@ class CallTakerPanel extends Component {
       setQueryParam,
       setUrlSearch,
       showUserSettings,
-      timeFormat,
-      usingOtp2
+      timeFormat
     } = this.props
     // FIXME: Remove showPlanTripButton
     const showPlanTripButton =
@@ -313,6 +313,7 @@ class CallTakerPanel extends Component {
               <AdvancedOptions
                 currentQuery={currentQuery}
                 findRoutesIfNeeded={this.props.findRoutesIfNeeded}
+                hasMobilityProfile={hasMobilityProfile}
                 modes={modes}
                 modeSettings={this.props.modeSettingDefinitions}
                 modeSettingValues={this.props.modeSettingValues}
@@ -358,6 +359,7 @@ const mapStateToProps = (state) => {
     currentQuery: state.otp.currentQuery,
     fieldTripVisible: visible,
     groupSize,
+    hasMobilityProfile: state.otp.config.mobilityProfile,
     mainPanelContent: state.otp.ui.mainPanelContent,
     maxGroupSize: getGroupSize(request),
     modeDropdownOptions:

--- a/lib/components/form/advanced-settings-panel.tsx
+++ b/lib/components/form/advanced-settings-panel.tsx
@@ -283,6 +283,7 @@ const AdvancedSettingsPanel = ({
           <FormattedMessage id="components.MobilityProfile.MobilityPane.planTripDescription" />
           <MobilityProfileSelector
             name="forEmail"
+            // Don't use onSettingsUpdate, so that the dependent's mobility profile doesn't appear in the URL.
             onSettingsUpdate={setQueryParam}
             options={[
               {

--- a/lib/components/form/advanced-settings-panel.tsx
+++ b/lib/components/form/advanced-settings-panel.tsx
@@ -83,7 +83,15 @@ const HeaderContainer = styled.div`
 const InvisibleSubheader = styled.h2`
   ${invisibleCss}
 `
-
+const VisibleSubheader = styled.h2`
+  display: block;
+  font-size: 18px;
+  font-weight: 700;
+  height: auto;
+  margin: 1em 0;
+  position: static;
+  width: auto;
+`
 const ReturnToTripPlanButton = styled.button`
   align-items: center;
   background-color: var(--main-base-color, ${blue[900]});
@@ -120,6 +128,10 @@ const DtSelectorContainer = styled.div`
       }
     }
   }
+`
+
+const MobilityProfileContainer = styled.div`
+  margin: 60px 0 60px 5px;
 `
 
 const AdvancedSettingsPanel = ({
@@ -264,23 +276,29 @@ const AdvancedSettingsPanel = ({
         </>
       )}
       {loggedInUser?.dependentsInfo?.length && (
-        <MobilityProfileSelector
-          name="forEmail"
-          options={[
-            {
-              text: intl.formatMessage({
-                id: 'components.MobilityProfile.myself'
-              }),
-              value: loggedInUser?.email
-            },
-            ...(loggedInUser?.dependentsInfo?.map((user) => ({
-              text: getDependentName(user),
-              value: user.email
-            })) || [])
-          ]}
-          setQueryParam={setQueryParam}
-          value={currentQuery.forEmail || loggedInUser?.email}
-        />
+        <MobilityProfileContainer>
+          <VisibleSubheader>
+            <FormattedMessage id="components.MobilityProfile.MobilityPane.header" />
+          </VisibleSubheader>
+          <FormattedMessage id="components.MobilityProfile.MobilityPane.planTripDescription" />
+          <MobilityProfileSelector
+            name="forEmail"
+            options={[
+              {
+                text: intl.formatMessage({
+                  id: 'components.MobilityProfile.myself'
+                }),
+                value: loggedInUser?.email
+              },
+              ...(loggedInUser?.dependentsInfo?.map((user) => ({
+                text: getDependentName(user),
+                value: user.email
+              })) || [])
+            ]}
+            setQueryParam={setQueryParam}
+            value={currentQuery.forEmail || loggedInUser?.email}
+          />
+        </MobilityProfileContainer>
       )}
 
       <AdvancedModeSubsettingsContainer

--- a/lib/components/form/advanced-settings-panel.tsx
+++ b/lib/components/form/advanced-settings-panel.tsx
@@ -283,6 +283,7 @@ const AdvancedSettingsPanel = ({
           <FormattedMessage id="components.MobilityProfile.MobilityPane.planTripDescription" />
           <MobilityProfileSelector
             name="forEmail"
+            onSettingsUpdate={setQueryParam}
             options={[
               {
                 text: intl.formatMessage({
@@ -295,7 +296,6 @@ const AdvancedSettingsPanel = ({
                 value: user.email
               })) || [])
             ]}
-            setQueryParam={setQueryParam}
             value={currentQuery.forEmail || loggedInUser?.email}
           />
         </MobilityProfileContainer>

--- a/lib/components/form/advanced-settings-panel.tsx
+++ b/lib/components/form/advanced-settings-panel.tsx
@@ -1,7 +1,6 @@
 import {
   addSettingsToButton,
   AdvancedModeSubsettingsContainer,
-  DropdownSelector,
   ModeSettingRenderer,
   populateSettingWithValue
 } from '@opentripplanner/trip-form'
@@ -16,7 +15,6 @@ import {
   ModeSetting,
   ModeSettingValues
 } from '@opentripplanner/types'
-import { QueryParamChangeEvent } from '@opentripplanner/trip-form/lib/types'
 import React, {
   RefObject,
   useCallback,
@@ -35,6 +33,7 @@ import { ComponentContext } from '../../util/contexts'
 import { generateModeSettingValues } from '../../util/api'
 import { getDependentName } from '../../util/user'
 import { User } from '../user/types'
+import MobilityProfileSelector from '../user/mobility-profile/mobility-profile-selector'
 
 import {
   addCustomSettingLabels,
@@ -84,15 +83,7 @@ const HeaderContainer = styled.div`
 const InvisibleSubheader = styled.h2`
   ${invisibleCss}
 `
-const VisibleSubheader = styled.h2`
-  display: block;
-  font-size: 18px;
-  font-weight: 700;
-  height: auto;
-  margin: 1em 0;
-  position: static;
-  width: auto;
-`
+
 const ReturnToTripPlanButton = styled.button`
   align-items: center;
   background-color: var(--main-base-color, ${blue[900]});
@@ -131,17 +122,6 @@ const DtSelectorContainer = styled.div`
   }
 `
 
-const MobilityProfileContainer = styled.div`
-  margin: 60px 0 60px 5px;
-`
-
-const MobilityProfileDropdown = styled(DropdownSelector)`
-  margin: 20px 0px;
-  label {
-    padding-left: 0;
-  }
-`
-
 const AdvancedSettingsPanel = ({
   autoPlan,
   closeAdvancedSettings,
@@ -173,12 +153,10 @@ const AdvancedSettingsPanel = ({
   modeSettingValues: ModeSettingValues
   saveAndReturnButton?: boolean
   setCloseAdvancedSettingsWithDelay: () => void
-  setQueryParam: (evt: any) => void
+  setQueryParam: (args: Record<string, unknown>) => void
 }): JSX.Element => {
   const intl = useIntl()
   const [closingBySave, setClosingBySave] = useState(false)
-  const [selectedMobilityProfile, setSelectedMobilityProfile] =
-    useState<string>(currentQuery.forEmail || loggedInUser?.email)
   const dependents = useMemo(
     () => loggedInUser?.dependents || [],
     [loggedInUser]
@@ -257,16 +235,6 @@ const AdvancedSettingsPanel = ({
     closePanel()
   }, [closePanel, setCloseAdvancedSettingsWithDelay])
 
-  const onMobilityProfileChange = useCallback(
-    (evt: QueryParamChangeEvent) => {
-      const value = evt.forEmail
-      setSelectedMobilityProfile(value as string)
-      setQueryParam({
-        forEmail: value
-      })
-    },
-    [setSelectedMobilityProfile, setQueryParam]
-  )
   return (
     <PanelOverlay className="advanced-settings" ref={innerRef}>
       <HeaderContainer>
@@ -296,32 +264,23 @@ const AdvancedSettingsPanel = ({
         </>
       )}
       {loggedInUser?.dependentsInfo?.length && (
-        <MobilityProfileContainer>
-          <VisibleSubheader>
-            <FormattedMessage id="components.MobilityProfile.MobilityPane.header" />
-          </VisibleSubheader>
-          <FormattedMessage id="components.MobilityProfile.MobilityPane.planTripDescription" />
-          <MobilityProfileDropdown
-            label={intl.formatMessage({
-              id: 'components.MobilityProfile.dropdownLabel'
-            })}
-            name="forEmail"
-            onChange={onMobilityProfileChange}
-            options={[
-              {
-                text: intl.formatMessage({
-                  id: 'components.MobilityProfile.myself'
-                }),
-                value: loggedInUser?.email
-              },
-              ...(loggedInUser?.dependentsInfo?.map((user) => ({
-                text: getDependentName(user),
-                value: user.email
-              })) || [])
-            ]}
-            value={selectedMobilityProfile}
-          />
-        </MobilityProfileContainer>
+        <MobilityProfileSelector
+          name="forEmail"
+          options={[
+            {
+              text: intl.formatMessage({
+                id: 'components.MobilityProfile.myself'
+              }),
+              value: loggedInUser?.email
+            },
+            ...(loggedInUser?.dependentsInfo?.map((user) => ({
+              text: getDependentName(user),
+              value: user.email
+            })) || [])
+          ]}
+          setQueryParam={setQueryParam}
+          value={currentQuery.forEmail || loggedInUser?.email}
+        />
       )}
 
       <AdvancedModeSubsettingsContainer

--- a/lib/components/form/call-taker/advanced-options.js
+++ b/lib/components/form/call-taker/advanced-options.js
@@ -1,6 +1,4 @@
 /* eslint-disable react/prop-types */
-// FIXME: Remove the following eslint rule exception.
-/* eslint-disable jsx-a11y/label-has-for */
 import * as TripFormClasses from '@opentripplanner/trip-form/lib/styled'
 import { checkIfModeSettingApplies } from '@opentripplanner/trip-form/lib/MetroModeSelector/utils'
 import { injectIntl } from 'react-intl'
@@ -9,7 +7,6 @@ import {
   populateSettingWithValue,
   SubmodeSelector
 } from '@opentripplanner/trip-form'
-import isEmpty from 'lodash.isempty'
 import React, { Component, lazy, Suspense } from 'react'
 import styled from 'styled-components'
 
@@ -42,9 +39,6 @@ export const StyledSubmodeSelector = styled(SubmodeSelector)`
 
   margin: 5px 0;
 `
-
-const metersToMiles = (meters) => Math.round(meters * 0.000621371 * 100) / 100
-const milesToMeters = (miles) => miles / 0.000621371
 
 /**
  * Converts a new TransportMode object to legacy style underscore qualifier
@@ -80,7 +74,7 @@ class AdvancedOptions extends Component {
     this.props.findRoutesIfNeeded()
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate() {
     const { routes } = this.props
     // Once routes are available, map them to the route options format.
     const routeOptions = Object.values(routes).map(this.routeToOption)
@@ -111,17 +105,6 @@ class AdvancedOptions extends Component {
     // Disable routes that are banned already.
     const bannedRoutes = this.getRouteList('banned')
     return bannedRoutes && bannedRoutes.find((o) => o.value === option.value)
-  }
-
-  getDistanceStep = (distanceInMeters) => {
-    // Determine step for max walk/bike based on current value. Increment by a
-    // quarter mile if dealing with small values, whatever number will round off
-    // the number if it is not an integer, or default to one mile.
-    return metersToMiles(distanceInMeters) <= 2
-      ? '.25'
-      : metersToMiles(distanceInMeters) % 1 !== 0
-      ? `${metersToMiles(distanceInMeters) % 1}`
-      : '1'
   }
 
   _onSubModeChange = (changedMode) => {

--- a/lib/components/form/call-taker/advanced-options.js
+++ b/lib/components/form/call-taker/advanced-options.js
@@ -11,6 +11,7 @@ import React, { Component, lazy, Suspense } from 'react'
 import styled from 'styled-components'
 
 import { ComponentContext } from '../../../util/contexts'
+import { getMobilityProfileOptions } from '../../../util/mobility-profile'
 import { modeButtonButtonCss } from '../styled'
 import MobilityProfileSelector from '../../user/mobility-profile/mobility-profile-selector'
 
@@ -232,16 +233,7 @@ class AdvancedOptions extends Component {
         {hasMobilityProfile && (
           <MobilityProfileSelector
             name="mobilityProfile"
-            options={[
-              {
-                text: 'Able-bodied person',
-                value: 'None'
-              },
-              {
-                text: 'Electric Wheelchair User',
-                value: 'WChairE'
-              }
-            ]}
+            options={getMobilityProfileOptions(intl)}
             setQueryParam={setQueryParam}
           />
         )}

--- a/lib/components/form/call-taker/advanced-options.js
+++ b/lib/components/form/call-taker/advanced-options.js
@@ -234,8 +234,10 @@ class AdvancedOptions extends Component {
         {hasMobilityProfile && (
           <MobilityProfileSelector
             name="mobilityProfile"
+            // Use onSettingsUpdate to include the mobility profile in the URL
             onSettingsUpdate={onSettingsUpdate(setQueryParam)}
             options={getMobilityProfileOptions(intl)}
+            value={currentQuery.mobilityProfile}
           />
         )}
         <Suspense fallback={<span>...</span>}>

--- a/lib/components/form/call-taker/advanced-options.js
+++ b/lib/components/form/call-taker/advanced-options.js
@@ -12,6 +12,7 @@ import styled from 'styled-components'
 
 import { ComponentContext } from '../../../util/contexts'
 import { modeButtonButtonCss } from '../styled'
+import MobilityProfileSelector from '../../user/mobility-profile/mobility-profile-selector'
 
 export const StyledSubmodeSelector = styled(SubmodeSelector)`
   ${TripFormClasses.SubmodeSelector.Row} {
@@ -173,7 +174,14 @@ class AdvancedOptions extends Component {
   }
 
   render() {
-    const { currentQuery, intl, modes, onKeyDown } = this.props
+    const {
+      currentQuery,
+      hasMobilityProfile,
+      intl,
+      modes,
+      onKeyDown,
+      setQueryParam
+    } = this.props
     const { ModeIcon } = this.context
 
     const Select = lazy(() => import('react-select'))
@@ -221,6 +229,22 @@ class AdvancedOptions extends Component {
             onKeyDown={onKeyDown}
           />
         </div>
+        {hasMobilityProfile && (
+          <MobilityProfileSelector
+            name="mobilityProfile"
+            options={[
+              {
+                text: 'Able-bodied person',
+                value: 'None'
+              },
+              {
+                text: 'Electric Wheelchair User',
+                value: 'WChairE'
+              }
+            ]}
+            setQueryParam={setQueryParam}
+          />
+        )}
         <Suspense fallback={<span>...</span>}>
           <Select
             id="preferredRoutes"

--- a/lib/components/form/call-taker/advanced-options.js
+++ b/lib/components/form/call-taker/advanced-options.js
@@ -13,6 +13,7 @@ import styled from 'styled-components'
 import { ComponentContext } from '../../../util/contexts'
 import { getMobilityProfileOptions } from '../../../util/mobility-profile'
 import { modeButtonButtonCss } from '../styled'
+import { onSettingsUpdate } from '../util'
 import MobilityProfileSelector from '../../user/mobility-profile/mobility-profile-selector'
 
 export const StyledSubmodeSelector = styled(SubmodeSelector)`
@@ -233,8 +234,8 @@ class AdvancedOptions extends Component {
         {hasMobilityProfile && (
           <MobilityProfileSelector
             name="mobilityProfile"
+            onSettingsUpdate={onSettingsUpdate(setQueryParam)}
             options={getMobilityProfileOptions(intl)}
-            setQueryParam={setQueryParam}
           />
         )}
         <Suspense fallback={<span>...</span>}>

--- a/lib/components/user/mobility-profile/mobility-profile-selector.tsx
+++ b/lib/components/user/mobility-profile/mobility-profile-selector.tsx
@@ -1,0 +1,77 @@
+import { DropdownSelector } from '@opentripplanner/trip-form'
+import { FormattedMessage, useIntl } from 'react-intl'
+import { QueryParamChangeEvent } from '@opentripplanner/trip-form/lib/types'
+import React, { useCallback, useState } from 'react'
+import styled from 'styled-components'
+
+const VisibleSubheader = styled.h2`
+  display: block;
+  font-size: 18px;
+  font-weight: 700;
+  height: auto;
+  margin: 1em 0;
+  position: static;
+  width: auto;
+`
+
+const MobilityProfileContainer = styled.div`
+  margin: 60px 0 60px 5px;
+`
+
+const MobilityProfileDropdown = styled(DropdownSelector)`
+  margin: 20px 0px;
+  label {
+    padding-left: 0;
+  }
+`
+
+const MobilityProfileSelector = ({
+  name,
+  options,
+  setQueryParam,
+  value
+}: {
+  name: string
+  options: {
+    text: string
+    value: string
+  }[]
+  setQueryParam: (args: Record<string, unknown>) => void
+  value?: string
+}): JSX.Element => {
+  const intl = useIntl()
+  const [selectedProfile, setSelectedProfile] = useState<string | undefined>(
+    value
+  )
+
+  const onMobilityProfileChange = useCallback(
+    (evt: QueryParamChangeEvent) => {
+      const value = evt[name]
+      setSelectedProfile(value as string)
+      setQueryParam({
+        [name]: value
+      })
+    },
+    [name, setSelectedProfile, setQueryParam]
+  )
+
+  return (
+    <MobilityProfileContainer>
+      <VisibleSubheader>
+        <FormattedMessage id="components.MobilityProfile.MobilityPane.header" />
+      </VisibleSubheader>
+      <FormattedMessage id="components.MobilityProfile.MobilityPane.planTripDescription" />
+      <MobilityProfileDropdown
+        label={intl.formatMessage({
+          id: 'components.MobilityProfile.dropdownLabel'
+        })}
+        name={name}
+        onChange={onMobilityProfileChange}
+        options={options}
+        value={selectedProfile}
+      />
+    </MobilityProfileContainer>
+  )
+}
+
+export default MobilityProfileSelector

--- a/lib/components/user/mobility-profile/mobility-profile-selector.tsx
+++ b/lib/components/user/mobility-profile/mobility-profile-selector.tsx
@@ -1,22 +1,8 @@
 import { DropdownSelector } from '@opentripplanner/trip-form'
-import { FormattedMessage, useIntl } from 'react-intl'
 import { QueryParamChangeEvent } from '@opentripplanner/trip-form/lib/types'
+import { useIntl } from 'react-intl'
 import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
-
-const VisibleSubheader = styled.h2`
-  display: block;
-  font-size: 18px;
-  font-weight: 700;
-  height: auto;
-  margin: 1em 0;
-  position: static;
-  width: auto;
-`
-
-const MobilityProfileContainer = styled.div`
-  margin: 60px 0 60px 5px;
-`
 
 const MobilityProfileDropdown = styled(DropdownSelector)`
   margin: 20px 0px;
@@ -56,21 +42,15 @@ const MobilityProfileSelector = ({
   )
 
   return (
-    <MobilityProfileContainer>
-      <VisibleSubheader>
-        <FormattedMessage id="components.MobilityProfile.MobilityPane.header" />
-      </VisibleSubheader>
-      <FormattedMessage id="components.MobilityProfile.MobilityPane.planTripDescription" />
-      <MobilityProfileDropdown
-        label={intl.formatMessage({
-          id: 'components.MobilityProfile.dropdownLabel'
-        })}
-        name={name}
-        onChange={onMobilityProfileChange}
-        options={options}
-        value={selectedProfile}
-      />
-    </MobilityProfileContainer>
+    <MobilityProfileDropdown
+      label={intl.formatMessage({
+        id: 'components.MobilityProfile.dropdownLabel'
+      })}
+      name={name}
+      onChange={onMobilityProfileChange}
+      options={options}
+      value={selectedProfile}
+    />
   )
 }
 

--- a/lib/components/user/mobility-profile/mobility-profile-selector.tsx
+++ b/lib/components/user/mobility-profile/mobility-profile-selector.tsx
@@ -1,7 +1,7 @@
 import { DropdownSelector } from '@opentripplanner/trip-form'
 import { QueryParamChangeEvent } from '@opentripplanner/trip-form/lib/types'
 import { useIntl } from 'react-intl'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback } from 'react'
 import styled from 'styled-components'
 
 const MobilityProfileDropdown = styled(DropdownSelector)`
@@ -15,7 +15,7 @@ const MobilityProfileSelector = ({
   name,
   onSettingsUpdate,
   options,
-  value = 'None'
+  value
 }: {
   name: string
   onSettingsUpdate: (args: Record<string, unknown>) => void
@@ -23,18 +23,16 @@ const MobilityProfileSelector = ({
     text: string
     value: string
   }[]
-  value?: string
+  value: string
 }): JSX.Element => {
   const intl = useIntl()
-  const [selectedProfile, setSelectedProfile] = useState<string>(value)
 
   const onMobilityProfileChange = useCallback(
     (evt: QueryParamChangeEvent) => {
-      const value = evt[name]
-      setSelectedProfile(value as string)
-      onSettingsUpdate({ [name]: value })
+      const paramValue = evt[name]
+      onSettingsUpdate({ [name]: paramValue })
     },
-    [name, setSelectedProfile, onSettingsUpdate]
+    [name, onSettingsUpdate]
   )
 
   return (
@@ -45,7 +43,7 @@ const MobilityProfileSelector = ({
       name={name}
       onChange={onMobilityProfileChange}
       options={options}
-      value={selectedProfile}
+      value={value}
     />
   )
 }

--- a/lib/components/user/mobility-profile/mobility-profile-selector.tsx
+++ b/lib/components/user/mobility-profile/mobility-profile-selector.tsx
@@ -15,7 +15,7 @@ const MobilityProfileSelector = ({
   name,
   options,
   setQueryParam,
-  value
+  value = 'None'
 }: {
   name: string
   options: {
@@ -26,9 +26,7 @@ const MobilityProfileSelector = ({
   value?: string
 }): JSX.Element => {
   const intl = useIntl()
-  const [selectedProfile, setSelectedProfile] = useState<string | undefined>(
-    value
-  )
+  const [selectedProfile, setSelectedProfile] = useState<string>(value)
 
   const onMobilityProfileChange = useCallback(
     (evt: QueryParamChangeEvent) => {

--- a/lib/components/user/mobility-profile/mobility-profile-selector.tsx
+++ b/lib/components/user/mobility-profile/mobility-profile-selector.tsx
@@ -13,16 +13,16 @@ const MobilityProfileDropdown = styled(DropdownSelector)`
 
 const MobilityProfileSelector = ({
   name,
+  onSettingsUpdate,
   options,
-  setQueryParam,
   value = 'None'
 }: {
   name: string
+  onSettingsUpdate: (args: Record<string, unknown>) => void
   options: {
     text: string
     value: string
   }[]
-  setQueryParam: (args: Record<string, unknown>) => void
   value?: string
 }): JSX.Element => {
   const intl = useIntl()
@@ -32,11 +32,9 @@ const MobilityProfileSelector = ({
     (evt: QueryParamChangeEvent) => {
       const value = evt[name]
       setSelectedProfile(value as string)
-      setQueryParam({
-        [name]: value
-      })
+      onSettingsUpdate({ [name]: value })
     },
-    [name, setSelectedProfile, setQueryParam]
+    [name, setSelectedProfile, onSettingsUpdate]
   )
 
   return (

--- a/lib/util/mobility-profile.ts
+++ b/lib/util/mobility-profile.ts
@@ -1,0 +1,92 @@
+import { IntlShape } from 'react-intl'
+
+/**
+ * Gets a list of standard options for the MobilityProfileSelector
+ * by combining assistive device use and vision limitations.
+ */
+export function getMobilityProfileOptions(intl: IntlShape): {
+  text: string
+  value: string
+}[] {
+  // Where applicable, device and vision codes used below are from DevicePane > devices in the language files.
+  const rawProfiles = [
+    {
+      device: 'none',
+      value: 'None'
+    },
+    {
+      // This text will be displayed as is.
+      device: 'Some mobility limitations but not using an assistive device',
+      value: 'Some'
+    },
+    {
+      device: [
+        'cane',
+        'crutches',
+        'manual walker',
+        'service animal',
+        'stroller',
+        'wheeled walker'
+      ],
+      value: 'Device'
+    },
+    {
+      device: 'manual wheelchair',
+      value: 'WChairM'
+    },
+    {
+      device: 'electric wheelchair',
+      value: 'WChairE'
+    },
+    {
+      device: 'mobility scooter',
+      value: 'MScooter'
+    }
+  ]
+
+  const visionLevels = [
+    {
+      level: undefined,
+      value: ''
+    },
+    {
+      level: 'low-vision',
+      value: 'LowVision'
+    },
+    {
+      level: 'legally-blind',
+      value: 'Blind'
+    }
+  ]
+
+  return rawProfiles.flatMap((p) =>
+    visionLevels.map((vision) => ({
+      text:
+        (typeof p.device === 'string'
+          ? intl.formatMessage({
+              id: `components.MobilityProfile.DevicesPane.devices.${p.device}`
+            })
+          : 'length' in p.device
+          ? p.device
+              .map((d) =>
+                intl.formatMessage({
+                  id: `components.MobilityProfile.DevicesPane.devices.${d}`
+                })
+              )
+              .join('/')
+          : '') +
+        (vision.level
+          ? ' + ' +
+            intl.formatMessage({
+              id: `components.MobilityProfile.LimitationsPane.visionLimitations.${vision.level}`
+            })
+          : ''),
+      value:
+        p.value === 'None' && vision.level
+          ? vision.value
+          : p.value !== 'None'
+          ? p.value + (vision.level ? '-' + vision.value : '')
+          : 'None'
+    }))
+  )
+}

--- a/lib/util/mobility-profile.ts
+++ b/lib/util/mobility-profile.ts
@@ -15,8 +15,7 @@ export function getMobilityProfileOptions(intl: IntlShape): {
       value: 'None'
     },
     {
-      // This text will be displayed as is.
-      device: 'Some mobility limitations but not using an assistive device',
+      device: ['some limitations', 'none'],
       value: 'Some'
     },
     {
@@ -82,10 +81,10 @@ export function getMobilityProfileOptions(intl: IntlShape): {
             })
           : ''),
       value:
-        p.value === 'None' && vision.level
-          ? vision.value
-          : p.value !== 'None'
+        p.value !== 'None'
           ? p.value + (vision.level ? '-' + vision.value : '')
+          : vision.level
+          ? vision.value
           : 'None'
     }))
   )

--- a/lib/util/mobility-profile.ts
+++ b/lib/util/mobility-profile.ts
@@ -8,13 +8,15 @@ export function getMobilityProfileOptions(intl: IntlShape): {
   text: string
   value: string
 }[] {
-  // Where applicable, device and vision codes used below are from DevicePane > devices in the language files.
+  // Device and vision codes used below are from DevicePane > devices and
+  // LimitationsPane > visionLimitation in the language files.
   const rawProfiles = [
     {
       device: 'none',
       value: 'None'
     },
     {
+      // 'some limitations' is not technically a device, but we've added in there to build the mobility profile.
       device: ['some limitations', 'none'],
       value: 'Some'
     },
@@ -61,19 +63,13 @@ export function getMobilityProfileOptions(intl: IntlShape): {
   return rawProfiles.flatMap((p) =>
     visionLevels.map((vision) => ({
       text:
-        (typeof p.device === 'string'
-          ? intl.formatMessage({
-              id: `components.MobilityProfile.DevicesPane.devices.${p.device}`
+        (typeof p.device === 'string' ? [p.device] : p.device)
+          .map((device) =>
+            intl.formatMessage({
+              id: `components.MobilityProfile.DevicesPane.devices.${device}`
             })
-          : 'length' in p.device
-          ? p.device
-              .map((d) =>
-                intl.formatMessage({
-                  id: `components.MobilityProfile.DevicesPane.devices.${d}`
-                })
-              )
-              .join('/')
-          : '') +
+          )
+          .join('/') +
         (vision.level
           ? ' + ' +
             intl.formatMessage({


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR adds a basic mobility profile selector to the CallTaker Advanced Options pane (see screenshot),
so that call center operators can plan and share trips for a given mobility profile. A new `mobilityProfile` URL parameter is added, so that when pasted, it will produce an itinerary for said mobility profile.

<img width="482" alt="image" src="https://github.com/user-attachments/assets/cbcb1442-1d64-4c99-bcc0-342e892bc177" />

Required config:
- `mobilityProfile: true` in `config.yml`
- GraphQL query template that includes a `mobilityProfile` parameter


<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

