### PR TITLE
feat: Add filtering to nearby view

### DIFF
--- a/__tests__/components/viewers/__snapshots__/nearby-view.js.snap
+++ b/__tests__/components/viewers/__snapshots__/nearby-view.js.snap
@@ -24,6 +24,14 @@ exports[`components > viewers > nearby view renders nothing on a blank page 1`] 
   >
     <Connect(NearbyView)>
       <NearbyView
+        activeNearbyFilters={
+          Object {
+            "BikeRentalStation": true,
+            "RentalVehicle": true,
+            "Stop": true,
+            "VehicleParking": true,
+          }
+        }
         currentPosition={
           Object {
             "coords": null,
@@ -41,6 +49,7 @@ exports[`components > viewers > nearby view renders nothing on a blank page 1`] 
         setHighlightedLocation={[Function]}
         setLocation={[Function]}
         setMainPanelContent={[Function]}
+        setNearbyViewFilter={[Function]}
         setViewedNearbyCoords={[Function]}
         viewNearby={[Function]}
         zoomToPlace={[Function]}
@@ -49,7 +58,7 @@ exports[`components > viewers > nearby view renders nothing on a blank page 1`] 
           className="nearby-view base-color-bg"
         >
           <div
-            className="sc-bTRMho cPleAt nearby-view base-color-bg"
+            className="sc-hRxcUd bEfbVP nearby-view base-color-bg"
           >
             <Connect(PageTitle)
               title="components.NearbyView.header"
@@ -69,7 +78,7 @@ exports[`components > viewers > nearby view renders nothing on a blank page 1`] 
               }
             >
               <h3
-                className="sc-jlIlqL lnCJHI"
+                className="sc-jlIlqL TTTqe"
                 style={
                   Object {
                     "position": "absolute",
@@ -336,11 +345,9 @@ exports[`components > viewers > nearby view renders nothing on a blank page 1`] 
                 </styled__InputGroup>
               </LocationField>
             </div>
-            <div
-              aria-hidden={true}
-            />
             <styled.ol
               className="base-color-bg"
+              filters={false}
               style={
                 Object {
                   "marginBottom": 0,
@@ -348,7 +355,7 @@ exports[`components > viewers > nearby view renders nothing on a blank page 1`] 
               }
             >
               <ol
-                className="sc-hFXoIY jPNBGq base-color-bg"
+                className="sc-iuAqRD TgsaW base-color-bg"
                 style={
                   Object {
                     "marginBottom": 0,
@@ -470,6 +477,14 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
   >
     <Connect(NearbyView)>
       <NearbyView
+        activeNearbyFilters={
+          Object {
+            "BikeRentalStation": true,
+            "RentalVehicle": true,
+            "Stop": true,
+            "VehicleParking": true,
+          }
+        }
         currentPosition={
           Object {
             "coords": null,
@@ -4405,6 +4420,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
         setHighlightedLocation={[Function]}
         setLocation={[Function]}
         setMainPanelContent={[Function]}
+        setNearbyViewFilter={[Function]}
         setViewedNearbyCoords={[Function]}
         viewNearby={[Function]}
         zoomToPlace={[Function]}
@@ -4413,7 +4429,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
           className="nearby-view base-color-bg"
         >
           <div
-            className="sc-bTRMho cPleAt nearby-view base-color-bg"
+            className="sc-hRxcUd bEfbVP nearby-view base-color-bg"
           >
             <Connect(PageTitle)
               title="components.NearbyView.header"
@@ -4433,7 +4449,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
               }
             >
               <h3
-                className="sc-jlIlqL lnCJHI"
+                className="sc-jlIlqL TTTqe"
                 style={
                   Object {
                     "position": "absolute",
@@ -4700,11 +4716,9 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                 </styled__InputGroup>
               </LocationField>
             </div>
-            <div
-              aria-hidden={true}
-            />
             <styled.ol
               className="base-color-bg"
+              filters={false}
               style={
                 Object {
                   "marginBottom": 0,
@@ -4712,7 +4726,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
               }
             >
               <ol
-                className="sc-hFXoIY jPNBGq base-color-bg"
+                className="sc-iuAqRD TgsaW base-color-bg"
                 style={
                   Object {
                     "marginBottom": 0,
@@ -4826,15 +4840,15 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <styled.div>
                               <div
-                                className="sc-DJgqy fJIhkf"
+                                className="sc-dwqccx bJjQOM"
                               >
                                 <styled.p>
                                   <p
-                                    className="sc-dwqccx jIIKnI"
+                                    className="sc-gUUBao eLkCwF"
                                   >
                                     <IconWithText
                                       icon={
@@ -4893,7 +4907,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 >
                                   <styled.p>
                                     <p
-                                      className="sc-hJxDiT kBoATC"
+                                      className="sc-liccgK bWddLw"
                                     >
                                       <FormattedMessage
                                         id="components.NearbyView.distanceAway"
@@ -4912,7 +4926,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             </styled.div>
                             <styled.div>
                               <div
-                                className="sc-liccgK inbCZP"
+                                className="sc-cuWdqJ ceWUCI"
                               >
                                 <Connect(FromToPicker)
                                   place={
@@ -5254,15 +5268,15 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <styled.div>
                               <div
-                                className="sc-DJgqy fJIhkf"
+                                className="sc-dwqccx bJjQOM"
                               >
                                 <styled.p>
                                   <p
-                                    className="sc-dwqccx jIIKnI"
+                                    className="sc-gUUBao eLkCwF"
                                   >
                                     <IconWithText
                                       icon={
@@ -5321,7 +5335,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 >
                                   <styled.p>
                                     <p
-                                      className="sc-hJxDiT kBoATC"
+                                      className="sc-liccgK bWddLw"
                                     >
                                       <FormattedMessage
                                         id="components.NearbyView.distanceAway"
@@ -5340,7 +5354,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             </styled.div>
                             <styled.div>
                               <div
-                                className="sc-liccgK inbCZP"
+                                className="sc-cuWdqJ ceWUCI"
                               >
                                 <Connect(FromToPicker)
                                   place={
@@ -5682,15 +5696,15 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <styled.div>
                               <div
-                                className="sc-DJgqy fJIhkf"
+                                className="sc-dwqccx bJjQOM"
                               >
                                 <styled.p>
                                   <p
-                                    className="sc-dwqccx jIIKnI"
+                                    className="sc-gUUBao eLkCwF"
                                   >
                                     <IconWithText
                                       icon={
@@ -5749,7 +5763,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 >
                                   <styled.p>
                                     <p
-                                      className="sc-hJxDiT kBoATC"
+                                      className="sc-liccgK bWddLw"
                                     >
                                       <FormattedMessage
                                         id="components.NearbyView.distanceAway"
@@ -5768,7 +5782,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             </styled.div>
                             <styled.div>
                               <div
-                                className="sc-liccgK inbCZP"
+                                className="sc-cuWdqJ ceWUCI"
                               >
                                 <Connect(FromToPicker)
                                   place={
@@ -8300,7 +8314,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <Connect(StopCardHeader)
                               actionIcon={
@@ -10622,11 +10636,11 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                               >
                                 <styled.div>
                                   <div
-                                    className="sc-DJgqy fJIhkf"
+                                    className="sc-dwqccx bJjQOM"
                                   >
                                     <styled.p>
                                       <p
-                                        className="sc-dwqccx jIIKnI"
+                                        className="sc-gUUBao eLkCwF"
                                       >
                                         <TransitOperatorLogos
                                           stopData={
@@ -11208,7 +11222,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                     >
                                       <styled.p>
                                         <p
-                                          className="sc-hJxDiT kBoATC"
+                                          className="sc-liccgK bWddLw"
                                         >
                                           <FormattedMessage
                                             id="components.NearbyView.distanceAway"
@@ -11227,7 +11241,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 </styled.div>
                                 <styled.div>
                                   <div
-                                    className="sc-liccgK inbCZP"
+                                    className="sc-cuWdqJ ceWUCI"
                                   >
                                     <div
                                       style={
@@ -11272,7 +11286,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                         }
                                       >
                                         <Connect(Component)
-                                          className="sc-hRxcUd JwFQy stop-header-action"
+                                          className="sc-fTNIjK cGCMkm stop-header-action"
                                           style={
                                             Object {
                                               "gridRow": 1,
@@ -11287,7 +11301,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                           }
                                         >
                                           <a
-                                            className="sc-hRxcUd JwFQy stop-header-action"
+                                            className="sc-fTNIjK cGCMkm stop-header-action"
                                             href="#/schedule/kcm:36940"
                                             style={
                                               Object {
@@ -12696,7 +12710,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             <div>
                               <styled.ul>
                                 <ul
-                                  className="sc-fTACoA bUDtkT"
+                                  className="sc-bTRMho kIiWKf"
                                 >
                                   <PatternRow
                                     homeTimezone="America/Los_Angeles"
@@ -12871,7 +12885,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -12919,7 +12933,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="45"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -12957,7 +12971,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -13106,10 +13120,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -13120,7 +13134,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -13132,7 +13146,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -13155,7 +13169,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -13268,10 +13282,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -13282,7 +13296,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -13294,7 +13308,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -13317,7 +13331,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -13474,7 +13488,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -13697,7 +13711,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -13745,7 +13759,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="62"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -13783,7 +13797,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -13932,10 +13946,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -13946,7 +13960,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -13958,7 +13972,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -13981,7 +13995,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -14138,7 +14152,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -14295,7 +14309,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -14453,7 +14467,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -14501,7 +14515,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="79"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -14539,7 +14553,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -14688,10 +14702,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -14702,7 +14716,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -14714,7 +14728,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -14737,7 +14751,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -14894,7 +14908,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -15051,7 +15065,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -16603,7 +16617,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <Connect(StopCardHeader)
                               actionIcon={
@@ -18121,11 +18135,11 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                               >
                                 <styled.div>
                                   <div
-                                    className="sc-DJgqy fJIhkf"
+                                    className="sc-dwqccx bJjQOM"
                                   >
                                     <styled.p>
                                       <p
-                                        className="sc-dwqccx jIIKnI"
+                                        className="sc-gUUBao eLkCwF"
                                       >
                                         <TransitOperatorLogos
                                           stopData={
@@ -18506,7 +18520,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                     >
                                       <styled.p>
                                         <p
-                                          className="sc-hJxDiT kBoATC"
+                                          className="sc-liccgK bWddLw"
                                         >
                                           <FormattedMessage
                                             id="components.NearbyView.distanceAway"
@@ -18525,7 +18539,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 </styled.div>
                                 <styled.div>
                                   <div
-                                    className="sc-liccgK inbCZP"
+                                    className="sc-cuWdqJ ceWUCI"
                                   >
                                     <div
                                       style={
@@ -18551,7 +18565,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                         }
                                       >
                                         <Connect(Component)
-                                          className="sc-hRxcUd JwFQy stop-header-action"
+                                          className="sc-fTNIjK cGCMkm stop-header-action"
                                           style={
                                             Object {
                                               "gridRow": 1,
@@ -18566,7 +18580,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                           }
                                         >
                                           <a
-                                            className="sc-hRxcUd JwFQy stop-header-action"
+                                            className="sc-fTNIjK cGCMkm stop-header-action"
                                             href="#/schedule/40:990003"
                                             style={
                                               Object {
@@ -19573,7 +19587,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             <div>
                               <styled.ul>
                                 <ul
-                                  className="sc-fTACoA bUDtkT"
+                                  className="sc-bTRMho kIiWKf"
                                 >
                                   <PatternRow
                                     homeTimezone="America/Los_Angeles"
@@ -19683,7 +19697,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -19731,7 +19745,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="1 Line"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK Ybfbu"
+                                                    className="sc-BXpxD dpbPJU"
                                                     color="28813F"
                                                     style={
                                                       Object {
@@ -19769,7 +19783,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -19962,7 +19976,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -20119,7 +20133,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -20276,7 +20290,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -20382,7 +20396,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -20430,7 +20444,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="1 Line"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK Ybfbu"
+                                                    className="sc-BXpxD dpbPJU"
                                                     color="28813F"
                                                     style={
                                                       Object {
@@ -20468,7 +20482,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -20661,7 +20675,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="saturday"
@@ -20884,7 +20898,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -20932,7 +20946,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="1 Line"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK Ybfbu"
+                                                    className="sc-BXpxD dpbPJU"
                                                     color="28813F"
                                                     style={
                                                       Object {
@@ -20970,7 +20984,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -21163,7 +21177,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="saturday"
@@ -21320,7 +21334,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="saturday"
@@ -21477,7 +21491,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="saturday"
@@ -21643,15 +21657,15 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <styled.div>
                               <div
-                                className="sc-DJgqy fJIhkf"
+                                className="sc-dwqccx bJjQOM"
                               >
                                 <styled.p>
                                   <p
-                                    className="sc-dwqccx jIIKnI"
+                                    className="sc-gUUBao eLkCwF"
                                   >
                                     <IconWithText
                                       icon={
@@ -21710,7 +21724,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 >
                                   <styled.p>
                                     <p
-                                      className="sc-hJxDiT kBoATC"
+                                      className="sc-liccgK bWddLw"
                                     >
                                       <FormattedMessage
                                         id="components.NearbyView.distanceAway"
@@ -21729,7 +21743,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             </styled.div>
                             <styled.div>
                               <div
-                                className="sc-liccgK inbCZP"
+                                className="sc-cuWdqJ ceWUCI"
                               >
                                 <Connect(FromToPicker)
                                   place={
@@ -22071,15 +22085,15 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <styled.div>
                               <div
-                                className="sc-DJgqy fJIhkf"
+                                className="sc-dwqccx bJjQOM"
                               >
                                 <styled.p>
                                   <p
-                                    className="sc-dwqccx jIIKnI"
+                                    className="sc-gUUBao eLkCwF"
                                   >
                                     <IconWithText
                                       icon={
@@ -22138,7 +22152,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 >
                                   <styled.p>
                                     <p
-                                      className="sc-hJxDiT kBoATC"
+                                      className="sc-liccgK bWddLw"
                                     >
                                       <FormattedMessage
                                         id="components.NearbyView.distanceAway"
@@ -22157,7 +22171,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             </styled.div>
                             <styled.div>
                               <div
-                                className="sc-liccgK inbCZP"
+                                className="sc-cuWdqJ ceWUCI"
                               >
                                 <Connect(FromToPicker)
                                   place={
@@ -22499,15 +22513,15 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <styled.div>
                               <div
-                                className="sc-DJgqy fJIhkf"
+                                className="sc-dwqccx bJjQOM"
                               >
                                 <styled.p>
                                   <p
-                                    className="sc-dwqccx jIIKnI"
+                                    className="sc-gUUBao eLkCwF"
                                   >
                                     <IconWithText
                                       icon={
@@ -22566,7 +22580,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 >
                                   <styled.p>
                                     <p
-                                      className="sc-hJxDiT kBoATC"
+                                      className="sc-liccgK bWddLw"
                                     >
                                       <FormattedMessage
                                         id="components.NearbyView.distanceAway"
@@ -22585,7 +22599,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             </styled.div>
                             <styled.div>
                               <div
-                                className="sc-liccgK inbCZP"
+                                className="sc-cuWdqJ ceWUCI"
                               >
                                 <Connect(FromToPicker)
                                   place={
@@ -25425,7 +25439,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <Connect(StopCardHeader)
                               actionIcon={
@@ -28055,11 +28069,11 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                               >
                                 <styled.div>
                                   <div
-                                    className="sc-DJgqy fJIhkf"
+                                    className="sc-dwqccx bJjQOM"
                                   >
                                     <styled.p>
                                       <p
-                                        className="sc-dwqccx jIIKnI"
+                                        className="sc-gUUBao eLkCwF"
                                       >
                                         <TransitOperatorLogos
                                           stopData={
@@ -28718,7 +28732,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                     >
                                       <styled.p>
                                         <p
-                                          className="sc-hJxDiT kBoATC"
+                                          className="sc-liccgK bWddLw"
                                         >
                                           <FormattedMessage
                                             id="components.NearbyView.distanceAway"
@@ -28737,7 +28751,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 </styled.div>
                                 <styled.div>
                                   <div
-                                    className="sc-liccgK inbCZP"
+                                    className="sc-cuWdqJ ceWUCI"
                                   >
                                     <div
                                       style={
@@ -28782,7 +28796,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                         }
                                       >
                                         <Connect(Component)
-                                          className="sc-hRxcUd JwFQy stop-header-action"
+                                          className="sc-fTNIjK cGCMkm stop-header-action"
                                           style={
                                             Object {
                                               "gridRow": 1,
@@ -28797,7 +28811,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                           }
                                         >
                                           <a
-                                            className="sc-hRxcUd JwFQy stop-header-action"
+                                            className="sc-fTNIjK cGCMkm stop-header-action"
                                             href="#/schedule/kcm:16430"
                                             style={
                                               Object {
@@ -30360,7 +30374,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             <div>
                               <styled.ul>
                                 <ul
-                                  className="sc-fTACoA bUDtkT"
+                                  className="sc-bTRMho kIiWKf"
                                 >
                                   <PatternRow
                                     homeTimezone="America/Los_Angeles"
@@ -30535,7 +30549,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -30583,7 +30597,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="45"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -30621,7 +30635,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -30770,10 +30784,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -30784,7 +30798,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -30796,7 +30810,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -30819,7 +30833,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -30932,10 +30946,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -30946,7 +30960,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -30958,7 +30972,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -30981,7 +30995,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -31138,7 +31152,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -31374,7 +31388,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -31422,7 +31436,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="62"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -31460,7 +31474,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -31609,10 +31623,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -31623,7 +31637,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -31635,7 +31649,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -31658,7 +31672,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -31815,7 +31829,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -31928,10 +31942,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -31942,7 +31956,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -31954,7 +31968,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -31977,7 +31991,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -32135,7 +32149,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -32183,7 +32197,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="79"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -32221,7 +32235,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -32414,7 +32428,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -32571,7 +32585,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -32728,7 +32742,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -32834,7 +32848,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -32882,7 +32896,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="988"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -32920,7 +32934,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -33113,7 +33127,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -33279,15 +33293,15 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <styled.div>
                               <div
-                                className="sc-DJgqy fJIhkf"
+                                className="sc-dwqccx bJjQOM"
                               >
                                 <styled.p>
                                   <p
-                                    className="sc-dwqccx jIIKnI"
+                                    className="sc-gUUBao eLkCwF"
                                   >
                                     <IconWithText
                                       icon={
@@ -33346,7 +33360,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 >
                                   <styled.p>
                                     <p
-                                      className="sc-hJxDiT kBoATC"
+                                      className="sc-liccgK bWddLw"
                                     >
                                       <FormattedMessage
                                         id="components.NearbyView.distanceAway"
@@ -33365,7 +33379,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             </styled.div>
                             <styled.div>
                               <div
-                                className="sc-liccgK inbCZP"
+                                className="sc-cuWdqJ ceWUCI"
                               >
                                 <Connect(FromToPicker)
                                   place={
@@ -33707,15 +33721,15 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <styled.div>
                               <div
-                                className="sc-DJgqy fJIhkf"
+                                className="sc-dwqccx bJjQOM"
                               >
                                 <styled.p>
                                   <p
-                                    className="sc-dwqccx jIIKnI"
+                                    className="sc-gUUBao eLkCwF"
                                   >
                                     <IconWithText
                                       icon={
@@ -33774,7 +33788,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 >
                                   <styled.p>
                                     <p
-                                      className="sc-hJxDiT kBoATC"
+                                      className="sc-liccgK bWddLw"
                                     >
                                       <FormattedMessage
                                         id="components.NearbyView.distanceAway"
@@ -33793,7 +33807,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             </styled.div>
                             <styled.div>
                               <div
-                                className="sc-liccgK inbCZP"
+                                className="sc-cuWdqJ ceWUCI"
                               >
                                 <Connect(FromToPicker)
                                   place={
@@ -34135,15 +34149,15 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <styled.div>
                               <div
-                                className="sc-DJgqy fJIhkf"
+                                className="sc-dwqccx bJjQOM"
                               >
                                 <styled.p>
                                   <p
-                                    className="sc-dwqccx jIIKnI"
+                                    className="sc-gUUBao eLkCwF"
                                   >
                                     <IconWithText
                                       icon={
@@ -34202,7 +34216,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 >
                                   <styled.p>
                                     <p
-                                      className="sc-hJxDiT kBoATC"
+                                      className="sc-liccgK bWddLw"
                                     >
                                       <FormattedMessage
                                         id="components.NearbyView.distanceAway"
@@ -34221,7 +34235,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             </styled.div>
                             <styled.div>
                               <div
-                                className="sc-liccgK inbCZP"
+                                className="sc-cuWdqJ ceWUCI"
                               >
                                 <Connect(FromToPicker)
                                   place={
@@ -34563,15 +34577,15 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <styled.div>
                               <div
-                                className="sc-DJgqy fJIhkf"
+                                className="sc-dwqccx bJjQOM"
                               >
                                 <styled.p>
                                   <p
-                                    className="sc-dwqccx jIIKnI"
+                                    className="sc-gUUBao eLkCwF"
                                   >
                                     <IconWithText
                                       icon={
@@ -34630,7 +34644,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 >
                                   <styled.p>
                                     <p
-                                      className="sc-hJxDiT kBoATC"
+                                      className="sc-liccgK bWddLw"
                                     >
                                       <FormattedMessage
                                         id="components.NearbyView.distanceAway"
@@ -34649,7 +34663,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             </styled.div>
                             <styled.div>
                               <div
-                                className="sc-liccgK inbCZP"
+                                className="sc-cuWdqJ ceWUCI"
                               >
                                 <Connect(FromToPicker)
                                   place={
@@ -34991,15 +35005,15 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <styled.div>
                               <div
-                                className="sc-DJgqy fJIhkf"
+                                className="sc-dwqccx bJjQOM"
                               >
                                 <styled.p>
                                   <p
-                                    className="sc-dwqccx jIIKnI"
+                                    className="sc-gUUBao eLkCwF"
                                   >
                                     <IconWithText
                                       icon={
@@ -35058,7 +35072,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 >
                                   <styled.p>
                                     <p
-                                      className="sc-hJxDiT kBoATC"
+                                      className="sc-liccgK bWddLw"
                                     >
                                       <FormattedMessage
                                         id="components.NearbyView.distanceAway"
@@ -35077,7 +35091,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             </styled.div>
                             <styled.div>
                               <div
-                                className="sc-liccgK inbCZP"
+                                className="sc-cuWdqJ ceWUCI"
                               >
                                 <Connect(FromToPicker)
                                   place={
@@ -36805,7 +36819,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <Connect(StopCardHeader)
                               actionIcon={
@@ -38323,11 +38337,11 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                               >
                                 <styled.div>
                                   <div
-                                    className="sc-DJgqy fJIhkf"
+                                    className="sc-dwqccx bJjQOM"
                                   >
                                     <styled.p>
                                       <p
-                                        className="sc-dwqccx jIIKnI"
+                                        className="sc-gUUBao eLkCwF"
                                       >
                                         <TransitOperatorLogos
                                           stopData={
@@ -38708,7 +38722,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                     >
                                       <styled.p>
                                         <p
-                                          className="sc-hJxDiT kBoATC"
+                                          className="sc-liccgK bWddLw"
                                         >
                                           <FormattedMessage
                                             id="components.NearbyView.distanceAway"
@@ -38727,7 +38741,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 </styled.div>
                                 <styled.div>
                                   <div
-                                    className="sc-liccgK inbCZP"
+                                    className="sc-cuWdqJ ceWUCI"
                                   >
                                     <div
                                       style={
@@ -38772,7 +38786,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                         }
                                       >
                                         <Connect(Component)
-                                          className="sc-hRxcUd JwFQy stop-header-action"
+                                          className="sc-fTNIjK cGCMkm stop-header-action"
                                           style={
                                             Object {
                                               "gridRow": 1,
@@ -38787,7 +38801,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                           }
                                         >
                                           <a
-                                            className="sc-hRxcUd JwFQy stop-header-action"
+                                            className="sc-fTNIjK cGCMkm stop-header-action"
                                             href="#/schedule/kcm:16440"
                                             style={
                                               Object {
@@ -39794,7 +39808,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             <div>
                               <styled.ul>
                                 <ul
-                                  className="sc-fTACoA bUDtkT"
+                                  className="sc-bTRMho kIiWKf"
                                 >
                                   <PatternRow
                                     homeTimezone="America/Los_Angeles"
@@ -39904,7 +39918,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -39952,7 +39966,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="67"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -39990,7 +40004,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -40139,10 +40153,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -40153,7 +40167,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -40165,7 +40179,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -40188,7 +40202,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -40345,7 +40359,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -40502,7 +40516,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -40725,7 +40739,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -40773,7 +40787,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="73"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -40811,7 +40825,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -41004,7 +41018,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -41161,7 +41175,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -41318,7 +41332,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -41424,7 +41438,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -41472,7 +41486,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="984"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -41510,7 +41524,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -41703,7 +41717,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -41869,15 +41883,15 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <styled.div>
                               <div
-                                className="sc-DJgqy fJIhkf"
+                                className="sc-dwqccx bJjQOM"
                               >
                                 <styled.p>
                                   <p
-                                    className="sc-dwqccx jIIKnI"
+                                    className="sc-gUUBao eLkCwF"
                                   >
                                     <IconWithText
                                       icon={
@@ -41936,7 +41950,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 >
                                   <styled.p>
                                     <p
-                                      className="sc-hJxDiT kBoATC"
+                                      className="sc-liccgK bWddLw"
                                     >
                                       <FormattedMessage
                                         id="components.NearbyView.distanceAway"
@@ -41955,7 +41969,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             </styled.div>
                             <styled.div>
                               <div
-                                className="sc-liccgK inbCZP"
+                                className="sc-cuWdqJ ceWUCI"
                               >
                                 <Connect(FromToPicker)
                                   place={
@@ -44383,7 +44397,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <Connect(StopCardHeader)
                               actionIcon={
@@ -46601,11 +46615,11 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                               >
                                 <styled.div>
                                   <div
-                                    className="sc-DJgqy fJIhkf"
+                                    className="sc-dwqccx bJjQOM"
                                   >
                                     <styled.p>
                                       <p
-                                        className="sc-dwqccx jIIKnI"
+                                        className="sc-gUUBao eLkCwF"
                                       >
                                         <TransitOperatorLogos
                                           stopData={
@@ -47161,7 +47175,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                     >
                                       <styled.p>
                                         <p
-                                          className="sc-hJxDiT kBoATC"
+                                          className="sc-liccgK bWddLw"
                                         >
                                           <FormattedMessage
                                             id="components.NearbyView.distanceAway"
@@ -47180,7 +47194,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 </styled.div>
                                 <styled.div>
                                   <div
-                                    className="sc-liccgK inbCZP"
+                                    className="sc-cuWdqJ ceWUCI"
                                   >
                                     <div
                                       style={
@@ -47206,7 +47220,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                         }
                                       >
                                         <Connect(Component)
-                                          className="sc-hRxcUd JwFQy stop-header-action"
+                                          className="sc-fTNIjK cGCMkm stop-header-action"
                                           style={
                                             Object {
                                               "gridRow": 1,
@@ -47221,7 +47235,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                           }
                                         >
                                           <a
-                                            className="sc-hRxcUd JwFQy stop-header-action"
+                                            className="sc-fTNIjK cGCMkm stop-header-action"
                                             href="#/schedule/40:990004"
                                             style={
                                               Object {
@@ -48578,7 +48592,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             <div>
                               <styled.ul>
                                 <ul
-                                  className="sc-fTACoA bUDtkT"
+                                  className="sc-bTRMho kIiWKf"
                                 >
                                   <PatternRow
                                     homeTimezone="America/Los_Angeles"
@@ -48844,7 +48858,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -48892,7 +48906,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="1 Line"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK Ybfbu"
+                                                    className="sc-BXpxD dpbPJU"
                                                     color="28813F"
                                                     style={
                                                       Object {
@@ -48930,7 +48944,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -49079,10 +49093,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -49093,7 +49107,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -49105,7 +49119,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -49128,7 +49142,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -49241,10 +49255,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -49255,7 +49269,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -49267,7 +49281,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -49290,7 +49304,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -49403,10 +49417,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -49417,7 +49431,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -49429,7 +49443,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -49452,7 +49466,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -52116,7 +52130,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <Connect(StopCardHeader)
                               actionIcon={
@@ -54746,11 +54760,11 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                               >
                                 <styled.div>
                                   <div
-                                    className="sc-DJgqy fJIhkf"
+                                    className="sc-dwqccx bJjQOM"
                                   >
                                     <styled.p>
                                       <p
-                                        className="sc-dwqccx jIIKnI"
+                                        className="sc-gUUBao eLkCwF"
                                       >
                                         <TransitOperatorLogos
                                           stopData={
@@ -55409,7 +55423,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                     >
                                       <styled.p>
                                         <p
-                                          className="sc-hJxDiT kBoATC"
+                                          className="sc-liccgK bWddLw"
                                         >
                                           <FormattedMessage
                                             id="components.NearbyView.distanceAway"
@@ -55428,7 +55442,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 </styled.div>
                                 <styled.div>
                                   <div
-                                    className="sc-liccgK inbCZP"
+                                    className="sc-cuWdqJ ceWUCI"
                                   >
                                     <div
                                       style={
@@ -55473,7 +55487,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                         }
                                       >
                                         <Connect(Component)
-                                          className="sc-hRxcUd JwFQy stop-header-action"
+                                          className="sc-fTNIjK cGCMkm stop-header-action"
                                           style={
                                             Object {
                                               "gridRow": 1,
@@ -55488,7 +55502,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                           }
                                         >
                                           <a
-                                            className="sc-hRxcUd JwFQy stop-header-action"
+                                            className="sc-fTNIjK cGCMkm stop-header-action"
                                             href="#/schedule/kcm:23561"
                                             style={
                                               Object {
@@ -57051,7 +57065,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             <div>
                               <styled.ul>
                                 <ul
-                                  className="sc-fTACoA bUDtkT"
+                                  className="sc-bTRMho kIiWKf"
                                 >
                                   <PatternRow
                                     homeTimezone="America/Los_Angeles"
@@ -57161,7 +57175,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -57209,7 +57223,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="522"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK hQvkFm"
+                                                    className="sc-BXpxD fcWIjg"
                                                     color="2B376E"
                                                     style={
                                                       Object {
@@ -57247,7 +57261,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -57440,7 +57454,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -57597,7 +57611,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -57754,7 +57768,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -57912,7 +57926,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -57960,7 +57974,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="67"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -57998,7 +58012,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -58147,10 +58161,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -58161,7 +58175,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -58173,7 +58187,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -58196,7 +58210,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -58353,7 +58367,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -58510,7 +58524,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -58668,7 +58682,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -58716,7 +58730,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="522"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK hQvkFm"
+                                                    className="sc-BXpxD fcWIjg"
                                                     color="2B376E"
                                                     style={
                                                       Object {
@@ -58754,7 +58768,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -58947,7 +58961,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -59104,7 +59118,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -59261,7 +59275,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -59484,7 +59498,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -59532,7 +59546,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="73"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -59570,7 +59584,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -59763,7 +59777,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -59920,7 +59934,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -60077,7 +60091,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -60235,7 +60249,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -60283,7 +60297,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="322"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -60321,7 +60335,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -60514,7 +60528,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -60671,7 +60685,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -60828,7 +60842,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -60960,7 +60974,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -61008,7 +61022,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="322"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -61046,7 +61060,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -61239,7 +61253,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -61396,7 +61410,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -61553,7 +61567,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -61719,15 +61733,15 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <styled.div>
                               <div
-                                className="sc-DJgqy fJIhkf"
+                                className="sc-dwqccx bJjQOM"
                               >
                                 <styled.p>
                                   <p
-                                    className="sc-dwqccx jIIKnI"
+                                    className="sc-gUUBao eLkCwF"
                                   >
                                     <IconWithText
                                       icon={
@@ -61786,7 +61800,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 >
                                   <styled.p>
                                     <p
-                                      className="sc-hJxDiT kBoATC"
+                                      className="sc-liccgK bWddLw"
                                     >
                                       <FormattedMessage
                                         id="components.NearbyView.distanceAway"
@@ -61805,7 +61819,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             </styled.div>
                             <styled.div>
                               <div
-                                className="sc-liccgK inbCZP"
+                                className="sc-cuWdqJ ceWUCI"
                               >
                                 <Connect(FromToPicker)
                                   place={
@@ -64337,7 +64351,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       >
                         <styled.div>
                           <div
-                            className="sc-iuAqRD fnpnZg"
+                            className="sc-DJgqy hBRUWj"
                           >
                             <Connect(StopCardHeader)
                               actionIcon={
@@ -66659,11 +66673,11 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                               >
                                 <styled.div>
                                   <div
-                                    className="sc-DJgqy fJIhkf"
+                                    className="sc-dwqccx bJjQOM"
                                   >
                                     <styled.p>
                                       <p
-                                        className="sc-dwqccx jIIKnI"
+                                        className="sc-gUUBao eLkCwF"
                                       >
                                         <TransitOperatorLogos
                                           stopData={
@@ -67245,7 +67259,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                     >
                                       <styled.p>
                                         <p
-                                          className="sc-hJxDiT kBoATC"
+                                          className="sc-liccgK bWddLw"
                                         >
                                           <FormattedMessage
                                             id="components.NearbyView.distanceAway"
@@ -67264,7 +67278,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                 </styled.div>
                                 <styled.div>
                                   <div
-                                    className="sc-liccgK inbCZP"
+                                    className="sc-cuWdqJ ceWUCI"
                                   >
                                     <div
                                       style={
@@ -67309,7 +67323,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                         }
                                       >
                                         <Connect(Component)
-                                          className="sc-hRxcUd JwFQy stop-header-action"
+                                          className="sc-fTNIjK cGCMkm stop-header-action"
                                           style={
                                             Object {
                                               "gridRow": 1,
@@ -67324,7 +67338,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                           }
                                         >
                                           <a
-                                            className="sc-hRxcUd JwFQy stop-header-action"
+                                            className="sc-fTNIjK cGCMkm stop-header-action"
                                             href="#/schedule/kcm:36931"
                                             style={
                                               Object {
@@ -68733,7 +68747,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                             <div>
                               <styled.ul>
                                 <ul
-                                  className="sc-fTACoA bUDtkT"
+                                  className="sc-bTRMho kIiWKf"
                                 >
                                   <PatternRow
                                     homeTimezone="America/Los_Angeles"
@@ -68908,7 +68922,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -68956,7 +68970,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="45"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -68994,7 +69008,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -69143,10 +69157,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -69157,7 +69171,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -69169,7 +69183,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -69192,7 +69206,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -69305,10 +69319,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -69319,7 +69333,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -69331,7 +69345,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -69354,7 +69368,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -69511,7 +69525,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -69734,7 +69748,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -69782,7 +69796,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="62"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -69820,7 +69834,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -69969,10 +69983,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -69983,7 +69997,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -69995,7 +70009,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -70018,7 +70032,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -70175,7 +70189,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -70332,7 +70346,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -70490,7 +70504,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                       className="pattern-row-item"
                                     >
                                       <li
-                                        className="sc-kGNyvp gCOQlS pattern-row-item"
+                                        className="sc-bAffKu gvThCO pattern-row-item"
                                       >
                                         <div
                                           className="header stop-view"
@@ -70538,7 +70552,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                   title="79"
                                                 >
                                                   <span
-                                                    className="sc-fTNIjK itbFoq"
+                                                    className="sc-BXpxD bYqyKk"
                                                     color="333333"
                                                     style={
                                                       Object {
@@ -70576,7 +70590,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                             className="departure-times"
                                           >
                                             <ol
-                                              className="sc-bAffKu ckoppS departure-times"
+                                              className="sc-jYCGPb dDLykO departure-times"
                                             >
                                               <p
                                                 aria-hidden={true}
@@ -70725,10 +70739,10 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                         >
                                                           <Styled(Rss)>
                                                             <Rss
-                                                              className="sc-jYCGPb gFpca"
+                                                              className="sc-bxnjHY bDQXdg"
                                                             >
                                                               <StyledIconBase
-                                                                className="sc-jYCGPb gFpca"
+                                                                className="sc-bxnjHY bDQXdg"
                                                                 iconAttrs={
                                                                   Object {
                                                                     "fill": "currentColor",
@@ -70739,7 +70753,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 iconViewBox="0 0 448 512"
                                                               >
                                                                 <ForwardRef
-                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                  className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                   iconAttrs={
                                                                     Object {
                                                                       "fill": "currentColor",
@@ -70751,7 +70765,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden="true"
-                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-jYCGPb gFpca"
+                                                                    className="StyledIconBase-sc-ea9ulj-0 fqiNOa sc-bxnjHY bDQXdg"
                                                                     fill="currentColor"
                                                                     focusable="false"
                                                                     viewBox="0 0 448 512"
@@ -70774,7 +70788,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -70931,7 +70945,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -71088,7 +71102,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL fflrIy"
+                                                            className="sc-jlIlqL gzOFyY"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"

--- a/__tests__/components/viewers/__snapshots__/nearby-view.js.snap
+++ b/__tests__/components/viewers/__snapshots__/nearby-view.js.snap
@@ -78,7 +78,7 @@ exports[`components > viewers > nearby view renders nothing on a blank page 1`] 
               }
             >
               <h3
-                className="sc-jlIlqL TTTqe"
+                className="sc-jlIlqL jKiTCX"
                 style={
                   Object {
                     "position": "absolute",
@@ -4449,7 +4449,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
               }
             >
               <h3
-                className="sc-jlIlqL TTTqe"
+                className="sc-jlIlqL jKiTCX"
                 style={
                   Object {
                     "position": "absolute",
@@ -13169,7 +13169,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -13331,7 +13331,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -13488,7 +13488,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -13995,7 +13995,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -14152,7 +14152,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -14309,7 +14309,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -14751,7 +14751,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -14908,7 +14908,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -15065,7 +15065,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -19976,7 +19976,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -20133,7 +20133,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -20290,7 +20290,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -20675,7 +20675,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="saturday"
@@ -21177,7 +21177,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="saturday"
@@ -21334,7 +21334,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="saturday"
@@ -21491,7 +21491,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="saturday"
@@ -30833,7 +30833,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -30995,7 +30995,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -31152,7 +31152,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -31672,7 +31672,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -31829,7 +31829,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -31991,7 +31991,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -32428,7 +32428,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -32585,7 +32585,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -32742,7 +32742,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -33127,7 +33127,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -40202,7 +40202,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -40359,7 +40359,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -40516,7 +40516,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -41018,7 +41018,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -41175,7 +41175,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -41332,7 +41332,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -41717,7 +41717,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -49142,7 +49142,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -49304,7 +49304,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -49466,7 +49466,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -57454,7 +57454,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -57611,7 +57611,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -57768,7 +57768,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -58210,7 +58210,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -58367,7 +58367,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -58524,7 +58524,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -58961,7 +58961,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -59118,7 +59118,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -59275,7 +59275,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -59777,7 +59777,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -59934,7 +59934,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -60091,7 +60091,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -60528,7 +60528,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -60685,7 +60685,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -60842,7 +60842,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -61253,7 +61253,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -61410,7 +61410,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -61567,7 +61567,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -69206,7 +69206,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -69368,7 +69368,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -69525,7 +69525,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -70032,7 +70032,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -70189,7 +70189,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -70346,7 +70346,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -70788,7 +70788,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -70945,7 +70945,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"
@@ -71102,7 +71102,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                                       >
                                                         <styled.span>
                                                           <span
-                                                            className="sc-jlIlqL gzOFyY"
+                                                            className="sc-jlIlqL ktGXbJ"
                                                           >
                                                             <FormattedDayOfWeek
                                                               day="friday"

--- a/__tests__/reducers/__snapshots__/create-otp-reducer.js.snap
+++ b/__tests__/reducers/__snapshots__/create-otp-reducer.js.snap
@@ -90,6 +90,14 @@ Object {
     "localizedMessages": null,
     "mainPanelContent": null,
     "mobileScreen": 1,
+    "nearbyView": Object {
+      "filters": Object {
+        "BikeRentalStation": true,
+        "RentalVehicle": true,
+        "Stop": true,
+        "VehicleParking": true,
+      },
+    },
     "popup": Object {
       "id": null,
     },

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -480,6 +480,14 @@ export function setLocale(locale, isUpdatingLocale = false) {
   }
 }
 
+const updateNearbyViewFilter = createAction('UPDATE_NEARBY_VIEW_FILTER')
+
+export function setNearbyViewFilter(filter) {
+  return function (dispatch) {
+    dispatch(updateNearbyViewFilter(filter))
+  }
+}
+
 const updateRouteViewerFilter = createAction('UPDATE_ROUTE_VIEWER_FILTER')
 /**
  * Updates the route viewer filter

--- a/lib/app.js
+++ b/lib/app.js
@@ -104,7 +104,7 @@ const TermsOfStorage = () => (
 )
 
 // eslint-disable-next-line complexity
-const SvgIcon = ({ className, iconName, style }) => {
+const SvgIcon = ({ className, FallbackIcon, iconName, style }) => {
   const CustomIcon = getCustomIcon && getCustomIcon(iconName)
   if (CustomIcon) return <CustomIcon className={className} style={style} />
   // Some often used defaults
@@ -135,15 +135,20 @@ const SvgIcon = ({ className, iconName, style }) => {
     case 'clock-o':
       return <Clock className={className} style={style} />
     default:
-      console.warn(
-        `Custom icon provider not found for icon ${iconName}. Using fallback icon ExternalLinkAlt.`
-      )
-      return <ExternalLinkAlt className={className} style={style} />
+      if (FallbackIcon) {
+        return <FallbackIcon />
+      } else {
+        console.warn(
+          `Custom icon provider not found for icon ${iconName}. Using fallback icon ExternalLinkAlt.`
+        )
+        return <ExternalLinkAlt className={className} style={style} />
+      }
   }
 }
 
 SvgIcon.propTypes = {
   className: string,
+  FallbackIcon: object | undefined,
   iconName: string,
   style: object
 }

--- a/lib/app.js
+++ b/lib/app.js
@@ -19,7 +19,7 @@ import React from 'react'
 // import OTP-RR components
 
 // Loads a yaml config file from /tmp folder that contains customizations.
-import { Parking } from '@styled-icons/fa-solid'
+import { Parking } from '@styled-icons/fa-solid/Parking'
 
 import otpConfig from '../tmp/config.yml'
 
@@ -136,7 +136,7 @@ const SvgIcon = ({ className, Fallback, iconName, style }) => {
       return <Clock className={className} style={style} />
     default:
       if (Fallback) {
-        return <Fallback />
+        return <Fallback className={className} style={style} />
       } else {
         console.warn(
           `Custom icon provider not found for icon ${iconName}. Using fallback icon ExternalLinkAlt.`
@@ -148,7 +148,7 @@ const SvgIcon = ({ className, Fallback, iconName, style }) => {
 
 SvgIcon.propTypes = {
   className: string,
-  Fallback: object | undefined,
+  Fallback: object,
   iconName: string,
   style: object
 }

--- a/lib/app.js
+++ b/lib/app.js
@@ -104,7 +104,7 @@ const TermsOfStorage = () => (
 )
 
 // eslint-disable-next-line complexity
-const SvgIcon = ({ className, FallbackIcon, iconName, style }) => {
+const SvgIcon = ({ className, Fallback, iconName, style }) => {
   const CustomIcon = getCustomIcon && getCustomIcon(iconName)
   if (CustomIcon) return <CustomIcon className={className} style={style} />
   // Some often used defaults
@@ -135,8 +135,8 @@ const SvgIcon = ({ className, FallbackIcon, iconName, style }) => {
     case 'clock-o':
       return <Clock className={className} style={style} />
     default:
-      if (FallbackIcon) {
-        return <FallbackIcon />
+      if (Fallback) {
+        return <Fallback />
       } else {
         console.warn(
           `Custom icon provider not found for icon ${iconName}. Using fallback icon ExternalLinkAlt.`
@@ -148,7 +148,7 @@ const SvgIcon = ({ className, FallbackIcon, iconName, style }) => {
 
 SvgIcon.propTypes = {
   className: string,
-  FallbackIcon: object | undefined,
+  Fallback: object | undefined,
   iconName: string,
   style: object
 }

--- a/lib/app.js
+++ b/lib/app.js
@@ -19,6 +19,8 @@ import React from 'react'
 // import OTP-RR components
 
 // Loads a yaml config file from /tmp folder that contains customizations.
+import { Parking } from '@styled-icons/fa-solid'
+
 import otpConfig from '../tmp/config.yml'
 
 // Loads a configuration JavaScript file from the /tmp folder that contains customizations.
@@ -128,6 +130,8 @@ const SvgIcon = ({ className, iconName, style }) => {
       return <Utensils className={className} style={style} />
     case 'plus':
       return <Plus className={className} style={style} />
+    case 'parking':
+      return <Parking className={className} style={style} />
     case 'clock-o':
       return <Clock className={className} style={style} />
     default:

--- a/lib/components/form/advanced-settings-panel.tsx
+++ b/lib/components/form/advanced-settings-panel.tsx
@@ -10,7 +10,6 @@ import { Check } from '@styled-icons/boxicons-regular'
 import { connect } from 'react-redux'
 import { decodeQueryParams, DelimitedArrayParam } from 'serialize-query-params'
 import { FormattedMessage, IntlShape, useIntl } from 'react-intl'
-import { invisibleCss } from '@opentripplanner/trip-form/lib/MetroModeSelector'
 import {
   ModeButtonDefinition,
   ModeSetting,
@@ -45,6 +44,7 @@ import {
   setModeButton,
   tripPlannerValidationErrors
 } from './util'
+import { invisibleCss } from '../util/invisible-a11y-label'
 import { setModeButtonEnabled } from './batch-settings'
 import { styledCheckboxCss } from './styled'
 import DateTimeModal from './date-time-modal'

--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -63,7 +63,7 @@ const MapContainer = styled.div<{ hideLayerFilters: boolean }>`
 
   // If we're using filtering in the nearby view, hide the toggleable layers so there's no confusion.
   ul.layers-list {
-    display: ${(props) => (props.hideLayerFilters ? 'none' : 'block')};
+    visibility: ${(props) => (props.hideLayerFilters ? 'hidden' : 'visible')};
   }
 `
 /**
@@ -165,18 +165,18 @@ class DefaultMap extends Component {
   }
 
   _filterNearbyMapLayers = () => {
-    const { mapConfig, nearbyFilters } = this.props
+    const { activeNearbyFilters, mapConfig } = this.props
     const { overlays } = mapConfig
     const newOverlays = overlays
       .filter((overlay) => {
-        return overlay.cardType ? nearbyFilters[overlay.cardType] : true
+        return overlay.cardType ? activeNearbyFilters[overlay.cardType] : true
       })
       .map((overlay) => {
         if (overlay.layers) {
           return {
             ...overlay,
             layers: overlay?.layers?.filter(
-              (layer) => nearbyFilters[layer.cardType]
+              (layer) => activeNearbyFilters[layer.cardType]
             )
           }
         }
@@ -285,7 +285,7 @@ class DefaultMap extends Component {
   }
 
   componentDidMount() {
-    this._filterNearbyMapLayers()
+    this.props.nearbyFilters && this._filterNearbyMapLayers()
     // HACK: Set state lat and lon to null to prevent re-rendering of the
     // underlying OTP-UI map.
     this.setState({
@@ -295,11 +295,14 @@ class DefaultMap extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { mapConfig, nearbyFilters, nearbyViewActive } = this.props
+    const { activeNearbyFilters, mapConfig, nearbyViewActive } = this.props
     // Check if any overlays should be toggled due to mode change
     this._handleQueryChange(prevProps.query, this.props.query)
     // If we're in the nearby view, filter the visible layers according to the nearby view filters.
-    if (prevProps.nearbyFilters !== nearbyFilters && nearbyViewActive)
+    if (
+      prevProps.activeNearbyFilters !== activeNearbyFilters &&
+      nearbyViewActive
+    )
       this._filterNearbyMapLayers()
     // If we leave the nearby view, reset the map overlays back to defaults.
     if (prevProps.nearbyViewActive !== nearbyViewActive && !nearbyViewActive) {
@@ -320,7 +323,7 @@ class DefaultMap extends Component {
       intl,
       itinerary,
       mapConfig,
-      nearbyFiltersConfigured,
+      nearbyFilters,
       nearbyViewActive,
       pending,
       setLocation,
@@ -364,7 +367,7 @@ class DefaultMap extends Component {
     return (
       <MapContainer
         className="percy-hide"
-        hideLayerFilters={nearbyViewActive && nearbyFiltersConfigured}
+        hideLayerFilters={nearbyViewActive && nearbyFilters}
       >
         <BaseMap
           baseLayer={
@@ -504,8 +507,8 @@ class DefaultMap extends Component {
 const mapStateToProps = (state) => {
   const activeSearch = getActiveSearch(state)
   const viewedRoute = state.otp?.ui?.viewedRoute?.routeId
-  const nearbyFilters = state.otp?.ui?.nearbyView?.filters
-  const nearbyFiltersConfigured = state.otp.config.nearbyView.filterConfig
+  const activeNearbyFilters = state.otp?.ui?.nearbyView?.filters
+  const nearbyFilters = state.otp.config?.nearbyView?.filters
   const nearbyViewerActive =
     state.otp.ui.mainPanelContent === MainPanelContent.NEARBY_VIEW
 
@@ -527,13 +530,13 @@ const mapStateToProps = (state) => {
       : null
 
   return {
+    activeNearbyFilters,
     bikeRentalStations: state.otp.overlay.bikeRental.stations,
     carRentalStations: state.otp.overlay.carRental.stations,
     config: state.otp.config,
     itinerary: getActiveItinerary(state),
     mapConfig: state.otp.config.map,
     nearbyFilters,
-    nearbyFiltersConfigured,
     nearbyViewActive:
       state.otp.ui.mainPanelContent === MainPanelContent.NEARBY_VIEW,
     pending: activeSearch ? Boolean(activeSearch.pending) : false,

--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -167,9 +167,9 @@ class DefaultMap extends Component {
     const { activeNearbyFilters, mapConfig } = this.props
     const { overlays } = mapConfig
     const nearbyViewFilteredOverlays = overlays
-      ?.filter((overlay) => {
-        return overlay.cardType && !!activeNearbyFilters[overlay.cardType]
-      })
+      ?.filter((overlay) =>
+        overlay.cardType ? activeNearbyFilters[overlay.cardType] : true
+      )
       .map((overlay) => {
         if (overlay.layers) {
           return {
@@ -293,23 +293,8 @@ class DefaultMap extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { activeNearbyFilters, mapConfig, nearbyViewActive } = this.props
     // Check if any overlays should be toggled due to mode change
     this._handleQueryChange(prevProps.query, this.props.query)
-    // If we're in the nearby view, filter the visible layers according to the nearby view filters.
-    if (
-      prevProps.activeNearbyFilters !== activeNearbyFilters &&
-      nearbyViewActive
-    )
-      if (
-        prevProps.nearbyViewActive !== nearbyViewActive &&
-        !nearbyViewActive
-      ) {
-        // If we leave the nearby view, reset the map overlays back to defaults.
-        this.setState({
-          filteredOverlays: mapConfig?.overlays
-        })
-      }
   }
 
   render() {

--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -42,7 +42,7 @@ import TripViewerOverlay from './connected-trip-viewer-overlay'
 import VehicleRentalOverlay from './connected-vehicle-rental-overlay'
 import withMap from './with-map'
 
-const MapContainer = styled.div`
+const MapContainer = styled.div<{ hideLayerFilters: boolean }>`
   height: 100%;
   width: 100%;
 
@@ -59,6 +59,10 @@ const MapContainer = styled.div`
   .mapboxgl-popup-content {
     border-radius: 10px;
     box-shadow: 0 3px 14px 4px rgb(0 0 0 / 20%);
+  }
+
+  ul.layers-list {
+    display: ${(props) => (props.hideLayerFilters ? 'none' : 'block')};
   }
 `
 /**
@@ -152,10 +156,32 @@ class DefaultMap extends Component {
       initZoom: zoom = 13
     } = props.mapConfig || {}
     this.state = {
+      filteredOverlays: this.props.mapConfig.overlays,
       lat,
       lon,
       zoom
     }
+  }
+
+  _filterNearbyMapLayers = () => {
+    const { mapConfig, nearbyFilters } = this.props
+    const { overlays } = mapConfig
+    const newOverlays = overlays
+      .filter((overlay) => {
+        return overlay.cardType ? nearbyFilters[overlay.cardType] : true
+      })
+      .map((overlay) => {
+        if (overlay.layers) {
+          return {
+            ...overlay,
+            layers: overlay?.layers?.filter(
+              (layer) => nearbyFilters[layer.cardType]
+            )
+          }
+        }
+        return overlay
+      })
+    return this.setState({ filteredOverlays: newOverlays })
   }
 
   // Generate operator logos to pass through OTP tile layer to map-popup
@@ -258,6 +284,7 @@ class DefaultMap extends Component {
   }
 
   componentDidMount() {
+    this._filterNearbyMapLayers()
     // HACK: Set state lat and lon to null to prevent re-rendering of the
     // underlying OTP-UI map.
     this.setState({
@@ -267,8 +294,16 @@ class DefaultMap extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    const { mapConfig, nearbyFilters, nearbyViewActive } = this.props
     // Check if any overlays should be toggled due to mode change
     this._handleQueryChange(prevProps.query, this.props.query)
+    if (prevProps.nearbyFilters !== nearbyFilters && nearbyViewActive)
+      this._filterNearbyMapLayers()
+    if (prevProps.nearbyViewActive !== nearbyViewActive && !nearbyViewActive) {
+      this.setState({
+        filteredOverlays: mapConfig.overlays
+      })
+    }
   }
 
   render() {
@@ -282,6 +317,7 @@ class DefaultMap extends Component {
       intl,
       itinerary,
       mapConfig,
+      nearbyFiltersConfigured,
       nearbyViewActive,
       pending,
       setLocation,
@@ -323,7 +359,10 @@ class DefaultMap extends Component {
       overlays?.find((o) => o.type === 'vehicles-one-route') || undefined
 
     return (
-      <MapContainer className="percy-hide">
+      <MapContainer
+        className="percy-hide"
+        hideLayerFilters={nearbyViewActive && nearbyFiltersConfigured}
+      >
         <BaseMap
           baseLayer={
             baseLayerUrls?.length > 1 ? baseLayerUrls : baseLayerUrls?.[0]
@@ -367,7 +406,7 @@ class DefaultMap extends Component {
           <ElevationPointMarker />
 
           {/* The configurable overlays */}
-          {overlays?.map((overlayConfig, k) => {
+          {this.state.filteredOverlays?.map((overlayConfig, k) => {
             const namedLayerProps = {
               ...overlayConfig,
               id: k,
@@ -462,6 +501,8 @@ class DefaultMap extends Component {
 const mapStateToProps = (state) => {
   const activeSearch = getActiveSearch(state)
   const viewedRoute = state.otp?.ui?.viewedRoute?.routeId
+  const nearbyFilters = state.otp?.ui?.nearbyView?.filters
+  const nearbyFiltersConfigured = state.otp.config.nearbyView.filterConfig
   const nearbyViewerActive =
     state.otp.ui.mainPanelContent === MainPanelContent.NEARBY_VIEW
 
@@ -488,6 +529,8 @@ const mapStateToProps = (state) => {
     config: state.otp.config,
     itinerary: getActiveItinerary(state),
     mapConfig: state.otp.config.map,
+    nearbyFilters,
+    nearbyFiltersConfigured,
     nearbyViewActive:
       state.otp.ui.mainPanelContent === MainPanelContent.NEARBY_VIEW,
     pending: activeSearch ? Boolean(activeSearch.pending) : false,

--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -169,7 +169,7 @@ class DefaultMap extends Component {
     const { overlays } = mapConfig
     const newOverlays = overlays
       ?.filter((overlay) => {
-        return overlay.cardType ? activeNearbyFilters[overlay.cardType] : true
+        return overlay.cardType && !!activeNearbyFilters[overlay.cardType]
       })
       .map((overlay) => {
         if (overlay.layers) {

--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -61,6 +61,7 @@ const MapContainer = styled.div<{ hideLayerFilters: boolean }>`
     box-shadow: 0 3px 14px 4px rgb(0 0 0 / 20%);
   }
 
+  // If we're using filtering in the nearby view, hide the toggleable layers so there's no confusion.
   ul.layers-list {
     display: ${(props) => (props.hideLayerFilters ? 'none' : 'block')};
   }
@@ -297,8 +298,10 @@ class DefaultMap extends Component {
     const { mapConfig, nearbyFilters, nearbyViewActive } = this.props
     // Check if any overlays should be toggled due to mode change
     this._handleQueryChange(prevProps.query, this.props.query)
+    // If we're in the nearby view, filter the visible layers according to the nearby view filters.
     if (prevProps.nearbyFilters !== nearbyFilters && nearbyViewActive)
       this._filterNearbyMapLayers()
+    // If we leave the nearby view, reset the map overlays back to defaults.
     if (prevProps.nearbyViewActive !== nearbyViewActive && !nearbyViewActive) {
       this.setState({
         filteredOverlays: mapConfig.overlays

--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -157,7 +157,7 @@ class DefaultMap extends Component {
       initZoom: zoom = 13
     } = props.mapConfig || {}
     this.state = {
-      filteredOverlays: this.props.mapConfig.overlays,
+      filteredOverlays: this.props.mapConfig?.overlays,
       lat,
       lon,
       zoom
@@ -168,7 +168,7 @@ class DefaultMap extends Component {
     const { activeNearbyFilters, mapConfig } = this.props
     const { overlays } = mapConfig
     const newOverlays = overlays
-      .filter((overlay) => {
+      ?.filter((overlay) => {
         return overlay.cardType ? activeNearbyFilters[overlay.cardType] : true
       })
       .map((overlay) => {
@@ -307,7 +307,7 @@ class DefaultMap extends Component {
     // If we leave the nearby view, reset the map overlays back to defaults.
     if (prevProps.nearbyViewActive !== nearbyViewActive && !nearbyViewActive) {
       this.setState({
-        filteredOverlays: mapConfig.overlays
+        filteredOverlays: mapConfig?.overlays
       })
     }
   }

--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -157,17 +157,16 @@ class DefaultMap extends Component {
       initZoom: zoom = 13
     } = props.mapConfig || {}
     this.state = {
-      filteredOverlays: this.props.mapConfig?.overlays,
       lat,
       lon,
       zoom
     }
   }
 
-  _filterNearbyMapLayers = () => {
+  getNearbyViewFilteredOverlays = () => {
     const { activeNearbyFilters, mapConfig } = this.props
     const { overlays } = mapConfig
-    const newOverlays = overlays
+    const nearbyViewFilteredOverlays = overlays
       ?.filter((overlay) => {
         return overlay.cardType && !!activeNearbyFilters[overlay.cardType]
       })
@@ -182,7 +181,7 @@ class DefaultMap extends Component {
         }
         return overlay
       })
-    return this.setState({ filteredOverlays: newOverlays })
+    return nearbyViewFilteredOverlays
   }
 
   // Generate operator logos to pass through OTP tile layer to map-popup
@@ -285,7 +284,6 @@ class DefaultMap extends Component {
   }
 
   componentDidMount() {
-    this.props.nearbyFilters && this._filterNearbyMapLayers()
     // HACK: Set state lat and lon to null to prevent re-rendering of the
     // underlying OTP-UI map.
     this.setState({
@@ -303,13 +301,15 @@ class DefaultMap extends Component {
       prevProps.activeNearbyFilters !== activeNearbyFilters &&
       nearbyViewActive
     )
-      this._filterNearbyMapLayers()
-    // If we leave the nearby view, reset the map overlays back to defaults.
-    if (prevProps.nearbyViewActive !== nearbyViewActive && !nearbyViewActive) {
-      this.setState({
-        filteredOverlays: mapConfig?.overlays
-      })
-    }
+      if (
+        prevProps.nearbyViewActive !== nearbyViewActive &&
+        !nearbyViewActive
+      ) {
+        // If we leave the nearby view, reset the map overlays back to defaults.
+        this.setState({
+          filteredOverlays: mapConfig?.overlays
+        })
+      }
   }
 
   render() {
@@ -364,6 +364,10 @@ class DefaultMap extends Component {
     const routeBasedTransitVehicleOverlayNameOverride =
       overlays?.find((o) => o.type === 'vehicles-one-route') || undefined
 
+    const visibleOverlays = nearbyViewActive
+      ? this.getNearbyViewFilteredOverlays()
+      : overlays
+
     return (
       <MapContainer
         className="percy-hide"
@@ -412,7 +416,7 @@ class DefaultMap extends Component {
           <ElevationPointMarker />
 
           {/* The configurable overlays */}
-          {this.state.filteredOverlays?.map((overlayConfig, k) => {
+          {visibleOverlays?.map((overlayConfig, k) => {
             const namedLayerProps = {
               ...overlayConfig,
               id: k,

--- a/lib/components/util/invisible-a11y-label.ts
+++ b/lib/components/util/invisible-a11y-label.ts
@@ -4,7 +4,6 @@ export const invisibleCss = css`
   clip: rect(0, 0, 0, 0);
   height: 0;
   overflow: hidden;
-  position: absolute;
   width: 0;
 `
 

--- a/lib/components/util/invisible-a11y-label.ts
+++ b/lib/components/util/invisible-a11y-label.ts
@@ -1,4 +1,12 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
+
+export const invisibleCss = css`
+  clip: rect(0, 0, 0, 0);
+  height: 0;
+  overflow: hidden;
+  position: absolute;
+  width: 0;
+`
 
 const InvisibleA11yLabel = styled.span<{ as?: string }>`
   ${(props) => {
@@ -6,9 +14,7 @@ const InvisibleA11yLabel = styled.span<{ as?: string }>`
     // If the tag type is overwritten, use that tag's display type.
     return props.as ? '' : 'display: inline-block;'
   }}
-  height: 0;
-  overflow: hidden;
-  width: 0;
+  ${invisibleCss}
 `
 
 export default InvisibleA11yLabel

--- a/lib/components/viewers/nearby/nearby-filter.tsx
+++ b/lib/components/viewers/nearby/nearby-filter.tsx
@@ -40,6 +40,9 @@ const StyledFilterCheckbox = styled.label<{ checked: boolean }>`
   }
   &:hover {
     box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+    cursor: pointer;
+    background: ${(props) => (props.checked ? '#fff' : '#ffffffe5')};
+    transition: all ease 150ms;
   }
 `
 
@@ -62,17 +65,15 @@ export const FilterCheckboxes = ({
     )
 
   return (
-    <>
-      <StyledFilterCheckbox checked={value} htmlFor={filter.cardType}>
-        <FilterIcon />
-        {value && <Check2 />}
-        <input
-          checked={value}
-          id={filter.cardType}
-          onChange={onChange}
-          type="checkbox"
-        />
-      </StyledFilterCheckbox>
-    </>
+    <StyledFilterCheckbox checked={value} htmlFor={filter.cardType}>
+      <FilterIcon />
+      {value && <Check2 />}
+      <input
+        checked={value}
+        id={filter.cardType}
+        onChange={onChange}
+        type="checkbox"
+      />
+    </StyledFilterCheckbox>
   )
 }

--- a/lib/components/viewers/nearby/nearby-filter.tsx
+++ b/lib/components/viewers/nearby/nearby-filter.tsx
@@ -1,0 +1,74 @@
+import { Check2 } from '@styled-icons/bootstrap'
+import { Parking } from '@styled-icons/fa-solid'
+
+import { ComponentContext } from '../../../util/contexts'
+import { getBaseColor } from '../../util/colors'
+import { invisibleCss } from '@opentripplanner/trip-form/lib/MetroModeSelector'
+import { NearbyFilterConfig } from '../../../util/config-types'
+
+import React, { useContext } from 'react'
+import styled from 'styled-components'
+
+const StyledFilterCheckbox = styled.label<{ checked: boolean }>`
+  width: 75px;
+  height: 35px;
+  border-radius: 50px;
+  background: ${(props) => (props.checked ? '#fff' : '#ffffffd9')};
+  display: grid;
+  grid-template-columns: 50% 50%;
+  align-items: center;
+  margin: 0;
+  justify-content: space-between;
+  padding: 0.5em;
+  align-content: center;
+  justify-items: center;
+  transition: all ease 150ms;
+
+  svg {
+    width: 25px;
+    height: 25px;
+    color: ${getBaseColor()};
+
+    &:first-of-type {
+      grid-column: 1;
+    }
+  }
+
+  input {
+    ${invisibleCss}
+  }
+`
+
+export const FilterCheckboxes = ({
+  filter,
+  onChange,
+  value
+}: {
+  filter: NearbyFilterConfig
+  onChange: (arg: any) => void
+  value: boolean
+}): JSX.Element => {
+  // @ts-expect-error component context
+  const { ModeIcon } = useContext(ComponentContext)
+  const FilterIcon = () =>
+    filter.cardType === 'VehicleParking' ? (
+      <Parking />
+    ) : (
+      <ModeIcon className="mode-svg" mode={filter.iconName} />
+    )
+
+  return (
+    <>
+      <StyledFilterCheckbox checked={value} htmlFor={filter.cardType}>
+        <FilterIcon />
+        {value && <Check2 />}
+        <input
+          checked={value}
+          id={filter.cardType}
+          onChange={onChange}
+          type="checkbox"
+        />
+      </StyledFilterCheckbox>
+    </>
+  )
+}

--- a/lib/components/viewers/nearby/nearby-filter.tsx
+++ b/lib/components/viewers/nearby/nearby-filter.tsx
@@ -1,12 +1,12 @@
 import { Check2 } from '@styled-icons/bootstrap/Check2'
-import { Parking } from '@styled-icons/fa-solid/Parking'
 
 import { ComponentContext } from '../../../util/contexts'
 import { getBaseColor } from '../../util/colors'
-import { invisibleCss } from '@opentripplanner/trip-form/lib/MetroModeSelector'
 import { NearbyFilterConfig } from '../../../util/config-types'
-
 import React, { useContext } from 'react'
+
+import { invisibleCss } from '../../util/invisible-a11y-label'
+
 import styled from 'styled-components'
 
 const StyledFilterCheckbox = styled.label<{ checked: boolean }>`
@@ -52,7 +52,7 @@ export const FilterCheckboxes = ({
   value
 }: {
   filter: NearbyFilterConfig
-  onChange: (arg: any) => void
+  onChange: (arg: React.ChangeEvent<HTMLInputElement>) => void
   value: boolean
 }): JSX.Element => {
   // @ts-expect-error component context

--- a/lib/components/viewers/nearby/nearby-filter.tsx
+++ b/lib/components/viewers/nearby/nearby-filter.tsx
@@ -61,13 +61,10 @@ export const FilterCheckboxes = ({
   const ModeFilterIcon = () => (
     <ModeIcon className="mode-svg" mode={filter.iconName} />
   )
-  const FilterIcon = () => (
-    <SvgIcon FallbackIcon={ModeFilterIcon} iconName={filter.iconName} />
-  )
 
   return (
     <StyledFilterCheckbox checked={value} htmlFor={filter.cardType}>
-      <FilterIcon />
+      <SvgIcon Fallback={ModeFilterIcon} iconName={filter.iconName} />
       {value && <Check2 />}
       <input
         checked={value}

--- a/lib/components/viewers/nearby/nearby-filter.tsx
+++ b/lib/components/viewers/nearby/nearby-filter.tsx
@@ -1,5 +1,5 @@
-import { Check2 } from '@styled-icons/bootstrap'
-import { Parking } from '@styled-icons/fa-solid'
+import { Check2 } from '@styled-icons/bootstrap/Check2'
+import { Parking } from '@styled-icons/fa-solid/Parking'
 
 import { ComponentContext } from '../../../util/contexts'
 import { getBaseColor } from '../../util/colors'

--- a/lib/components/viewers/nearby/nearby-filter.tsx
+++ b/lib/components/viewers/nearby/nearby-filter.tsx
@@ -12,8 +12,9 @@ import styled from 'styled-components'
 const StyledFilterCheckbox = styled.label<{ checked: boolean }>`
   width: 75px;
   height: 35px;
-  border-radius: 50px;
+  border-radius: 10px;
   background: ${(props) => (props.checked ? '#fff' : '#ffffffd9')};
+  box-shadow: 0px 0px 5px 1px inset rgb(0 0 0 / 0.05);
   display: grid;
   grid-template-columns: 50% 50%;
   align-items: center;
@@ -36,6 +37,9 @@ const StyledFilterCheckbox = styled.label<{ checked: boolean }>`
 
   input {
     ${invisibleCss}
+  }
+  &:hover {
+    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   }
 `
 

--- a/lib/components/viewers/nearby/nearby-filter.tsx
+++ b/lib/components/viewers/nearby/nearby-filter.tsx
@@ -56,13 +56,14 @@ export const FilterCheckboxes = ({
   value: boolean
 }): JSX.Element => {
   // @ts-expect-error component context
-  const { ModeIcon } = useContext(ComponentContext)
-  const FilterIcon = () =>
-    filter.cardType === 'VehicleParking' ? (
-      <Parking />
-    ) : (
-      <ModeIcon className="mode-svg" mode={filter.iconName} />
-    )
+  const { ModeIcon, SvgIcon } = useContext(ComponentContext)
+  // The icon is either in SvgIcon or ModeIcon so provide both
+  const ModeFilterIcon = () => (
+    <ModeIcon className="mode-svg" mode={filter.iconName} />
+  )
+  const FilterIcon = () => (
+    <SvgIcon FallbackIcon={ModeFilterIcon} iconName={filter.iconName} />
+  )
 
   return (
     <StyledFilterCheckbox checked={value} htmlFor={filter.cardType}>

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -85,7 +85,7 @@ type Props = {
   setHighlightedLocation: (location: Location | null) => void
   setLocation: SetLocationHandler
   setMainPanelContent: (content: number) => void
-  setNearbyViewFilter: (arg: any) => void
+  setNearbyViewFilter: (arg: NearbyFilters) => void
   setViewedNearbyCoords: (location: Location | null) => void
   zoomToPlace: ZoomToPlaceHandler
 }
@@ -247,7 +247,6 @@ function NearbyView({
   const onFilterChange = (event: FormEvent) => {
     const { target } = event
     const { id } = target as HTMLInputElement
-    // setFilters({ ...filters, [id]: !filters[id] })
     setNearbyViewFilter({
       ...activeNearbyFilters,
       [id]: !activeNearbyFilters[id as NearbyFilterKey]

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -195,10 +195,11 @@ function NearbyView({
   }
 
   const scrollToTop = () => {
-    nearbyContainerRef?.current?.scroll({
-      behavior: 'smooth',
-      top: 0
-    })
+    nearbyContainerRef?.current?.scroll &&
+      nearbyContainerRef?.current?.scroll({
+        behavior: 'smooth',
+        top: 0
+      })
   }
 
   // Make sure the highlighted location is cleaned up when leaving nearby

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -51,9 +51,8 @@ type LatLonObj = { lat: number; lon: number }
 type CurrentPosition = { coords?: { latitude: number; longitude: number } }
 type ServiceWeek = { end: string; start: string }
 
-type Filter = Record<string, boolean>
-
 type Props = {
+  activeNearbyFilters: any
   currentPosition?: CurrentPosition
   currentServiceWeek?: ServiceWeek
   defaultLatLon: LatLonObj | null
@@ -64,7 +63,6 @@ type Props = {
     radius?: number,
     currentServiceWeek?: ServiceWeek
   ) => void
-  filterConfig: any
   geocoderConfig: GeocoderConfig
   getCurrentPosition: any // TODO
   hideBackButton?: boolean
@@ -73,7 +71,7 @@ type Props = {
   mobile?: boolean
   // Todo: type nearby results
   nearby: any
-  nearbyFilters: any
+  nearbyFilters?: Array<NearbyFilterConfig>
   nearbyViewCoords?: LatLonObj
   radius?: number
   routeSortComparator: (a: PatternStopTime, b: PatternStopTime) => number
@@ -136,13 +134,13 @@ function getNearbyCoordsFromUrlOrLocationOrMapCenter(
 }
 
 function NearbyView({
+  activeNearbyFilters,
   currentPosition,
   currentServiceWeek,
   defaultLatLon,
   displayedCoords,
   entityId,
   fetchNearby,
-  filterConfig,
   geocoderConfig,
   getCurrentPosition,
   hideEmptyStops,
@@ -164,17 +162,7 @@ function NearbyView({
   const intl = useIntl()
   const [loading, setLoading] = useState(true)
   const [reversedPoint, setReversedPoint] = useState('')
-  const [filters, setFilters] = useState(
-    // Set the filters according to the configuration settings. If there's no filter config, set the filters to default (which is just all filters set to true)
-    filterConfig
-      ? Object.fromEntries(
-          filterConfig.map((filter: Filter) => [
-            filter.cardType,
-            filter.defaultOn
-          ])
-        )
-      : nearbyFilters
-  )
+  const [filters, setFilters] = useState(activeNearbyFilters)
 
   const nearbyContainerRef = useRef<HTMLOListElement>(null)
   const finalNearbyCoords = useMemo(
@@ -194,7 +182,6 @@ function NearbyView({
   }
 
   const scrollToTop = () => {
-    console.log(nearbyContainerRef)
     nearbyContainerRef?.current?.scroll({
       behavior: 'smooth',
       top: 0
@@ -370,7 +357,7 @@ function NearbyView({
           />
         </InvisibleA11yLabel>
       )}
-      <div style={{ padding: filterConfig ? '1em 1em .75em' : '1em' }}>
+      <div style={{ padding: nearbyFilters ? '1em 1em .75em' : '1em' }}>
         <LocationField
           className="nearby-view-location-field"
           // TODO: why does this cause the jump to the trip planner when selecting location
@@ -407,12 +394,12 @@ function NearbyView({
           sortByDistance
           suggestionCount={geocoderConfig?.resultsCount}
         />
-        {filterConfig && (
+        {nearbyFilters && (
           <div
             className="filter-container"
             style={{ display: 'flex', gap: '10px', marginTop: '10px' }}
           >
-            {filterConfig.map((filter: NearbyFilterConfig) => {
+            {nearbyFilters.map((filter: NearbyFilterConfig) => {
               return (
                 <FilterCheckboxes
                   filter={filter}
@@ -430,7 +417,7 @@ function NearbyView({
       {/* This is used to scroll to top */}
       <NearbySidebarContainer
         className="base-color-bg"
-        filters={filterConfig}
+        filters={!!nearbyFilters}
         ref={nearbyContainerRef}
         style={{ marginBottom: 0 }}
       >
@@ -458,7 +445,7 @@ const mapStateToProps = (state: AppReduxState) => {
   const { entityId } = state.router.location.query
   const { currentPosition, sessionSearches } = location
   const { filters } = nearbyView
-  const filterConfig = nearbyViewConfig?.filterConfig
+  const nearbyFilters = nearbyViewConfig?.filters
   const defaultLatLon =
     map?.initLat && map?.initLon ? { lat: map.initLat, lon: map.initLon } : null
 
@@ -482,18 +469,18 @@ const mapStateToProps = (state: AppReduxState) => {
   }
 
   return {
+    activeNearbyFilters: filters,
     currentPosition,
     currentServiceWeek,
     defaultLatLon,
     displayedCoords: nearby?.coords,
     entityId: entityId && decodeURIComponent(entityId),
-    filterConfig,
     geocoderConfig: config.geocoder,
     hideEmptyStops: config.nearbyView?.hideEmptyStops,
     homeTimezone: config.homeTimezone,
     location: state.router.location.hash,
     nearby: nearby?.data,
-    nearbyFilters: filters,
+    nearbyFilters,
     nearbyViewCoords,
     radius: config.nearbyView?.radius,
     routeSortComparator,

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -23,6 +23,7 @@ import * as mapActions from '../../../actions/map'
 import * as uiActions from '../../../actions/ui'
 import {
   AppReduxState,
+  LatLonObj,
   NearbyFilterKey,
   NearbyFilters
 } from '../../../util/state-types'
@@ -52,7 +53,6 @@ import VehicleParking from './vehicle-parking'
 const AUTO_REFRESH_INTERVAL = 15000000
 
 // TODO: use lonlat package
-type LatLonObj = { lat: number; lon: number }
 type CurrentPosition = { coords?: { latitude: number; longitude: number } }
 type ServiceWeek = { end: string; start: string }
 

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { connect } from 'react-redux'
 import { FormattedMessage, useIntl } from 'react-intl'
 import { Location } from '@opentripplanner/types'
@@ -7,14 +8,21 @@ import { Search } from '@styled-icons/fa-solid/Search'
 import coreUtils from '@opentripplanner/core-utils'
 import getGeocoder from '@opentripplanner/geocoder'
 import LocationField from '@opentripplanner/location-field'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, {
+  FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 
 import * as apiActions from '../../../actions/api'
 import * as locationActions from '../../../actions/location'
 import * as mapActions from '../../../actions/map'
 import * as uiActions from '../../../actions/ui'
 import { AppReduxState } from '../../../util/state-types'
-import { GeocoderConfig } from '../../../util/config-types'
+import { GeocoderConfig, NearbyFilterConfig } from '../../../util/config-types'
 import { getCurrentServiceWeek } from '../../../util/current-service-week'
 import {
   PatternStopTime,
@@ -28,6 +36,7 @@ import MobileNavigationBar from '../../mobile/navigation-bar'
 import PageTitle from '../../util/page-title'
 import VehiclePositionRetriever from '../vehicle-position-retriever'
 
+import { FilterCheckboxes } from './nearby-filter'
 import { FullHeightContainer, NearbySidebarContainer } from './styled'
 import FromToPicker from './from-to-picker'
 import RentalStation from './rental-station'
@@ -42,6 +51,8 @@ type LatLonObj = { lat: number; lon: number }
 type CurrentPosition = { coords?: { latitude: number; longitude: number } }
 type ServiceWeek = { end: string; start: string }
 
+type Filter = Record<string, boolean>
+
 type Props = {
   currentPosition?: CurrentPosition
   currentServiceWeek?: ServiceWeek
@@ -53,6 +64,7 @@ type Props = {
     radius?: number,
     currentServiceWeek?: ServiceWeek
   ) => void
+  filterConfig: any
   geocoderConfig: GeocoderConfig
   getCurrentPosition: any // TODO
   hideBackButton?: boolean
@@ -61,6 +73,7 @@ type Props = {
   mobile?: boolean
   // Todo: type nearby results
   nearby: any
+  nearbyFilters: any
   nearbyViewCoords?: LatLonObj
   radius?: number
   routeSortComparator: (a: PatternStopTime, b: PatternStopTime) => number
@@ -68,6 +81,7 @@ type Props = {
   setHighlightedLocation: (location: Location | null) => void
   setLocation: SetLocationHandler
   setMainPanelContent: (content: number) => void
+  setNearbyViewFilter: (arg: any) => void
   setViewedNearbyCoords: (location: Location | null) => void
   zoomToPlace: ZoomToPlaceHandler
 }
@@ -128,18 +142,21 @@ function NearbyView({
   displayedCoords,
   entityId,
   fetchNearby,
+  filterConfig,
   geocoderConfig,
   getCurrentPosition,
   hideEmptyStops,
   location,
   mobile,
   nearby,
+  nearbyFilters,
   nearbyViewCoords,
   radius,
   routeSortComparator,
   sessionSearches,
   setHighlightedLocation,
   setMainPanelContent,
+  setNearbyViewFilter,
   setViewedNearbyCoords,
   zoomToPlace
 }: Props): JSX.Element {
@@ -147,6 +164,17 @@ function NearbyView({
   const intl = useIntl()
   const [loading, setLoading] = useState(true)
   const [reversedPoint, setReversedPoint] = useState('')
+  const [filters, setFilters] = useState(
+    filterConfig
+      ? Object.fromEntries(
+          filterConfig.map((filter: Filter) => [
+            filter.cardType,
+            filter.defaultOn
+          ])
+        )
+      : nearbyFilters
+  )
+
   const firstItemRef = useRef<HTMLDivElement>(null)
   const finalNearbyCoords = useMemo(
     () =>
@@ -158,12 +186,18 @@ function NearbyView({
       ),
     [nearbyViewCoords, currentPosition, map]
   )
-
   const reverseCoords = (coords: LonLatInput) => {
     getGeocoder(geocoderConfig)
       .reverse({ point: coords })
       .then((result: Location) => setReversedPoint(result?.name || ''))
   }
+
+  const scrollToTop = () =>
+    window.scrollTo({
+      behavior: 'smooth',
+      left: 0,
+      top: 0
+    })
 
   // Make sure the highlighted location is cleaned up when leaving nearby
   useEffect(() => {
@@ -208,12 +242,19 @@ function NearbyView({
     }
   }, [map, setViewedNearbyCoords, setHighlightedLocation])
 
+  const onFilterChange = (event: FormEvent) => {
+    const { target } = event
+    const { id } = target as HTMLInputElement
+    setFilters({ ...filters, [id]: !filters[id] })
+  }
+
   useEffect(() => {
-    window.scrollTo({
-      behavior: 'smooth',
-      left: 0,
-      top: 0
-    })
+    setNearbyViewFilter(filters)
+    scrollToTop()
+  }, [filters, setNearbyViewFilter])
+
+  useEffect(() => {
+    scrollToTop()
     if (finalNearbyCoords) {
       fetchNearby(finalNearbyCoords, radius, currentServiceWeek)
       setLoading(true)
@@ -259,9 +300,9 @@ function NearbyView({
   const filteredNearby = nearby?.filter((n: any) => {
     if (n.place.__typename === 'Stop' && hideEmptyStops) {
       const patternArray = patternArrayforStops(n.place, routeSortComparator)
-      return !(patternArray?.length === 0)
+      return !(patternArray?.length === 0) && filters[n.place.__typename]
     }
-    return true
+    return filters[n.place.__typename]
   })
 
   const nearbyItemList =
@@ -327,7 +368,7 @@ function NearbyView({
           />
         </InvisibleA11yLabel>
       )}
-      <div style={{ padding: '1em' }}>
+      <div style={{ padding: filterConfig ? '1em 1em .5em 1em' : '1em' }}>
         <LocationField
           className="nearby-view-location-field"
           // TODO: why does this cause the jump to the trip planner when selecting location
@@ -364,6 +405,23 @@ function NearbyView({
           sortByDistance
           suggestionCount={geocoderConfig?.resultsCount}
         />
+        {filterConfig && (
+          <div
+            className="filter-container"
+            style={{ display: 'flex', gap: '10px', marginTop: '10px' }}
+          >
+            {filterConfig.map((filter: NearbyFilterConfig) => {
+              return (
+                <FilterCheckboxes
+                  filter={filter}
+                  key={filter.cardType}
+                  onChange={onFilterChange}
+                  value={filters[filter.cardType]}
+                />
+              )
+            })}
+          </div>
+        )}
       </div>
 
       {loading && <Loading extraSmall />}
@@ -371,6 +429,7 @@ function NearbyView({
       <div aria-hidden ref={firstItemRef} />
       <NearbySidebarContainer
         className="base-color-bg"
+        filters={filterConfig}
         style={{ marginBottom: 0 }}
       >
         {nearby &&
@@ -392,10 +451,12 @@ const mapStateToProps = (state: AppReduxState) => {
   const { config, location, transitIndex, ui } = state.otp
   const { map, nearbyView: nearbyViewConfig, routeViewer } = config
   const transitOperators = config?.transitOperators || []
-  const { nearbyViewCoords } = ui
+  const { nearbyView, nearbyViewCoords } = ui
   const { nearby } = transitIndex
   const { entityId } = state.router.location.query
   const { currentPosition, sessionSearches } = location
+  const { filters } = nearbyView
+  const filterConfig = nearbyViewConfig?.filterConfig
   const defaultLatLon =
     map?.initLat && map?.initLon ? { lat: map.initLat, lon: map.initLon } : null
 
@@ -424,11 +485,14 @@ const mapStateToProps = (state: AppReduxState) => {
     defaultLatLon,
     displayedCoords: nearby?.coords,
     entityId: entityId && decodeURIComponent(entityId),
+    filterConfig,
     geocoderConfig: config.geocoder,
     hideEmptyStops: config.nearbyView?.hideEmptyStops,
     homeTimezone: config.homeTimezone,
     location: state.router.location.hash,
+    mapConfig: config.map,
     nearby: nearby?.data,
+    nearbyFilters: filters,
     nearbyViewCoords,
     radius: config.nearbyView?.radius,
     routeSortComparator,
@@ -442,6 +506,7 @@ const mapDispatchToProps = {
   setHighlightedLocation: uiActions.setHighlightedLocation,
   setLocation: mapActions.setLocation,
   setMainPanelContent: uiActions.setMainPanelContent,
+  setNearbyViewFilter: uiActions.setNearbyViewFilter,
   setViewedNearbyCoords: uiActions.setViewedNearbyCoords,
   viewNearby: uiActions.viewNearby,
   zoomToPlace: mapActions.zoomToPlace

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -21,7 +21,11 @@ import * as apiActions from '../../../actions/api'
 import * as locationActions from '../../../actions/location'
 import * as mapActions from '../../../actions/map'
 import * as uiActions from '../../../actions/ui'
-import { AppReduxState } from '../../../util/state-types'
+import {
+  AppReduxState,
+  NearbyFilterKey,
+  NearbyFilters
+} from '../../../util/state-types'
 import { GeocoderConfig, NearbyFilterConfig } from '../../../util/config-types'
 import { getCurrentServiceWeek } from '../../../util/current-service-week'
 import {
@@ -52,7 +56,7 @@ type CurrentPosition = { coords?: { latitude: number; longitude: number } }
 type ServiceWeek = { end: string; start: string }
 
 type Props = {
-  activeNearbyFilters: any
+  activeNearbyFilters: NearbyFilters
   currentPosition?: CurrentPosition
   currentServiceWeek?: ServiceWeek
   defaultLatLon: LatLonObj | null
@@ -236,7 +240,7 @@ function NearbyView({
     // setFilters({ ...filters, [id]: !filters[id] })
     setNearbyViewFilter({
       ...activeNearbyFilters,
-      [id]: !activeNearbyFilters[id]
+      [id]: !activeNearbyFilters[id as NearbyFilterKey]
     })
     scrollToTop()
   }
@@ -289,10 +293,11 @@ function NearbyView({
     if (n.place.__typename === 'Stop' && hideEmptyStops) {
       const patternArray = patternArrayforStops(n.place, routeSortComparator)
       return (
-        !(patternArray?.length === 0) && activeNearbyFilters[n.place.__typename]
+        !(patternArray?.length === 0) &&
+        activeNearbyFilters[n.place.__typename as NearbyFilterKey]
       )
     }
-    return activeNearbyFilters[n.place.__typename]
+    return activeNearbyFilters[n.place.__typename as NearbyFilterKey]
   })
 
   const nearbyItemList =
@@ -445,7 +450,7 @@ const mapStateToProps = (state: AppReduxState) => {
   const { nearby } = transitIndex
   const { entityId } = state.router.location.query
   const { currentPosition, sessionSearches } = location
-  const { filters } = nearbyView
+  const filters = nearbyView.filters
   const nearbyFilters = nearbyViewConfig?.filters
   const defaultLatLon =
     map?.initLat && map?.initLon ? { lat: map.initLat, lon: map.initLon } : null

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -162,7 +162,6 @@ function NearbyView({
   const intl = useIntl()
   const [loading, setLoading] = useState(true)
   const [reversedPoint, setReversedPoint] = useState('')
-  const [filters, setFilters] = useState(activeNearbyFilters)
 
   const nearbyContainerRef = useRef<HTMLOListElement>(null)
   const finalNearbyCoords = useMemo(
@@ -234,13 +233,13 @@ function NearbyView({
   const onFilterChange = (event: FormEvent) => {
     const { target } = event
     const { id } = target as HTMLInputElement
-    setFilters({ ...filters, [id]: !filters[id] })
-  }
-
-  useEffect(() => {
-    setNearbyViewFilter(filters)
+    // setFilters({ ...filters, [id]: !filters[id] })
+    setNearbyViewFilter({
+      ...activeNearbyFilters,
+      [id]: !activeNearbyFilters[id]
+    })
     scrollToTop()
-  }, [filters, setNearbyViewFilter])
+  }
 
   useEffect(() => {
     scrollToTop()
@@ -289,9 +288,11 @@ function NearbyView({
   const filteredNearby = nearby?.filter((n: any) => {
     if (n.place.__typename === 'Stop' && hideEmptyStops) {
       const patternArray = patternArrayforStops(n.place, routeSortComparator)
-      return !(patternArray?.length === 0) && filters[n.place.__typename]
+      return (
+        !(patternArray?.length === 0) && activeNearbyFilters[n.place.__typename]
+      )
     }
-    return filters[n.place.__typename]
+    return activeNearbyFilters[n.place.__typename]
   })
 
   const nearbyItemList =
@@ -405,7 +406,7 @@ function NearbyView({
                   filter={filter}
                   key={filter.cardType}
                   onChange={onFilterChange}
-                  value={filters[filter.cardType]}
+                  value={activeNearbyFilters[filter.cardType]}
                 />
               )
             })}

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -165,6 +165,7 @@ function NearbyView({
   const [loading, setLoading] = useState(true)
   const [reversedPoint, setReversedPoint] = useState('')
   const [filters, setFilters] = useState(
+    // Set the filters according to the configuration settings. If there's no filter config, set the filters to default (which is just all filters set to true)
     filterConfig
       ? Object.fromEntries(
           filterConfig.map((filter: Filter) => [
@@ -175,7 +176,7 @@ function NearbyView({
       : nearbyFilters
   )
 
-  const firstItemRef = useRef<HTMLDivElement>(null)
+  const nearbyContainerRef = useRef<HTMLOListElement>(null)
   const finalNearbyCoords = useMemo(
     () =>
       getNearbyCoordsFromUrlOrLocationOrMapCenter(
@@ -192,12 +193,13 @@ function NearbyView({
       .then((result: Location) => setReversedPoint(result?.name || ''))
   }
 
-  const scrollToTop = () =>
-    window.scrollTo({
+  const scrollToTop = () => {
+    console.log(nearbyContainerRef)
+    nearbyContainerRef?.current?.scroll({
       behavior: 'smooth',
-      left: 0,
       top: 0
     })
+  }
 
   // Make sure the highlighted location is cleaned up when leaving nearby
   useEffect(() => {
@@ -368,7 +370,7 @@ function NearbyView({
           />
         </InvisibleA11yLabel>
       )}
-      <div style={{ padding: filterConfig ? '1em 1em .5em 1em' : '1em' }}>
+      <div style={{ padding: filterConfig ? '1em 1em .75em' : '1em' }}>
         <LocationField
           className="nearby-view-location-field"
           // TODO: why does this cause the jump to the trip planner when selecting location
@@ -426,10 +428,10 @@ function NearbyView({
 
       {loading && <Loading extraSmall />}
       {/* This is used to scroll to top */}
-      <div aria-hidden ref={firstItemRef} />
       <NearbySidebarContainer
         className="base-color-bg"
         filters={filterConfig}
+        ref={nearbyContainerRef}
         style={{ marginBottom: 0 }}
       >
         {nearby &&
@@ -490,7 +492,6 @@ const mapStateToProps = (state: AppReduxState) => {
     hideEmptyStops: config.nearbyView?.hideEmptyStops,
     homeTimezone: config.homeTimezone,
     location: state.router.location.hash,
-    mapConfig: config.map,
     nearby: nearby?.data,
     nearbyFilters: filters,
     nearbyViewCoords,

--- a/lib/components/viewers/nearby/styled.tsx
+++ b/lib/components/viewers/nearby/styled.tsx
@@ -21,7 +21,7 @@ export const NearbySidebarContainer = styled.ol<{ filters: boolean }>`
   padding: 0.5em 1em;
   list-style: none;
   overflow-y: scroll;
-  height: ${(props) => (props.filters ? '85%' : '90%')};
+  height: ${(props) => (props.filters ? '84%' : '90%')};
 
   & > li:last-of-type {
     margin-bottom: 1em;

--- a/lib/components/viewers/nearby/styled.tsx
+++ b/lib/components/viewers/nearby/styled.tsx
@@ -14,14 +14,14 @@ export const FloatingLoadingIndicator = styled.div`
   position: fixed;
 `
 
-export const NearbySidebarContainer = styled.ol`
+export const NearbySidebarContainer = styled.ol<{ filters: boolean }>`
   display: flex;
   flex-direction: column;
   gap: 1em;
   padding: 0.5em 1em;
   list-style: none;
   overflow-y: scroll;
-  height: 90%;
+  height: ${(props) => (props.filters ? '85%' : '90%')};
 
   & > li:last-of-type {
     margin-bottom: 1em;

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -165,6 +165,8 @@ export function getInitialState(userDefinedConfig) {
 
   const sessionId = new URLSearchParams(getUrlParams()).get('sessionId')
 
+  const nearbyFilters = config.nearbyView.filters
+
   return {
     activeSearchId: 0,
     config,
@@ -233,12 +235,21 @@ export function getInitialState(userDefinedConfig) {
       mainPanelContent: null,
       mobileScreen: MobileScreens.WELCOME_SCREEN,
       nearbyView: {
-        filters: {
-          BikeRentalStation: true,
-          RentalVehicle: true,
-          Stop: true,
-          VehicleParking: true
-        }
+        filters:
+          // Set the filters according to the configuration settings. If there's no filter config, set the filters to default (which is just all filters set to true)
+          nearbyFilters
+            ? Object.fromEntries(
+                nearbyFilters.map((filter) => [
+                  filter.cardType,
+                  filter.defaultOn
+                ])
+              )
+            : {
+                BikeRentalStation: true,
+                RentalVehicle: true,
+                Stop: true,
+                VehicleParking: true
+              }
       },
       popup: { id: null },
       printView: window.location.href.indexOf('/print/') !== -1,

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -232,6 +232,14 @@ export function getInitialState(userDefinedConfig) {
       localizedMessages: null,
       mainPanelContent: null,
       mobileScreen: MobileScreens.WELCOME_SCREEN,
+      nearbyView: {
+        filters: {
+          BikeRentalStation: true,
+          RentalVehicle: true,
+          Stop: true,
+          VehicleParking: true
+        }
+      },
       popup: { id: null },
       printView: window.location.href.indexOf('/print/') !== -1,
       routeViewer: {
@@ -1057,6 +1065,15 @@ function createOtpReducer(config) {
           ui: {
             locale: { $set: action.payload.locale },
             localizedMessages: { $set: action.payload.messages }
+          }
+        })
+
+      case 'UPDATE_NEARBY_VIEW_FILTER':
+        return update(state, {
+          ui: {
+            nearbyView: {
+              filters: { $set: action.payload }
+            }
           }
         })
 

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -165,7 +165,7 @@ export function getInitialState(userDefinedConfig) {
 
   const sessionId = new URLSearchParams(getUrlParams()).get('sessionId')
 
-  const nearbyFilters = config.nearbyView.filters
+  const nearbyFilters = config.nearbyView?.filters
 
   return {
     activeSearchId: 0,

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -241,7 +241,7 @@ export function getInitialState(userDefinedConfig) {
             ? Object.fromEntries(
                 nearbyFilters.map((filter) => [
                   filter.cardType,
-                  filter.defaultOn
+                  filter.initiallyShown
                 ])
               )
             : {

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -70,13 +70,13 @@ export type BugsnagConfig = ApiKeyConfig
 export type MapillaryConfig = ApiKeyConfig
 export type NearbyFilterConfig = {
   cardType: 'Stop' | 'RentalVehicle' | 'VehicleParking' | 'BikeRentalStation'
-  defaultOn: boolean
+  default?: boolean
   iconName: string
 }
 
 export type NearbyViewConfig = {
   alwaysShowLongName?: boolean
-  filterConfig?: Array<NearbyFilterConfig>
+  filters?: Array<NearbyFilterConfig>
   hideEmptyStops?: boolean
   radius?: number
   showShadowDotOnMapDrag?: boolean

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -68,9 +68,15 @@ interface ApiKeyConfig {
 
 export type BugsnagConfig = ApiKeyConfig
 export type MapillaryConfig = ApiKeyConfig
+export type NearbyFilterConfig = {
+  cardType: 'Stop' | 'RentalVehicle' | 'VehicleParking' | 'BikeRentalStation'
+  defaultOn: boolean
+  iconName: string
+}
 
 export type NearbyViewConfig = {
   alwaysShowLongName?: boolean
+  filterConfig?: Array<NearbyFilterConfig>
   hideEmptyStops?: boolean
   radius?: number
   showShadowDotOnMapDrag?: boolean

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -18,6 +18,8 @@ import {
 import { ControlPosition } from 'react-map-gl'
 import { GeocoderConfig as GeocoderConfigOtpUI } from '@opentripplanner/geocoder'
 
+import { NearbyFilterKey } from './state-types'
+
 /** Accessibility threshold settings */
 export interface AccessibilityScoreThresholdConfig {
   color: string
@@ -69,7 +71,7 @@ interface ApiKeyConfig {
 export type BugsnagConfig = ApiKeyConfig
 export type MapillaryConfig = ApiKeyConfig
 export type NearbyFilterConfig = {
-  cardType: 'Stop' | 'RentalVehicle' | 'VehicleParking' | 'BikeRentalStation'
+  cardType: NearbyFilterKey
   default?: boolean
   iconName: string
 }

--- a/lib/util/state-types.ts
+++ b/lib/util/state-types.ts
@@ -5,9 +5,9 @@ import {
   MonitoredTrip,
   User
 } from '../components/user/types'
-import { ModeSetting } from '@opentripplanner/types'
+import { Leg, Location, ModeSetting } from '@opentripplanner/types'
 
-import { AppConfig } from './config-types'
+import { AppConfig, PopupTargetConfig } from './config-types'
 
 export type NearbyFilterKey =
   | 'Stop'
@@ -15,6 +15,8 @@ export type NearbyFilterKey =
   | 'VehicleParking'
   | 'BikeRentalStation'
 export type NearbyFilters = Record<NearbyFilterKey, boolean>
+
+export type LatLonObj = { lat: number; lon: number }
 
 export interface OtpState {
   // TODO: Add other OTP states
@@ -30,12 +32,28 @@ export interface OtpState {
     start: number
   }
   transitIndex: any
-  // TODO: Add other OTP states
+  // TODO: Finish ui typing
   ui: {
+    diagramLeg: Leg
+    errors: any
+    highlightedLocation: Location | null
+    highlightedStop: any
+    locale: string
+    localizedMessages: any
+    mainPanelContent: number
+    mobileScreen: number
     nearbyView: {
       filters: NearbyFilters
     }
-    nearbyViewCoords: any
+    nearbyViewCoords: LatLonObj
+    popup: PopupTargetConfig
+    printView: boolean
+    routeViewer: any
+    viewedRoute: {
+      patternId: string
+      routeId: string
+    }
+    viewedStop?: any
   }
 }
 

--- a/lib/util/state-types.ts
+++ b/lib/util/state-types.ts
@@ -9,6 +9,13 @@ import { ModeSetting } from '@opentripplanner/types'
 
 import { AppConfig } from './config-types'
 
+export type NearbyFilterKey =
+  | 'Stop'
+  | 'RentalVehicle'
+  | 'VehicleParking'
+  | 'BikeRentalStation'
+export type NearbyFilters = Record<NearbyFilterKey, boolean>
+
 export interface OtpState {
   // TODO: Add other OTP states
   activeSearchId?: string
@@ -24,7 +31,12 @@ export interface OtpState {
   }
   transitIndex: any
   // TODO: Add other OTP states
-  ui: any // TODO
+  ui: {
+    nearbyView?: {
+      filters?: NearbyFilters
+    }
+    nearbyViewCoords: any
+  }
 }
 
 export interface SortType {

--- a/lib/util/state-types.ts
+++ b/lib/util/state-types.ts
@@ -32,8 +32,8 @@ export interface OtpState {
   transitIndex: any
   // TODO: Add other OTP states
   ui: {
-    nearbyView?: {
-      filters?: NearbyFilters
+    nearbyView: {
+      filters: NearbyFilters
     }
     nearbyViewCoords: any
   }


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Adds configurable filtering inside the nearby view that corresponds to the card types in nearby view. Also filters map layers and removes the layers list in nearby in cases where the filtering config is active.

Curious if folks feel like we need some key value pairs for these card values? Using "Stop" "RentalVehicle" etc for all these values feels a little messy.


<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<img width="941" height="810" alt="image" src="https://github.com/user-attachments/assets/46800a12-afbf-4eed-82c8-9477397c1e11" />


<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

