### PR TITLE
Fix Recent Search click action

### DIFF
--- a/lib/components/form/user-settings.js
+++ b/lib/components/form/user-settings.js
@@ -334,6 +334,9 @@ const TripRequest = ({
   const _onSelect = useCallback(
     // Update query params and initiate search.
     () => {
+      // In previous versions of this code, tripRequest.id was passed to setQueryParam,
+      // however that causes an extra entry to be added to the recent searches on click,
+      // in addition to the entry added when clicking the "Plan" (magnifying glass) button.
       setQueryParam(query)
       if (query.modeButtons) {
         setUrlSearch({ modeButtons: query.modeButtons })

--- a/lib/components/form/user-settings.js
+++ b/lib/components/form/user-settings.js
@@ -329,12 +329,12 @@ const TripRequest = ({
   tripRequest,
   user
 }) => {
-  const { canDelete = true, id, query, timestamp } = tripRequest
+  const { canDelete = true, query, timestamp } = tripRequest
 
   const _onSelect = useCallback(
     // Update query params and initiate search.
     () => {
-      setQueryParam(query, id)
+      setQueryParam(query)
       if (query.modeButtons) {
         setUrlSearch({ modeButtons: query.modeButtons })
       }
@@ -342,7 +342,7 @@ const TripRequest = ({
         setUrlSearch({ modeSettings: query.modeSettings })
       }
     },
-    [setQueryParam, setUrlSearch, query, id]
+    [setQueryParam, setUrlSearch, query]
   )
 
   const _onForget = useCallback(


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR prevents a duplicate entry to be added to Recent Searches when clicking a recent search entry.

Before: clicking a recent entry and clicking "Plan" (and refreshing the page) adds two identical entries in the recents list (see screenshot).

<img width="394" alt="image" src="https://github.com/user-attachments/assets/916c5a09-4f10-4461-a0c6-e3e92c6f3c6b" />

After: Only one entry is added.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

