### PR TITLE
Avoid Unnecessary Flex Requests

### DIFF
--- a/lib/actions/api-utils.ts
+++ b/lib/actions/api-utils.ts
@@ -1,0 +1,4 @@
+import { TransportMode } from '@opentripplanner/types'
+
+export const countFlexModes = (modes: TransportMode[]): number =>
+  modes.filter((m) => m.mode === 'FLEX').length

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -37,6 +37,7 @@ import {
 import { isLastStop } from '../util/stop-times'
 
 import { addToRecentSearches, rememberPlace } from './user'
+import { countFlexModes } from './api-utils'
 import {
   createQueryAction,
   fetchingStopTimesForStop,
@@ -1039,7 +1040,16 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
     // Generate combinations if the modes for query are not specified in the query
     // FIXME: BICYCLE_RENT does not appear in this list unless TRANSIT is also enabled.
     // This is likely due to the fact that BICYCLE_RENT is treated as a transit submode.
-    const combinations = modes ? [baseQuery] : generateCombinations(baseQuery)
+    let combinations = modes ? [baseQuery] : generateCombinations(baseQuery)
+
+    // Pre-planConnection API hack: FLEX should always be bundled together.
+    // The real solution is to change how we generate mode selections, but for now
+    // this removes superfluous flex requests.
+    combinations = combinations.filter((c) => {
+      const flexCount = countFlexModes(c.modes)
+      // We need either all 3 flex modes or none! Anything in-between is invalid
+      return flexCount === 0 || flexCount === 3
+    })
 
     if (combinations.length === 0) {
       return RoutingQueryCallResult.INVALID_MODE_SELECTION


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Previously we were generating upwards of 6 flex requests per request. It turns out we didn't have to do that. An OTP-UI patch would be a cleaner way to do this, but since we will soon be moving to PlanConnection, I think this quicker solution makes more sense!
