### PR TITLE
fix(user): Add recent search entry after routingQuery.

### DIFF
--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -36,6 +36,7 @@ import {
 } from '../util/viewer'
 import { isLastStop } from '../util/stop-times'
 
+import { addToRecentSearches, rememberPlace } from './user'
 import {
   createQueryAction,
   fetchingStopTimesForStop,
@@ -61,7 +62,6 @@ import {
   routingResponse,
   updateOtpUrlParams
 } from './api'
-import { rememberPlace } from './user'
 import { RoutingQueryCallResult } from './api-constants'
 import { setViewedNearbyCoords } from './ui'
 
@@ -1053,6 +1053,8 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
         updateSearchInReducer
       })
     )
+
+    dispatch(addToRecentSearches(searchId, baseQuery.modes))
 
     combinations.forEach((combo, index) => {
       const query = generateOtp2Query(combo)

--- a/lib/actions/user.js
+++ b/lib/actions/user.js
@@ -877,3 +877,29 @@ export function forgetPlace(placeId, intl) {
     }
   }
 }
+
+/**
+ * Record this search for the logged-in user
+ * (Note: intentionally does not happen when reloading a page).
+ */
+export function addToRecentSearches(searchId, modes) {
+  return function (dispatch, getState) {
+    const state = getState()
+    const { currentQuery } = state.otp
+    const { loggedInUser, loggedInUserTripRequests } = state.user
+    if (loggedInUser) {
+      dispatch(
+        setCurrentUserTripRequests([
+          {
+            canDelete: false,
+            id: searchId,
+            query: { ...currentQuery, modes },
+            timestamp: new Date().valueOf(),
+            url: window.location.href
+          },
+          ...(loggedInUserTripRequests || [])
+        ])
+      )
+    }
+  }
+}


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

With this PR, a recent search entry is added after planning a trip and can be accessed from the recents list when clearing one or both of the origin/destination.
(Currently, you have to reload the page for recent searches to appear.)

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

