### PR TITLE
Monitored Trips: Remove OTP1 query params

### DIFF
--- a/lib/actions/user.js
+++ b/lib/actions/user.js
@@ -735,39 +735,47 @@ export function getDependentUserInfo(userIds, intl) {
 }
 
 /**
+ * Constructs OTP-RR URL query params from a monitored trip's OTP2 query params.
+ */
+function queryParamsFromTrip(config, monitoredTrip) {
+  const { homeTimezone, modes: configModes } = config
+  const { arriveBy, fromPlace, modes, time, toPlace } =
+    monitoredTrip.otp2QueryParams
+  const tripModes = modes.map(({ mode }) => mode)
+  const isTripTransit = !!tripModes.find(isTransit)
+
+  const selectedButtons = new Set()
+  configModes.modeButtons.forEach(({ modes }) => {
+    modes.forEach(({ mode }) => {
+      if (isTripTransit && isTransit(mode)) {
+        selectedButtons.add('transit')
+      } else if (tripModes.includes(mode)) {
+        // walk, bike, car (does not include rentals or special modes)
+        selectedButtons.add(mode.toLowerCase())
+      }
+    })
+  })
+
+  return {
+    arriveBy,
+    date: getCurrentDate(homeTimezone),
+    fromPlace,
+    modeButtons: [...selectedButtons].join('_'),
+    time,
+    toPlace
+  }
+}
+
+/**
  * Plans a new trip for the current date using the OTP2 query parameters in the given
  * monitored trip.
  */
 export function planNewTripFromMonitoredTrip(monitoredTrip) {
   return function (dispatch, getState) {
-    const { homeTimezone, modes: configModes } = getState().otp.config
-    const { arriveBy, fromPlace, modes, time, toPlace } =
-      monitoredTrip.otp2QueryParams
-    const tripModes = modes.map(({ mode }) => mode)
-    const isTripTransit = !!tripModes.find(isTransit)
-
-    const selectedButtons = new Set()
-    configModes.modeButtons.forEach(({ modes }) => {
-      modes.forEach(({ mode }) => {
-        if (isTripTransit && isTransit(mode)) {
-          selectedButtons.add('transit')
-        } else if (tripModes.includes(mode)) {
-          // walk, bike, car (does not include rentals or special modes)
-          selectedButtons.add(mode.toLowerCase())
-        }
-      })
-    })
-    const newQuery = {
-      arriveBy,
-      date: getCurrentDate(homeTimezone),
-      fromPlace,
-      modeButtons: [...selectedButtons].join('_'),
-      time,
-      toPlace
-    }
-
     dispatch(routeTo('/', ''))
-    dispatch(setUrlSearch(newQuery))
+    dispatch(
+      setUrlSearch(queryParamsFromTrip(getState().otp.config, monitoredTrip))
+    )
 
     // This prevents some kind of race condition whose origin I can't figure
     // out. Unless this is called after redux catches up with routing to the '/'

--- a/lib/actions/user.js
+++ b/lib/actions/user.js
@@ -734,8 +734,8 @@ export function getDependentUserInfo(userIds, intl) {
 }
 
 /**
- * Plans a new trip for the current date given the query parameters in the given
- * monitored trip
+ * Plans a new trip for the current date using the OTP2 query parameters in the given
+ * monitored trip.
  */
 export function planNewTripFromMonitoredTrip(monitoredTrip) {
   return function (dispatch, getState) {

--- a/lib/actions/user.js
+++ b/lib/actions/user.js
@@ -739,9 +739,14 @@ export function getDependentUserInfo(userIds, intl) {
  */
 export function planNewTripFromMonitoredTrip(monitoredTrip) {
   return function (dispatch, getState) {
-    // update query params in store
-    const newQuery = planParamsToQuery(qs.parse(monitoredTrip.queryParams))
-    newQuery.date = getCurrentDate(getState().otp.config.homeTimezone)
+    const { arriveBy, fromPlace, time, toPlace } = monitoredTrip.otp2QueryParams
+    const newQuery = planParamsToQuery({
+      arriveBy,
+      date: getCurrentDate(getState().otp.config.homeTimezone),
+      fromPlace,
+      time,
+      toPlace
+    })
 
     dispatch(routeTo('/', ''))
     dispatch(setQueryParam(newQuery))

--- a/lib/actions/user.js
+++ b/lib/actions/user.js
@@ -24,11 +24,12 @@ import { secureFetch } from '../util/middleware'
 import { TRIPS_PATH } from '../util/constants'
 
 import { routeTo, setLocale } from './ui'
-import { routingQuery } from './api'
+import { routingQuery, setUrlSearch } from './api'
 import { setQueryParam } from './form'
 
 const { planParamsToQuery } = coreUtils.query
 const { getCurrentDate } = coreUtils.time
+const { isTransit } = coreUtils.itinerary
 
 // Middleware API paths.
 const API_MONITORED_TRIP_PATH = '/api/secure/monitoredtrip'
@@ -739,17 +740,34 @@ export function getDependentUserInfo(userIds, intl) {
  */
 export function planNewTripFromMonitoredTrip(monitoredTrip) {
   return function (dispatch, getState) {
-    const { arriveBy, fromPlace, time, toPlace } = monitoredTrip.otp2QueryParams
-    const newQuery = planParamsToQuery({
+    const { homeTimezone, modes: configModes } = getState().otp.config
+    const { arriveBy, fromPlace, modes, time, toPlace } =
+      monitoredTrip.otp2QueryParams
+    const tripModes = modes.map(({ mode }) => mode)
+    const isTripTransit = !!tripModes.find(isTransit)
+
+    const selectedButtons = new Set()
+    configModes.modeButtons.forEach(({ modes }) => {
+      modes.forEach(({ mode }) => {
+        if (isTripTransit && isTransit(mode)) {
+          selectedButtons.add('transit')
+        } else if (tripModes.includes(mode)) {
+          // walk, bike, car (does not include rentals or special modes)
+          selectedButtons.add(mode.toLowerCase())
+        }
+      })
+    })
+    const newQuery = {
       arriveBy,
-      date: getCurrentDate(getState().otp.config.homeTimezone),
+      date: getCurrentDate(homeTimezone),
       fromPlace,
+      modeButtons: [...selectedButtons].join('_'),
       time,
       toPlace
-    })
+    }
 
     dispatch(routeTo('/', ''))
-    dispatch(setQueryParam(newQuery))
+    dispatch(setUrlSearch(newQuery))
 
     // This prevents some kind of race condition whose origin I can't figure
     // out. Unless this is called after redux catches up with routing to the '/'

--- a/lib/components/user/monitored-trip/saved-trip-screen.js
+++ b/lib/components/user/monitored-trip/saved-trip-screen.js
@@ -61,8 +61,7 @@ class SavedTripScreen extends Component {
    * Initializes a monitored trip object from the props.
    */
   _createMonitoredTrip = () => {
-    const { currentQuery, homeTimezone, itinerary, loggedInUser, queryParams } =
-      this.props
+    const { currentQuery, homeTimezone, itinerary, loggedInUser } = this.props
     const monitoredDays = getItineraryDefaultMonitoredDays(
       itinerary,
       homeTimezone
@@ -88,10 +87,6 @@ class SavedTripScreen extends Component {
       leadTimeInMinutes: 30,
       otp2QueryParams,
       primary: primaryTraveler,
-      // when creating a monitored trip, the query params will be changed on the
-      // backend so that the modes parameter will reflect the modes seen in the
-      // itinerary
-      queryParams,
       tripName: '',
       // FIXME: Handle populating/checking userID from middleware too,
       // so that providing this field is no longer needed.
@@ -308,7 +303,6 @@ const mapStateToProps = (state, ownProps) => {
     loggedInUser: state.user.loggedInUser,
     monitoredTrips: state.user.loggedInUserMonitoredTrips,
     pending,
-    queryParams: state.router.location.search,
     tripId
   }
 }

--- a/lib/components/user/types.ts
+++ b/lib/components/user/types.ts
@@ -93,7 +93,6 @@ export type MonitoredTrip = Record<DaysOfWeek, boolean> & {
   observers?: CompanionInfo[]
   otp2QueryParams: Record<string, unknown>
   primary?: DependentInfo
-  queryParams: Record<string, unknown>
   secondary?: CompanionInfo
   tripName: string
   userId: string


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
## Description

This PR removes usage of the OTP1 `queryParams` in `MonitoredTrip`.
OTP-RR query params are re-generated using the field `otp2queryParams` instead.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
## PR Checklist
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

