### PR TITLE
correct `showScheduleDeviation`, enable flex

### DIFF
--- a/lib/components/narrative/line-itin/realtime-time-column.tsx
+++ b/lib/components/narrative/line-itin/realtime-time-column.tsx
@@ -1,5 +1,5 @@
 import { FormattedTime } from 'react-intl'
-import { isTransitLeg } from '@opentripplanner/core-utils/lib/itinerary'
+import { isFlex, isTransitLeg } from '@opentripplanner/core-utils/lib/itinerary'
 import { Leg } from '@opentripplanner/types'
 import React, { ReactElement } from 'react'
 import styled from 'styled-components'
@@ -50,6 +50,7 @@ function RealtimeTimeColumn({ isDestination, leg }: Props): ReactElement {
   return (
     <StyledStatusLabel
       delay={delaySeconds}
+      isFlex={isFlex(leg)}
       isRealtime={isRealtimeTransitLeg}
       originalTime={originalTimeMillis}
       time={timeMillis}

--- a/lib/components/util/formatted-realtime-status-label.tsx
+++ b/lib/components/util/formatted-realtime-status-label.tsx
@@ -34,7 +34,7 @@ const FormattedRealtimeStatusLabel = ({
     case 'scheduled':
       return <FormattedMessage id="components.RealtimeStatusLabel.scheduled" />
     default:
-      return null
+      return minutes
   }
 }
 

--- a/lib/components/viewers/realtime-status-label.tsx
+++ b/lib/components/viewers/realtime-status-label.tsx
@@ -65,6 +65,7 @@ const STATUS = {
 const RealtimeStatusLabel = ({
   className,
   delay,
+  isFlex = false,
   isRealtime,
   onTimeThresholdSeconds,
   originalTime,
@@ -74,6 +75,7 @@ const RealtimeStatusLabel = ({
 }: {
   className?: string
   delay: number
+  isFlex: boolean
   isRealtime?: boolean
   onTimeThresholdSeconds?: number
   originalTime?: number
@@ -125,7 +127,9 @@ const RealtimeStatusLabel = ({
         {showScheduleDeviation && (
           <FormattedRealtimeStatusLabel
             minutes={
-              isEarlyOrLate ? (
+              isFlex ? (
+                <FormattedMessage id="config.flex.flex-service" />
+              ) : isEarlyOrLate ? (
                 <DelayText>
                   <FormattedDuration
                     duration={Math.abs(delay)}
@@ -137,10 +141,10 @@ const RealtimeStatusLabel = ({
               )
             }
             // @ts-ignore getTripStatus is not typed yet
-            status={STATUS[status].label}
+            status={!isFlex && STATUS[status].label}
           />
         )}
-        {isEarlyOrLate && (
+        {isEarlyOrLate && !isFlex && (
           <InvisibleAdditionalDetails>
             <FormattedMessage
               id="components.MetroUI.originallyScheduledTime"
@@ -159,7 +163,7 @@ const RealtimeStatusLabel = ({
 
 const mapStateToProps = (state: AppReduxState) => ({
   onTimeThresholdSeconds: state.otp.config.onTimeThresholdSeconds,
-  showScheduleDeviation: state.otp.config.showScheduleDeviation
+  showScheduleDeviation: state.otp.config?.itinerary?.showScheduleDeviation
 })
 
 export default connect(mapStateToProps)(RealtimeStatusLabel)

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -301,6 +301,8 @@ export interface ItineraryConfig {
   showLegDurations?: boolean
   showPlanFirstLastButtons?: boolean
   showRouteFares?: boolean
+  /** Whether to show the x minutes late/early in the itinerary body */
+  showScheduleDeviation?: boolean
   sortModes?: ItinerarySortOption[]
   syncSortWithDepartArrive?: boolean
   weights?: ItineraryCostWeights
@@ -423,8 +425,6 @@ export interface AppConfig {
   routeViewer?: RouteViewerConfig
   /** Approx delay in seconds to reset the UI to an initial URL if there is no user activity */
   sessionTimeoutSeconds?: number
-  /** Whether to show the x minutes late/early in the itinerary body */
-  showScheduleDeviation?: boolean
   stopViewer?: StopScheduleViewerConfig
   /** Externally hosted terms of service URL */
   termsOfServiceLink?: string


### PR DESCRIPTION
`showScheduleDeviation` was incorrectly configured to not pull the config from the `itinerary` settings object. Additionally there was no flex support. This is now corrected.