### PR TITLE
remove watchPosition in favor of setInterval

### DIFF
--- a/lib/components/app/responsive-webapp.js
+++ b/lib/components/app/responsive-webapp.js
@@ -55,24 +55,6 @@ class ResponsiveWebapp extends Component {
 
   /** Lifecycle methods **/
 
-  // Check if the position has changed enough to update the currentPosition
-  // (prevent constant updates in nearby view)
-  // .001 works out to be about 94-300 ft depending on the longitude.
-  positionShouldUpdate = (position) => {
-    const { currentPosition } = this.props
-    if (!currentPosition.coords) return true
-    const latChanged =
-      Math.abs(
-        position?.coords?.latitude - currentPosition?.coords?.latitude
-      ) >= 0.001
-    const lonChanged =
-      Math.abs(
-        position?.coords?.longitude - currentPosition?.coords?.longitude
-      ) >= 0.001
-
-    return latChanged || lonChanged
-  }
-
   /* eslint-disable-next-line complexity */
   componentDidUpdate(prevProps) {
     const {
@@ -197,21 +179,10 @@ class ResponsiveWebapp extends Component {
     if (isMobile()) {
       // Test location availability on load
       getCurrentPosition(intl)
-      // Watch for position changing on mobile
-      navigator.geolocation.watchPosition(
-        // On success
-        (position) => {
-          if (this.positionShouldUpdate(position)) {
-            receivedPositionResponse({ position })
-          }
-        },
-        // On error
-        (error) => {
-          console.log('error in watchPosition', error)
-        },
-        // Options
-        { enableHighAccuracy: true }
-      )
+      // Update position every 30 seconds. watchPosition interferes with react-map-gl.
+      setInterval(() => {
+        getCurrentPosition(intl)
+      }, 30000)
     }
     // Handle routing to a specific part of the app (e.g. stop viewer) on page
     // load. (This happens prior to routing request in case special routerId is


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
`watchPosition` is interfering with some of the mobile functionality of `react-map-gl` so instead we're using `setInterval` to update the users position every 30 seconds.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

