### PR TITLE
Include route.shortname in the transitive route label

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -167,7 +167,7 @@ const components = {
    * @returns A string with the custom label to display for the given leg, or null to render no label.
    */
   getTransitiveRouteLabel: (itineraryLeg) => {
-    return itineraryLeg.routeShortName // null or undefined or empty string will tell transitive-js to not render a route label.
+    return itineraryLeg.routeShortName || itineraryLeg.route.shortName // null or undefined or empty string will tell transitive-js to not render a route label.
   },
 
   ItineraryBody: DefaultItinerary,

--- a/lib/app.js
+++ b/lib/app.js
@@ -167,7 +167,7 @@ const components = {
    * @returns A string with the custom label to display for the given leg, or null to render no label.
    */
   getTransitiveRouteLabel: (itineraryLeg) => {
-    return itineraryLeg.routeShortName || itineraryLeg.route.shortName // null or undefined or empty string will tell transitive-js to not render a route label.
+    return itineraryLeg.routeShortName || itineraryLeg.route?.shortName // null or undefined or empty string will tell transitive-js to not render a route label.
   },
 
   ItineraryBody: DefaultItinerary,


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Make sure all available short names are passed to transitive overlay. 

A follow up OTP-UI PR is needed because the comment on this line (that a blank string will render no label) is not the case with the new transitive overlay bubbles.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

