### PR TITLE
Remove mobile results header

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -500,10 +500,6 @@ components:
     scheduled: scheduled
   ResultsError:
     backToSearch: Back to Search
-  ResultsHeader:
-    noTripFound: No Trip Found
-    tripsFound: We Found {count, plural, one {# Option} other {# Options}}
-    waiting: Waiting...
   RouteDetails:
     headsignTo: "{headsign} ({lastStop})"
     moreDetails: More Details

--- a/i18n/es.yml
+++ b/i18n/es.yml
@@ -510,10 +510,6 @@ components:
     scheduled: programado
   ResultsError:
     backToSearch: Volver a la búsqueda
-  ResultsHeader:
-    noTripFound: No se encontró ningún viaje
-    tripsFound: Encontramos {count, plural, one {# opción} other {# opciones}}
-    waiting: Espera...
   RouteDetails:
     headsignTo: "{headsign} ({lastStop})"
     moreDetails: Más detalles

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -521,10 +521,6 @@ components:
     scheduled: horaire
   ResultsError:
     backToSearch: Retour à la recherche
-  ResultsHeader:
-    noTripFound: Aucun trajet trouvé
-    tripsFound: "{count, plural, one {# trajet trouvé} other {# trajets trouvés}}"
-    waiting: Patientez...
   RouteDetails:
     headsignTo: "{headsign} ({lastStop})"
     moreDetails: Plus d'infos

--- a/i18n/ko.yml
+++ b/i18n/ko.yml
@@ -453,10 +453,6 @@ components:
     scheduled: 예정
   ResultsError:
     backToSearch: 검색으로 돌아가기
-  ResultsHeader:
-    noTripFound: 트립을 찾을 수 없음
-    tripsFound: "{count} 개의 옵션 을 찾았습니다"
-    waiting: 기다리는 중...
   RouteDetails:
     headsignTo: "{headsign} ({lastStop})"
     moreDetails: 더 자세한 내용

--- a/i18n/ru.yml
+++ b/i18n/ru.yml
@@ -512,12 +512,6 @@ components:
     scheduled: по расписанию
   ResultsError:
     backToSearch: Вернуться к поиску
-  ResultsHeader:
-    noTripFound: Не удалось найти поездку
-    tripsFound: >-
-      {count, plural, one {Найден {count} вариант} other {Найдено несколько
-      вариантов ({count})}}
-    waiting: Ожидание…
   RouteDetails:
     headsignTo: "{headsign} ({lastStop})"
     moreDetails: Подробнее

--- a/i18n/tl.yml
+++ b/i18n/tl.yml
@@ -524,10 +524,6 @@ components:
     scheduled: nakaiskedyul
   ResultsError:
     backToSearch: Bumalik sa Paghahanap
-  ResultsHeader:
-    noTripFound: Walang Nakitang Biyahe
-    tripsFound: Nakakita kami ng {count} {count, plural, one {Option} other {Options}}
-    waiting: Naghihintay...
   RouteDetails:
     headsignTo: "{headsign} ({lastStop})"
     moreDetails: Higit Pang Detalye

--- a/i18n/vi.yml
+++ b/i18n/vi.yml
@@ -499,10 +499,6 @@ components:
     scheduled: lên kế hoạch
   ResultsError:
     backToSearch: Quay lại tìm kiếm
-  ResultsHeader:
-    noTripFound: Không tìm thấy chuyến đi nào
-    tripsFound: Đã tìm thấy {count} tùy chọn
-    waiting: Đang chờ đợi...
   RouteDetails:
     headsignTo: "{headsign} ({lastStop})"
     moreDetails: Thêm chi tiết

--- a/i18n/zh_Hans.yml
+++ b/i18n/zh_Hans.yml
@@ -399,10 +399,6 @@ components:
     scheduled: 预定的
   ResultsError:
     backToSearch: 返回搜索
-  ResultsHeader:
-    noTripFound: 没有找到行程
-    tripsFound: 我们发现了 {count} 选项
-    waiting: 等待...
   RouteDetails:
     headsignTo: "{headsign} ({lastStop})"
     moreDetails: 更多细节

--- a/i18n/zh_Hant.yml
+++ b/i18n/zh_Hant.yml
@@ -388,10 +388,6 @@ components:
     scheduled: 預定
   ResultsError:
     backToSearch: 返回搜尋
-  ResultsHeader:
-    noTripFound: 找不到行程
-    tripsFound: 我們找到了{count} 個選項
-    waiting: 等待中……
   RouteDetails:
     headsignTo: "{headsign} ({lastStop})"
     moreDetails: 更多詳細資訊

--- a/lib/components/mobile/results-header.js
+++ b/lib/components/mobile/results-header.js
@@ -57,16 +57,10 @@ class ResultsHeader extends Component {
   }
 
   render() {
-    const { errors, intl, query, resultCount } = this.props
-    const hasNoResult = resultCount === 0 && errors.length > 0
-    const headerText = hasNoResult
-      ? intl.formatMessage({ id: 'components.ResultsHeader.noTripFound' })
-      : resultCount
-      ? intl.formatMessage(
-          { id: 'components.ResultsHeader.tripsFound' },
-          { count: resultCount }
-        )
-      : intl.formatMessage({ id: 'components.ResultsHeader.waiting' })
+    const { intl, query } = this.props
+    const headerText = intl.formatMessage({
+      id: 'components.BatchSearchScreen.header'
+    })
 
     return (
       <>


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Remove the mobile header that describes search results, because it does not work well for all screen sizes and languages. The description of itinerary results and how to navigate them are already included in the itinerary results body in a status region for AT.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
|<img width="360" alt="image" src="https://github.com/user-attachments/assets/e46213e8-cde2-4fc3-bbe0-f69f7c3dfe7b" />|<img width="360" alt="image" src="https://github.com/user-attachments/assets/d2716de7-da3a-4958-bdf6-e869a9de9062" />|

