### PR TITLE
Fix pattern filtering

### DIFF
--- a/lib/components/viewers/route-row.tsx
+++ b/lib/components/viewers/route-row.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 
 import { blue } from '../util/colors'
 import { ComponentContext } from '../../util/contexts'
+import { extractMainHeadsigns } from '../../util/pattern-viewer'
 import { getFormattedMode } from '../../util/i18n'
 import { getModeFromRoute } from '../../util/viewer'
 import { Icon } from '../util/styledIcon'
@@ -167,7 +168,8 @@ export class RouteRow extends PureComponent<Props> {
     const { id, longName, mode, patterns, shortName } = route
     const modeFromRoute = getModeFromRoute(route)
     const routePath = `/route/${id}`
-    const firstPattern = patterns && Object.values(patterns)?.[0]?.id
+    const firstPattern =
+      patterns && extractMainHeadsigns(patterns, shortName, () => '')?.[0]?.id
 
     const patternViewerLinkText = intl.formatMessage({
       description: 'identifies the purpose of the pattern viewer button',

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -26,7 +26,7 @@ export function extractMainHeadsigns(
   // Address duplicate headsigns.
   return mapped.reduce((prev: PatternSummary[], cur) => {
     const amended = prev
-    let alreadyExistingIndex = prev.findIndex(
+    const alreadyExistingIndex = prev.findIndex(
       (h) => h.headsign === cur.headsign
     )
     // With all duplicate headsigns with the same last stops, only keep the pattern with the
@@ -37,8 +37,8 @@ export function extractMainHeadsigns(
     ) {
       if (amended[alreadyExistingIndex].geometryLength < cur.geometryLength) {
         amended[alreadyExistingIndex] = cur
-        // If we've addressed the alreadyExistingIndex, set it back to -1
-        alreadyExistingIndex = -1
+        // If we're replacing the already existing index, no need to continue
+        return amended
       }
     } else {
       amended.push(cur)

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -26,12 +26,23 @@ export function extractMainHeadsigns(
   // Address duplicate headsigns.
   return mapped.reduce((prev: PatternSummary[], cur) => {
     const amended = prev
-    const alreadyExistingIndex = prev.findIndex(
+    let alreadyExistingIndex = prev.findIndex(
       (h) => h.headsign === cur.headsign
     )
-    // If the headsign is a duplicate, and the last stop of the pattern is not the headsign,
-    // amend the headsign with the last stop name in parenthesis.
-    // e.g. "Headsign (Last Stop)"
+    // With all duplicate headsigns with the same last stops, only keep the pattern with the
+    // longest geometry.
+    if (
+      alreadyExistingIndex >= 0 &&
+      amended[alreadyExistingIndex].lastStop === cur.lastStop
+    ) {
+      if (amended[alreadyExistingIndex].geometryLength < cur.geometryLength) {
+        amended[alreadyExistingIndex] = cur
+        // If we've addressed the alreadyExistingIndex, set it back to -1
+        alreadyExistingIndex = -1
+      }
+    } else {
+      amended.push(cur)
+    }
     if (
       alreadyExistingIndex >= 0 &&
       cur.lastStop &&
@@ -48,18 +59,6 @@ export function extractMainHeadsigns(
       }
     }
 
-    // With all remaining duplicate headsigns with the same last stops, only keep the pattern with the
-    // longest geometry.
-    if (
-      alreadyExistingIndex >= 0 &&
-      amended[alreadyExistingIndex].lastStop === cur.lastStop
-    ) {
-      if (amended[alreadyExistingIndex].geometryLength < cur.geometryLength) {
-        amended[alreadyExistingIndex] = cur
-      }
-    } else {
-      amended.push(cur)
-    }
     return amended
   }, [])
 }

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -29,24 +29,14 @@ export function extractMainHeadsigns(
     const alreadyExistingIndex = prev.findIndex(
       (h) => h.headsign === cur.headsign
     )
-    // With all duplicate headsigns with the same last stops, only keep the pattern with the
-    // longest geometry.
-    if (
-      alreadyExistingIndex >= 0 &&
-      amended[alreadyExistingIndex].lastStop === cur.lastStop
-    ) {
-      if (amended[alreadyExistingIndex].geometryLength < cur.geometryLength) {
-        amended[alreadyExistingIndex] = cur
-        // If we're replacing the already existing index, no need to continue
-        return amended
-      }
-    } else {
-      amended.push(cur)
-    }
+
+    // If we encounter a duplicate headisgn, we may rename it in the case that the last stop is different than the headsign
     if (
       alreadyExistingIndex >= 0 &&
       cur.lastStop &&
-      cur.headsign !== cur.lastStop
+      cur.headsign !== cur.lastStop &&
+      // If the last stop is different than the headsign but the same as the last stop of the previously existing duplicate, there's no point in renaming.
+      cur.lastStop !== amended[alreadyExistingIndex].lastStop
     ) {
       editHeadsign(cur)
 
@@ -57,6 +47,20 @@ export function extractMainHeadsigns(
         amended.push(cur)
         return amended
       }
+    }
+
+    // With all duplicate headsigns with the same last stops, only keep the pattern with the
+    // longest geometry.
+    if (
+      alreadyExistingIndex >= 0 &&
+      amended[alreadyExistingIndex].lastStop === cur.lastStop
+    ) {
+      if (amended[alreadyExistingIndex].geometryLength < cur.geometryLength) {
+        amended[alreadyExistingIndex] = cur
+        // If we're replacing the already existing index, no need to continue
+      }
+    } else {
+      amended.push(cur)
     }
 
     return amended

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -29,7 +29,6 @@ export function extractMainHeadsigns(
     const alreadyExistingIndex = prev.findIndex(
       (h) => h.headsign === cur.headsign
     )
-
     // If we encounter a duplicate headisgn, we may rename it in the case that the last stop is different than the headsign
     if (
       alreadyExistingIndex >= 0 &&
@@ -62,7 +61,6 @@ export function extractMainHeadsigns(
     } else {
       amended.push(cur)
     }
-
     return amended
   }, [])
 }

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -29,7 +29,9 @@ export function extractMainHeadsigns(
     const alreadyExistingIndex = prev.findIndex(
       (h) => h.headsign === cur.headsign
     )
-    // If we encounter a duplicate headisgn, we may rename it in the case that the last stop is different than the headsign
+    // If the headsign is a duplicate, and the last stop of the pattern is not the headsign,
+    // amend the headsign with the last stop name in parenthesis.
+    // e.g. "Headsign (Last Stop)"
     if (
       alreadyExistingIndex >= 0 &&
       cur.lastStop &&
@@ -48,7 +50,7 @@ export function extractMainHeadsigns(
       }
     }
 
-    // With all duplicate headsigns with the same last stops, only keep the pattern with the
+    // With all remaining duplicate headsigns with the same last stops, only keep the pattern with the
     // longest geometry.
     if (
       alreadyExistingIndex >= 0 &&
@@ -56,7 +58,6 @@ export function extractMainHeadsigns(
     ) {
       if (amended[alreadyExistingIndex].geometryLength < cur.geometryLength) {
         amended[alreadyExistingIndex] = cur
-        // If we're replacing the already existing index, no need to continue
       }
     } else {
       amended.push(cur)


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
- Fixes an issue where patterns were being renamed unnecessarily after all other duplicates were filtered out
- Route viewer will now filter patterns before selecting a pattern to pass to the pattern viewer. This will prevent pattern viewer opening with an unnamed pattern and "select a direction..." in the dropdown.

Here is the updated order of operations when filtering duplicate patterns. Changes are in italics.
- Duplicate patterns are defined as "patterns with the same name"
- We rename patterns that have last stops that are a) different than the headsign and b) _different than the last stop of the previously encountered duplicate headsign._
- The renamed headsign is named "headsign (last stop)"
- If duplicate headsigns have the same last stop, we filter out all but the one with the longest geometry. 

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

