### PR TITLE
fix: support displaying endpoints overlay popup without persistence

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -122,6 +122,9 @@ map:
   initLon: -122.682
   # autoFlyOnTripFormUpdate: false
   # navigationControlPosition: "bottom-right"
+
+  # Enable the following option to show the endpoints popup even with persistence disabled
+  # forceDisplayEndpointsPopup: false
   baseLayers:
     - name: Streets
       # These tiles are free to use, but not in production

--- a/lib/components/map/connected-endpoints-overlay.tsx
+++ b/lib/components/map/connected-endpoints-overlay.tsx
@@ -73,7 +73,9 @@ const mapStateToProps = (state: any) => {
   // current query is no search is available.
   const activeSearch: any = getActiveSearch(state)
   const query = activeSearch ? activeSearch.query : state.otp.currentQuery
-  const showUserSettings = getShowUserSettings(state)
+  const showUserSettings =
+    getShowUserSettings(state) ||
+    state.otp.config?.map?.forceDisplayEndpointsPopup
   const { from, to } = query
   // Intermediate places doesn't trigger a re-plan, so for now default to
   // current query. FIXME: Determine with TriMet if this is desired behavior.

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -235,6 +235,7 @@ export interface TransitiveConfig {
 export interface MapConfig {
   autoFlyOnTripFormUpdate?: boolean
   baseLayers?: BaseLayerConfig[]
+  forceDisplayEndpointsPopup?: boolean
   initLat?: number
   initLon?: number
   initZoom?: number


### PR DESCRIPTION
Previously persistence had to be enabled to show the endpoint overlay popups. This PR corrects this by adding a new `forceDisplayEndpointsPopup` config item. Please note that the "save as home" and "save as work" won't do anything without an enhancement to otp-ui.