### PR TITLE
Pass auth0 correct chinese locale code

### DIFF
--- a/lib/components/user/nav-login-button-auth0.tsx
+++ b/lib/components/user/nav-login-button-auth0.tsx
@@ -32,8 +32,7 @@ const NavLoginButtonAuth0 = ({
   let auth0Locale = locale
   if (locale === 'zh-Hant') {
     auth0Locale = 'zh-TW'
-  }
-  if (locale === 'zh-Hans') {
+  } else if (locale === 'zh-Hans') {
     auth0Locale = 'zh-CN'
   }
 

--- a/lib/components/user/nav-login-button-auth0.tsx
+++ b/lib/components/user/nav-login-button-auth0.tsx
@@ -28,9 +28,14 @@ const NavLoginButtonAuth0 = ({
 }: NavLoginButtonAuth0Props): JSX.Element => {
   const { isAuthenticated, loginWithRedirect, logout, user } = useAuth0()
 
-  // For Chinese (Chinese (Simplified)), we must pass 'zh-CN' to auth0.
-  // Unlike 'fr', 'zh' alone is not recognized and falls back to English.
-  const auth0Locale = locale === 'zh' ? 'zh-CN' : locale
+  // For Chinese (Traditional and Simplified) we use a different language code than Auth0
+  let auth0Locale = locale
+  if (locale === 'zh-Hant') {
+    auth0Locale = 'zh-TW'
+  }
+  if (locale === 'zh-Hans') {
+    auth0Locale = 'zh-CN'
+  }
 
   // On login, preserve the current trip query if any.
   const handleLogin = useCallback(


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Passes the correct locale code for Chinese to Auth0 

Opted not to use a `switch` after reading [this](https://www.oreilly.com/library/view/high-performance-javascript/9781449382308/ch04.html#if-else_versus_switch:~:text=The%20prevailing%20theory%20on%20using%20if%2Delse%20versus%20switch%20is%20based%20on%20the%20number%20of%20conditions%20being%20tested%3A%20the%20larger%20the%20number%20of%20conditions%2C%20the%20more%20inclined%20you%20are%20to%20use%20a%20switch%20instead%20of%20if%2Delse) but I'm open to it

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

