### PR TITLE
Update mobile screen when origin changes

### DIFF
--- a/lib/actions/form.js
+++ b/lib/actions/form.js
@@ -174,6 +174,10 @@ export function checkShouldReplanTrip(autoPlan, isMobile, oldQuery, newQuery) {
   }
 }
 
+const checkIfOriginSetToCurrentPosition = (query, currentPosition) =>
+  query?.from?.lat === currentPosition?.coords?.latitude &&
+  query?.from?.lon === currentPosition?.coords?.longitude
+
 /**
  * If departArrive is set to 'NOW', update the query time to current
  */
@@ -198,8 +202,9 @@ export function updateQueryTimeIfLeavingNow() {
 export function formChanged(oldQuery, newQuery) {
   return function (dispatch, getState) {
     const state = getState()
-    const { config, ui } = state.otp
+    const { config, location, ui } = state.otp
     const { autoPlan, debouncePlanTimeMs } = config
+    const { currentPosition } = location
     const isMobile = coreUtils.ui.isMobile()
     const {
       fromChanged,
@@ -208,6 +213,11 @@ export function formChanged(oldQuery, newQuery) {
       shouldReplanTrip,
       toChanged
     } = checkShouldReplanTrip(autoPlan, isMobile, oldQuery, newQuery)
+
+    const originSetToCurrentPosition = checkIfOriginSetToCurrentPosition(
+      newQuery,
+      currentPosition
+    )
 
     dispatch(updateQueryTimeIfLeavingNow())
 
@@ -222,11 +232,13 @@ export function formChanged(oldQuery, newQuery) {
       // location changes.
       if (fromChanged || toChanged) {
         dispatch(clearActiveSearch())
-        // Return to search screen on mobile only if not currently on welcome
-        // screen (otherwise when the current position is auto-set the screen
-        // will change unexpectedly).
+        // Return to search screen on mobile only if not setting to current location
+        // (otherwise when the current position is auto-set the screen will change unexpectedly).
         if (
-          ui.mobileScreen !== MobileScreens.WELCOME_SCREEN &&
+          !(
+            ui.mobileScreen === MobileScreens.WELCOME_SCREEN &&
+            originSetToCurrentPosition
+          ) &&
           !locationChangedToBlank
         ) {
           dispatch(setMobileScreen(MobileScreens.SEARCH_FORM))


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Fixes an issue where updating the origin (eg. via stop popup from/to selector) while on the welcome screen was not updating the trip form, meaning users had no idea the origin had changed.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

