### PR TITLE
Display 'verified' status again for verified phone numbers

### DIFF
--- a/lib/components/util/status-badge.tsx
+++ b/lib/components/util/status-badge.tsx
@@ -22,6 +22,7 @@ function getStatusLabel(status?: string) {
         </StyledStatusLabel>
       )
     case 'confirmed':
+    case 'verified':
       return (
         <StyledStatusLabel style={{ background: 'green' }}>
           <FormattedMessage id="components.StatusBadge.verified" />


### PR DESCRIPTION

<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->

## Description

This PR makes the "Verified" badge to be shown for verified phone numbers after the badge was hidden by https://github.com/opentripplanner/otp-react-redux/commit/6599af58c5ad54408b6cc02e60794ca6c7d553f7. (see screenshot)

<img width="371" alt="before and after screenshots" src="https://github.com/user-attachments/assets/9058af59-b479-412d-bbfe-e7dbf611c6d2" />


<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

