### PR TITLE
Add status region to route viewer to announce filters

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -520,7 +520,9 @@ components:
     header: Route Viewer
     modeFilter: Mode Filter
     noFilteredRoutesFound: No routes match your filter!
+    noRouteFilter: No filters are currently applied to the route list.
     openPatternViewer: View route details
+    routesFilteredBy: "The following filters are currently applied to the route list: {list}."
     shortTitle: View Routes
     stopsInDirectionOfTravel: "Stops in this direction of travel:"
     title: Route Viewer

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -537,7 +537,9 @@ components:
     header: Index des lignes
     modeFilter: Filtre pour les modes
     noFilteredRoutesFound: Aucune ligne ne correspond à vos critères
+    noRouteFilter: Aucun filtre n'est appliqué à la liste de lignes.
     openPatternViewer: Voir les dessertes
+    routesFilteredBy: "Les filtres suivants sont appliqués à la liste de lignes : {list}."
     shortTitle: Index des lignes
     stopsInDirectionOfTravel: "Arrêts dans cette direction :"
     title: Index des lignes

--- a/lib/components/viewers/route-viewer.tsx
+++ b/lib/components/viewers/route-viewer.tsx
@@ -24,6 +24,7 @@ import { ViewedRouteObject, ViewedRouteState } from '../util/types'
 import PageTitle from '../util/page-title'
 
 import { RouteRow } from './route-row'
+import InvisibleA11yLabel from '../util/invisible-a11y-label'
 import VehiclePositionRetriever from './vehicle-position-retriever'
 
 interface FilterProps {
@@ -128,7 +129,7 @@ class RouteViewer extends Component<Props, State> {
     } = this.props
 
     const { initialRender } = this.state
-    const { search } = filter
+    const { agency, mode, search } = filter
     const operators =
       transitOperators.length > 0
         ? Array.from(new Set(transitOperators.map((x) => x.name)))
@@ -137,6 +138,14 @@ class RouteViewer extends Component<Props, State> {
     const searchRouteText = intl.formatMessage({
       id: 'components.RouteViewer.findARoute'
     })
+
+    const listOfFilters = [
+      agency,
+      mode ? getFormattedMode(mode, intl) : null,
+      search
+    ].filter(Boolean)
+
+    const noFilter = listOfFilters.length === 0
 
     return (
       <div className="route-viewer">
@@ -232,7 +241,18 @@ class RouteViewer extends Component<Props, State> {
             </span>
           </section>
         </div>
-
+        <InvisibleA11yLabel as="div" role="status">
+          {noFilter ? (
+            <FormattedMessage id="components.RouteViewer.noRouteFilter" />
+          ) : (
+            <FormattedMessage
+              id="components.RouteViewer.routesFilteredBy"
+              values={{
+                list: intl.formatList(listOfFilters, { type: 'conjunction' })
+              }}
+            />
+          )}
+        </InvisibleA11yLabel>
         <ul className="route-viewer-body">
           {sortedRoutes.map((route) => {
             // Find operator based on agency_id (extracted from OTP route ID).


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Adds a status region to the route viewer that announces to AT users which filters are currently being applied to the route. Matches the application of the itinerary sorting in plan trip page.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

