### PR TITLE
feat: add config item for hiding active time

### DIFF
--- a/lib/components/narrative/connected-trip-details.js
+++ b/lib/components/narrative/connected-trip-details.js
@@ -20,6 +20,10 @@ const mapStateToProps = (state) => {
       mediumId: null,
       riderCategoryId: null
     },
+    displayTimeActive:
+      itinerary?.hideTimeActive === undefined
+        ? true
+        : !itinerary?.hideTimeActive,
     fareDetailsLayout: itinerary?.fareDetailsLayout || undefined,
     fareKeyNameMap: itinerary?.fareKeyNameMap || {}
   }

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -288,6 +288,7 @@ export interface ItineraryConfig {
   groupByMode?: boolean
   groupTransitModes?: boolean
   hideSkeletons?: boolean
+  hideTimeActive?: boolean
   mergeItineraries?: boolean
   mutedErrors?: string[]
   onlyShowCountdownForRealtime?: boolean


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Adds a config item for hiding the active time from the trip details summary. This replaces a hack that was being used in some deployments to hide it using CSS.
<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

