### PR TITLE
Remove redundant text from delete button

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -533,7 +533,7 @@ components:
     signInText: Log in to save trip
     signInTooltip: Please log in to save trip.
   SavedTripEditor:
-    deleteSavedTrip: Delete saved trip
+    deleteSavedTrip: Delete
     editSavedTrip: Edit saved trip
     readOnlyBanner: >-
       {creator} created and added you to this trip. Therefore, you cannot make


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Removes redunant text from the delete button on the saved trip editor. A future PR will be needed to clean up the translation files to remove redunant text in buttons throughout the app.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

