### PR TITLE
remove stop id from nearby view side panel

### DIFF
--- a/__tests__/components/viewers/__snapshots__/nearby-view.js.snap
+++ b/__tests__/components/viewers/__snapshots__/nearby-view.js.snap
@@ -18401,17 +18401,6 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                     className="sc-gUUBao dCmAkv"
                                   >
                                     <div>
-                                      <FormattedMessage
-                                        id="components.StopViewer.displayStopId"
-                                        values={
-                                          Object {
-                                            "stopId": "40:990003",
-                                            "strong": [Function],
-                                          }
-                                        }
-                                      >
-                                        components.StopViewer.displayStopId
-                                      </FormattedMessage>
                                       <Styled(Connect(Component))
                                         className="stop-header-action"
                                         to="/schedule/40:990003"
@@ -46976,17 +46965,6 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                     className="sc-gUUBao dCmAkv"
                                   >
                                     <div>
-                                      <FormattedMessage
-                                        id="components.StopViewer.displayStopId"
-                                        values={
-                                          Object {
-                                            "stopId": "40:990004",
-                                            "strong": [Function],
-                                          }
-                                        }
-                                      >
-                                        components.StopViewer.displayStopId
-                                      </FormattedMessage>
                                       <Styled(Connect(Component))
                                         className="stop-header-action"
                                         to="/schedule/40:990004"

--- a/lib/components/viewers/nearby/stop-card-header.tsx
+++ b/lib/components/viewers/nearby/stop-card-header.tsx
@@ -60,13 +60,15 @@ const StopCardHeader = ({
       </CardHeader>
       <CardBody>
         <div>
-          <FormattedMessage
-            id="components.StopViewer.displayStopId"
-            values={{
-              stopId: stopData.code || stopData.gtfsId,
-              strong: Strong
-            }}
-          />
+          {stopData.code ? (
+            <FormattedMessage
+              id="components.StopViewer.displayStopId"
+              values={{
+                stopId: stopData.code,
+                strong: Strong
+              }}
+            />
+          ) : null}
           {onZoomClick ? (
             <button
               className="link-button"


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
Removes logic to display GTFS stop_id in the nearby view side panel as it is not a public facing value.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

