### PR TITLE
i18n Fixes and Updates

### DIFF
--- a/example/example-config.yml
+++ b/example/example-config.yml
@@ -93,6 +93,8 @@ persistence:
 ### If a Top level menu item contains submenu items (children) then use the 'children' flag.
 ### Icon URL is preferable over iconType. If none are given then a 'bus' iconType is used.
 #App menu
+### If set to true, a google translate suffix will be appended to the URL of external links for the active locale. For example, if the app is open in Spanish, the external URL will open with /#googtrans(es)
+translateExternalLinks: false
 #extraMenuItems:
 #  - id: link-list
 #    label: List of Links

--- a/lib/components/app/app-menu.tsx
+++ b/lib/components/app/app-menu.tsx
@@ -19,7 +19,7 @@ import * as uiActions from '../../actions/ui'
 import { AppMenuItemConfig, LanguageConfig } from '../../util/config-types'
 import { AppReduxState } from '../../util/state-types'
 import { ComponentContext } from '../../util/contexts'
-import { getLanguageOptions } from '../../util/i18n'
+import { convertChineseLanguageCode, getLanguageOptions } from '../../util/i18n'
 import { isModuleEnabled, Modules } from '../../util/config'
 
 import AppMenuItem from './app-menu-item'
@@ -117,8 +117,9 @@ class AppMenu extends Component<
         // Override the config label if a localized label exists
         const label = useLocalizedLabel ? localizedLabel : configLabel
 
+        const languageCode = convertChineseLanguageCode(activeLocale)
         const url = translateExternalLinks
