### PR TITLE
fix: place editor reverse geocode current location

### DIFF
--- a/lib/components/form/connect-location-field.js
+++ b/lib/components/form/connect-location-field.js
@@ -56,6 +56,7 @@ export default function connectLocationField(
     excludeSavedLocations = false,
     includeLocation = false
   } = options
+  // eslint-disable-next-line complexity
   const mapStateToProps = (state, ownProps) => {
     const { config, currentQuery, location, transitIndex } = state.otp
     const { currentPosition, nearbyStops, sessionSearches } = location

--- a/lib/components/user/places/place-editor.tsx
+++ b/lib/components/user/places/place-editor.tsx
@@ -86,19 +86,38 @@ class PlaceEditor extends Component<Props> {
   static contextType = ComponentContext
 
   _setLocation = (location: Location) => {
-    const { intl, setValues, values } = this.props
+    const { geocoderConfig, intl, setValues, values } = this.props
     const { category, lat, lon, name } = location
-    setValues({
-      ...values,
-      address:
-        // If the raw current location is passed without a name attribute (i.e. the address),
-        // set the "address" as the formatted coordinates of the current location at that time.
-        category === 'CURRENT_LOCATION'
-          ? intl.formatMessage({ id: 'common.coordinates' }, { lat, lon })
-          : name,
-      lat,
-      lon
-    })
+
+    // Helper function to update the form values.
+    const updateFormValues = (newAddress?: string) => {
+      setValues({
+        ...values,
+        address: newAddress,
+        lat,
+        lon
+      })
+    }
+
+    // If the location is a current location, reverse geocode the coordinates.
+    if (category === 'CURRENT_LOCATION') {
+      const initialAddress = intl.formatMessage(
+        { id: 'common.coordinates' },
+        { lat, lon }
+      )
+      updateFormValues(initialAddress)
+
+      getGeocoder(geocoderConfig)
+        .reverse({ point: { lat, lon } })
+        .then((geocodedLocation: Location) => {
+          updateFormValues(geocodedLocation.name)
+        })
+        .catch((err: Error) => {
+          console.warn('Reverse geocode failed:', err)
+        })
+    } else {
+      updateFormValues(name)
+    }
   }
 
   _handleLocationChange = (e: LocationSelectedEvent) => {


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
This fixes a bug in the place editor where it would not reverse geocode the current position after the first time it was requested. It would probably be good to overhaul the way the locations are handled to be more centralized, because now it feels a bit repetitive since we do this reverse geocode thing in 3 different spots, but they're all just different enough that it wouldn't really be easy to consolidate. 
<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

