### PR TITLE
Correct max MapPin icon size

### DIFF
--- a/lib/components/util/transit-operator-icons.tsx
+++ b/lib/components/util/transit-operator-icons.tsx
@@ -44,7 +44,7 @@ const Operator = ({ operator }: { operator?: TransitOperator }) => {
       // If operator exists but logo is missing,
       // we still need to announce the operator name to screen readers.
       <>
-        <MapPin />
+        <MapPin style={{ maxHeight: 24, padding: '0 0.25ch' }} />
         <InvisibleA11yLabel>{operatorLogoAriaLabel}</InvisibleA11yLabel>
       </>
     )


### PR DESCRIPTION
The unconstrained map pin was causing some trouble. This PR attempts to reign it in. <img width="441" alt="Screenshot 2025-05-14 at 11 36 18 AM" src="https://github.com/user-attachments/assets/c54b7df8-d9e6-495a-a7f9-6bd781ae1f77" />