-          ? href + `/#googtrans(${activeLocale})`
+          ? href + `/#googtrans(${languageCode})`
           : href
         return (
           <AppMenuItem

--- a/lib/components/app/app-menu.tsx
+++ b/lib/components/app/app-menu.tsx
@@ -54,6 +54,7 @@ type AppMenuProps = {
   setPopupContent: (url: string) => void
   startOverFromInitialUrl: () => void
   toggleMailables: () => void
+  translateExternalLinks?: boolean
 }
 type AppMenuState = {
   isPaneOpen: boolean
@@ -90,7 +91,10 @@ class AppMenu extends Component<
     document.querySelector('main')?.focus()
   }
 
-  _addExtraMenuItems = (menuItems?: MenuItem[] | null) => {
+  _addExtraMenuItems = (
+    menuItems?: MenuItem[] | null,
+    translateExternalLinks?: boolean
+  ) => {
     return (
       menuItems &&
       menuItems.map((menuItem) => {
@@ -113,11 +117,14 @@ class AppMenu extends Component<
         // Override the config label if a localized label exists
         const label = useLocalizedLabel ? localizedLabel : configLabel
 
+        const url = translateExternalLinks
+          ? href + `/#googtrans(${activeLocale})`
+          : href
         return (
           <AppMenuItem
             aria-selected={isSelected || undefined}
             className={subMenuDivider ? 'app-menu-divider' : undefined}
-            href={href}
+            href={url}
             icon={
               iconType && typeof iconType !== 'string' ? (
                 iconType
@@ -151,7 +158,8 @@ class AppMenu extends Component<
       resetAndToggleCallHistory,
       resetAndToggleFieldTrips,
       setLocale,
-      toggleMailables
+      toggleMailables,
+      translateExternalLinks
     } = this.props
     const languageMenuItems: MenuItem[] | null = languageOptions && [
       {
@@ -284,7 +292,7 @@ class AppMenu extends Component<
                 })}
               />
             )}
-            {this._addExtraMenuItems(extraMenuItems)}
+            {this._addExtraMenuItems(extraMenuItems, translateExternalLinks)}
             {this._addExtraMenuItems(languageMenuItems)}
           </div>
         </SlidingPane>
@@ -296,7 +304,8 @@ class AppMenu extends Component<
 // connect to the redux store
 
 const mapStateToProps = (state: AppReduxState) => {
-  const { extraMenuItems, language, popups } = state.otp.config
+  const { extraMenuItems, language, popups, translateExternalLinks } =
+    state.otp.config
   return {
     activeLocale: state.otp.ui.locale,
     callTakerEnabled: isModuleEnabled(state, Modules.CALL_TAKER),
@@ -305,7 +314,8 @@ const mapStateToProps = (state: AppReduxState) => {
     language,
     languageOptions: getLanguageOptions(language),
     mailablesEnabled: isModuleEnabled(state, Modules.MAILABLES),
-    popupTarget: popups?.launchers?.sidebarLink
+    popupTarget: popups?.launchers?.sidebarLink,
+    translateExternalLinks
   }
 }
 

--- a/lib/components/user/nav-login-button-auth0.tsx
+++ b/lib/components/user/nav-login-button-auth0.tsx
@@ -1,6 +1,7 @@
 import { useAuth0 } from '@auth0/auth0-react'
 import React, { HTMLAttributes, useCallback } from 'react'
 
+import { convertChineseLanguageCode } from '../../util/i18n'
 import { getCurrentRoute } from '../../util/ui'
 
 import NavLoginButton from './nav-login-button'
@@ -29,12 +30,7 @@ const NavLoginButtonAuth0 = ({
   const { isAuthenticated, loginWithRedirect, logout, user } = useAuth0()
 
   // For Chinese (Traditional and Simplified) we use a different language code than Auth0
-  let auth0Locale = locale
-  if (locale === 'zh-Hant') {
-    auth0Locale = 'zh-TW'
-  } else if (locale === 'zh-Hans') {
-    auth0Locale = 'zh-CN'
-  }
+  const auth0Locale = convertChineseLanguageCode(locale)
 
   // On login, preserve the current trip query if any.
   const handleLogin = useCallback(

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -434,6 +434,7 @@ export interface AppConfig {
   /** App title shown in the browser title bar. */
   title?: string
   transitOperators?: TransitOperatorConfig[]
+  translateExternalLinks?: boolean
 
   // Add other config items as needed.
 }

--- a/lib/util/i18n-loader.js
+++ b/lib/util/i18n-loader.js
@@ -32,8 +32,10 @@ async function loadOtpUiLocaleData(matchedLocale) {
  * Languages are lazily-loaded by virtue of the Vite glob imports above.
  */
 export async function loadLocaleData(matchedLocale, customMessages) {
-  // If only 'zh' is configured and no other Chinese subset is, use Chinese Simplified.
-  const loadedLocale = matchedLocale === 'zh' ? 'zh-Hans' : matchedLocale
+  // The Chinese YAML files are named with underscores, while the locale code has a dash. If the language is Chinese, redirect to the correct file.
+  const loadedLocale = matchedLocale.includes('zh')
+    ? matchedLocale.replace('-', '_')
+    : matchedLocale
 
   const messages = await i18nModules[`../../i18n/${loadedLocale}.yml`]()
   const otpUiMessages = await loadOtpUiLocaleData(loadedLocale)

--- a/lib/util/i18n.js
+++ b/lib/util/i18n.js
@@ -31,6 +31,20 @@ export function getLocalizedStringIfAvailable(intl, key) {
 }
 
 /**
+ * Language codes with 'hans' suffix are not often supported by external sites.
+ * In those cases, replace the code with a more commonly supported one.
+ */
+export const convertChineseLanguageCode = (locale) => {
+  let newLocale = locale
+  if (locale === 'zh-Hant') {
+    newLocale = 'zh-TW'
+  } else if (locale === 'zh-Hans') {
+    newLocale = 'zh-CN'
+  }
+  return newLocale
+}
+
+/**
  * Gets the language and region codes used within the configuration file
  * @param {Object} configLanguages The configured languages for the implementation.
  * @returns {Object} configLanguages destructured into language and region.


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
- Fixes a bug where neither Chinese language was being loaded correctly due to a difference in the language code and the file name.
- Creates a config item called `translateExternalSites` that opens an external menu item link with google translate depending on the active language
- Creates a util function called `convertChineseLanguageCode` that supplies a more commonly supported language code for both Chinese (simplified and traditional)

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

