### PR TITLE
Avoid fetch error if a user hasn't finished setting up their account

### DIFF
--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -82,7 +82,7 @@ function getOtpFetchOptions(state, includeToken = false) {
   if (isOtpServerSameAsMiddleware) {
     // Use access token only if the user has completed entire account setup
     // (Otherwise every request returns an error)
-    if (includeToken && state.user.loggedInUser.hasConsentedToTerms) {
+    if (includeToken && state.user?.loggedInUser?.hasConsentedToTerms) {
       const { accessToken, loggedInUser } = state.user
       if (accessToken && loggedInUser) {
         token = accessToken

--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -80,13 +80,11 @@ function getOtpFetchOptions(state, includeToken = false) {
 
   const isOtpServerSameAsMiddleware = apiBaseUrl === api.host
   if (isOtpServerSameAsMiddleware) {
+    const { accessToken, loggedInUser } = state.user
     // Use access token only if the user has completed entire account setup
     // (Otherwise every request returns an error)
-    if (includeToken && state.user?.loggedInUser?.hasConsentedToTerms) {
-      const { accessToken, loggedInUser } = state.user
-      if (accessToken && loggedInUser) {
-        token = accessToken
-      }
+    if (accessToken && loggedInUser?.hasConsentedToTerms) {
+      token = accessToken
     }
 
     return getSecureFetchOptions(token, apiKey)

--- a/lib/actions/api.js
+++ b/lib/actions/api.js
@@ -80,7 +80,9 @@ function getOtpFetchOptions(state, includeToken = false) {
 
   const isOtpServerSameAsMiddleware = apiBaseUrl === api.host
   if (isOtpServerSameAsMiddleware) {
-    if (includeToken && state.user) {
+    // Use access token only if the user has completed entire account setup
+    // (Otherwise every request returns an error)
+    if (includeToken && state.user.loggedInUser.hasConsentedToTerms) {
       const { accessToken, loggedInUser } = state.user
       if (accessToken && loggedInUser) {
         token = accessToken


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Previously if a user had created an account but had not yet made it all the way to the end of the account setup wizard, all otp requests would return errors. This makes sure we're only associating the search with an account if the account has been fully set up.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

