### PR TITLE
Gracefully handle pattern being wrong in pattern viewer

### DIFF
--- a/lib/components/viewers/pattern-viewer.tsx
+++ b/lib/components/viewers/pattern-viewer.tsx
@@ -49,12 +49,19 @@ const PatternViewer = ({
 }: Props) => {
   const intl = useIntl()
 
+  // @ts-expect-error TODO: add type to ComponentContext
+  const { ModeIcon, RouteRenderer } = useContext(ComponentContext)
+
+  const routePatternKeys = route?.patterns && Object.keys(route?.patterns)
+  const patternId = viewedRoute?.patternId
+  const routeId = viewedRoute?.routeId || null
+
   /**
    * If we're viewing a pattern's stops, route to main route viewer.
    */
   const _backClicked = useCallback(() => {
     // The if test is for typescript checks.
-    if (viewedRoute?.routeId) {
+    if (viewedRoute && routeId) {
       setViewedRoute({
         ...viewedRoute,
         patternId: undefined
@@ -64,29 +71,18 @@ const PatternViewer = ({
 
   useEffect(findRoutesIfNeeded, [findRoutesIfNeeded])
 
-  // @ts-expect-error TODO: add type to ComponentContext
-  const { ModeIcon, RouteRenderer } = useContext(ComponentContext)
-
-  const routePatternKeys = route?.patterns && Object.keys(route?.patterns)
-
   // If the patternId does not exist in the route, course correct back to a valid pattern.
   // (ex. the URL was /route/123/undefined)
-  if (
-    viewedRoute?.patternId &&
-    !routePatternKeys?.includes(viewedRoute?.patternId) &&
-    routePatternKeys &&
-    routePatternKeys.length > 0
-  ) {
+  if (patternId && !routePatternKeys?.includes(patternId) && routePatternKeys) {
     // Set the patternId to the first pattern in the route (this will reload the page).
     setViewedRoute({
       patternId: routePatternKeys[0],
-      routeId: viewedRoute?.routeId
+      routeId: routeId
     })
   }
 
   // If patternId is present and route data have been fetched, we're looking at a specific pattern's stops.
-  if (viewedRoute?.patternId && route) {
-    const { patternId } = viewedRoute
+  if (patternId && route) {
     // Find operator based on agency_id (extracted from OTP route ID).
     const operator = getRouteOperator(route, transitOperators)
     const routeColor = getRouteColorBasedOnSettings(operator, route)
@@ -153,7 +149,7 @@ const PatternViewer = ({
     )
   }
 
-  return <p>oops we cannot find this pattern.</p>
+  return null
 }
 
 // connect to redux store

--- a/lib/components/viewers/pattern-viewer.tsx
+++ b/lib/components/viewers/pattern-viewer.tsx
@@ -67,6 +67,23 @@ const PatternViewer = ({
   // @ts-expect-error TODO: add type to ComponentContext
   const { ModeIcon, RouteRenderer } = useContext(ComponentContext)
 
+  const routePatternKeys = route?.patterns && Object.keys(route?.patterns)
+
+  // If the patternId does not exist in the route, course correct back to a valid pattern.
+  // (ex. the URL was /route/123/undefined)
+  if (
+    viewedRoute?.patternId &&
+    !routePatternKeys?.includes(viewedRoute?.patternId) &&
+    routePatternKeys &&
+    routePatternKeys.length > 0
+  ) {
+    // Set the patternId to the first pattern in the route (this will reload the page).
+    setViewedRoute({
+      patternId: routePatternKeys[0],
+      routeId: viewedRoute?.routeId
+    })
+  }
+
   // If patternId is present and route data have been fetched, we're looking at a specific pattern's stops.
   if (viewedRoute?.patternId && route) {
     const { patternId } = viewedRoute
@@ -136,7 +153,7 @@ const PatternViewer = ({
     )
   }
 
-  return null
+  return <p>oops we cannot find this pattern.</p>
 }
 
 // connect to redux store


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

Previously, if the pattern in the URL didn't match a valid pattern id, we were showing a completely blank pattern page. 

This was particularly tough when a user tried to open the pattern viewer with no internet connection, the URL would populate the `patternId` in the URL as "undefined". When the internet connection restored, because the URL had "undefined" there was no way for the page to recover gracefully. 

Now, if the `patternId` does not exist on the route, we instead reload the page with a valid pattern.

Open to feedback on this. Maybe we only reroute explicitly if the `patternId` is set to the string "undefined"? I cannot imagine a lot of instances where a user is typing the pattern into the URL to find the correct page, but if those cases exist, maybe it's better to let the user know something went wrong rather than automatically redirect them?

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

