### PR TITLE
strict filtering use combination modes

### DIFF
--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -1094,7 +1094,7 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
               const itineraries = response.data?.plan?.itineraries
 
               // Convert user-selected transit modes from mode selector into modes recognized by OTP.
-              const activeModeStrings = activeModes.map(
+              const activeModeStrings = combo.modes.map(
                 (am) => SIMPLIFICATIONS[am.mode]
               )
 


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
We can't rely on `activeModes` because it misses addTransportModes that are added by mode settings. In one case, we added scooter and bike via the advanced settings/mode settings. These weren't included in the activeModes list. This change uses the post-processed combinations to determine what the active modes are for strict filtering. 
