### PR TITLE
Check fares are equal before merging itins

### DIFF
--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -54,14 +54,14 @@ function makeStartTime(itinerary) {
   }
 }
 
-export const doMergeItineraries = memoize((itineraries) => {
+export const doMergeItineraries = memoize((itineraries, defaultFareType) => {
   const mergedItineraries = itineraries
     .reduce((prev, cur) => {
       const updatedItineraries = clone(prev)
       const updatedItinerary = clone(cur)
 
       const duplicateIndex = updatedItineraries.findIndex((itin) =>
-        itinerariesAreEqual(itin, cur)
+        itinerariesAreEqual(itin, cur, defaultFareType)
       )
       // If no duplicate, push full itinerary to output
       if (duplicateIndex === -1 || cur.legs.some(isFlex)) {
@@ -528,6 +528,7 @@ const mapStateToProps = (state) => {
     itineraryView === ItineraryView.LEG_HIDDEN
   const {
     customBatchUiBackground,
+    defaultFareType,
     groupByMode: groupItineraries,
     groupTransitModes,
     mergeItineraries,
@@ -545,7 +546,7 @@ const mapStateToProps = (state) => {
   let allItineraries
   if (mergeItineraries) {
     // eslint-disable-next-line prettier/prettier
-    ({ allItineraries, mergedItineraries } = doMergeItineraries(itinsWithCo2))
+    ({ allItineraries, mergedItineraries } = doMergeItineraries(itinsWithCo2, defaultFareType))
   } else {
     allItineraries = itinsWithCo2
     mergedItineraries = [...allItineraries]

--- a/lib/util/itinerary.tsx
+++ b/lib/util/itinerary.tsx
@@ -1,6 +1,11 @@
 import { differenceInMinutes } from 'date-fns'
+import {
+  FareProductSelector,
+  Itinerary,
+  Leg,
+  Place
+} from '@opentripplanner/types'
 import { isTransitLeg } from '@opentripplanner/core-utils/lib/itinerary'
-import { Itinerary, Leg, Place } from '@opentripplanner/types'
 import { toDate, utcToZonedTime } from 'date-fns-tz'
 import coreUtils from '@opentripplanner/core-utils'
 import hash from 'object-hash'
@@ -131,9 +136,12 @@ function legLocationsAreEqual(legLocation: Place, other: Place) {
 
 export function itinerariesAreEqual(
   itinerary: Itinerary,
-  other: Itinerary
+  other: Itinerary,
+  defaultFareType: FareProductSelector
 ): boolean {
   return (
+    getFare(itinerary, defaultFareType).transitFare ===
+      getFare(other, defaultFareType).transitFare &&
     itinerary.legs.length === other.legs.length &&
     itinerary.legs.every((leg, index) => {
       const otherLeg = other?.legs?.[index]


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Previously, we would merge two itineraries even if the default fares were different, which could be misleading to the user since the itin preview implied the details between these itineraries were the same. This makes sure the fares are equal (at least based on the default fare type) before merging itineraries.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
|<img width="472" alt="image" src="https://github.com/user-attachments/assets/e9067211-63c1-4dca-98e6-90f3f1054d37" />|<img width="474" alt="image" src="https://github.com/user-attachments/assets/659e0c0a-18d1-4edb-af7f-c8ba5d4f05e5" />|

