### PR TITLE
fix default browser language for tagalog

### DIFF
--- a/lib/util/i18n.js
+++ b/lib/util/i18n.js
@@ -104,9 +104,11 @@ export function getDefaultLocale(config, loggedInUser) {
   const browserLocale =
     window.localStorage.getItem('lang') || navigator.language
 
+  const correctedBrowserLocale = browserLocale === 'fil' ? 'tl' : browserLocale
+
   return (
     loggedInUser?.preferredLocale ||
-    browserLocale ||
+    correctedBrowserLocale ||
     localization.defaultLocale ||
     'en-US'
   )


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

We take the browser locale when we start the app, but on some browsers Filipino is an option and Tagalog is not. This sets the app language to tagalog if the preferred language is filipino

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

