### PR TITLE
Set User's Preferred Language in Auth0 Metadata

### DIFF
--- a/example/example-config.yml
+++ b/example/example-config.yml
@@ -83,6 +83,10 @@ persistence:
 #  auth0:
 #    domain: your-auth0-domain
 #    clientId: your-auth0-client-id
+###  Management API credentials are required to update user metadata
+#    managementApi:
+#      clientId: your-auth0-management-api-client-id  
+#      clientSecret: your-auth0-management-api-client-secret
 #  otp_middleware:
 #    apiBaseUrl: https://otp-middleware.example.com
 #    apiKey: your-middleware-api-key

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -470,7 +470,7 @@ export function setLocale(locale, isUpdatingLocale = false) {
 
       if (loggedInUser) {
         loggedInUser.preferredLocale = matchedLocale
-        await dispatch(createOrUpdateUser(loggedInUser))
+        await dispatch(createOrUpdateUser(loggedInUser, null, true))
       }
 
       if (isUpdatingLocale) {

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -1,7 +1,6 @@
 import { createAction } from 'redux-actions'
 import { matchPath } from 'react-router'
 import { push } from 'connected-react-router'
-import { useIntl } from 'react-intl'
 import coreUtils from '@opentripplanner/core-utils'
 
 import {
@@ -444,7 +443,6 @@ export function showMobileSearchScreen() {
  */
 export function setLocale(locale, isUpdatingLocale = false) {
   return async function (dispatch, getState) {
-    const intl = useIntl()
     const { otp, user } = getState()
     const { config, ui } = otp
     const { loggedInUser } = user
@@ -472,7 +470,7 @@ export function setLocale(locale, isUpdatingLocale = false) {
 
       if (loggedInUser) {
         loggedInUser.preferredLocale = matchedLocale
-        await dispatch(createOrUpdateUser(loggedInUser, intl, true))
+        await dispatch(createOrUpdateUser(loggedInUser, null, true))
       }
 
       if (isUpdatingLocale) {

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -1,6 +1,7 @@
 import { createAction } from 'redux-actions'
 import { matchPath } from 'react-router'
 import { push } from 'connected-react-router'
+import { useIntl } from 'react-intl'
 import coreUtils from '@opentripplanner/core-utils'
 
 import {
@@ -443,6 +444,7 @@ export function showMobileSearchScreen() {
  */
 export function setLocale(locale, isUpdatingLocale = false) {
   return async function (dispatch, getState) {
+    const intl = useIntl()
     const { otp, user } = getState()
     const { config, ui } = otp
     const { loggedInUser } = user
@@ -470,7 +472,7 @@ export function setLocale(locale, isUpdatingLocale = false) {
 
       if (loggedInUser) {
         loggedInUser.preferredLocale = matchedLocale
-        await dispatch(createOrUpdateUser(loggedInUser, null, true))
+        await dispatch(createOrUpdateUser(loggedInUser, intl, true))
       }
 
       if (isUpdatingLocale) {

--- a/lib/actions/user.js
+++ b/lib/actions/user.js
@@ -373,25 +373,99 @@ export function fetchOrInitializeUser(auth0User) {
 }
 
 /**
+ * This convenience method wraps a fetch call to the Auth0 API.
+ * @param {string} url The URL to call.
+ * @param {object} headers If non-null, the Authorization token to add to request header.
+ * @param {object} body If non-null, the API key to add to the Authorization header.
+ * @param {string} method The HTTP method to execute.
+ * @return {object} The JSON response or an error object.
+ */
+async function secureAuth0Fetch(url, headers, body, method) {
+  let data
+  try {
+    const response = await fetch(url, {
+      body,
+      headers,
+      method
+    })
+    data = await response.json()
+  } catch (error) {
+    return error
+  }
+  return data
+}
+
+/**
+ * Updates the user's preferred language in the Auth0 user metadata so that
+ * Auth0 emails (e.g. password reset emails) are sent in the correct language.
+ * @param userData the user entry to persist.
+ * @param auth0Config the auth0 client confirguration from config.yml
+ */
+async function setAuth0UserLocale(userData, auth0Config) {
+  const { auth0UserId } = userData
+  const { clientId, clientSecret } = auth0Config.managementApi
+  const domain = auth0Config.domain
+
+  // Auth0 Management call to get access token.
+  const tokenResponse = await secureAuth0Fetch(
+    `https://${domain}/oauth/token`,
+    { 'content-type': 'application/x-www-form-urlencoded' },
+    new URLSearchParams({
+      audience: `https://${domain}/api/v2/`,
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: 'client_credentials'
+    }),
+    'POST'
+  )
+
+  const ACCESS_TOKEN = tokenResponse?.access_token
+
+  if (!ACCESS_TOKEN) {
+    console.error(tokenResponse)
+    return
+  }
+
+  // Once Access Token is obtained, set language in user metadata.
+  await secureAuth0Fetch(
+    `https://${domain}/api/v2/users/${auth0UserId}`,
+    {
+      authorization: `Bearer ${ACCESS_TOKEN}`,
+      'content-type': 'application/json'
+    },
+    JSON.stringify({
+      user_metadata: { lang: userData.preferredLocale }
+    }),
+    'PATCH'
+  )
+}
+
+/**
  * Updates (or creates) a user entry in the middleware,
  * then, if that was successful, updates the redux state with that user.
  * @param userData the user entry to persist.
  * @param intl the react-intl formatter
  */
-export function createOrUpdateUser(userData, intl) {
+export function createOrUpdateUser(userData, intl, updateMetadata = false) {
   return async function (dispatch, getState) {
     const { accessToken, apiBaseUrl, apiKey, loggedInUser } =
       getMiddlewareVariables(getState())
     const { id } = userData // Middleware ID, NOT auth0 (or similar) id.
     let method, requestUrl
+    const auth0Config = getState().otp.config.persistence.auth0
 
     // Before persisting, filter out entries from userData.savedLocations with blank addresses.
     userData.savedLocations = userData.savedLocations.filter(
       ({ address }) => !isBlank(address)
     )
+    const isCreatingUser = isNewUser(loggedInUser)
+
+    // Update user language in auth0 when first creating user or when language changes
+    if (updateMetadata || isCreatingUser) {
+      setAuth0UserLocale(userData, auth0Config)
+    }
 
     // Determine URL and method to use.
-    const isCreatingUser = isNewUser(loggedInUser)
     if (isCreatingUser) {
       requestUrl = `${apiBaseUrl}${API_OTPUSER_PATH}`
       method = 'POST'

--- a/lib/actions/user.js
+++ b/lib/actions/user.js
@@ -455,7 +455,7 @@ export function createOrUpdateUser(userData, intl, updateMetadata = false) {
     const auth0Config = getState().otp.config.persistence.auth0
     const { managementApi } = auth0Config
     const { clientId, clientSecret } = managementApi || {}
-    // Make sure we have all the credentials in the config to update the metatdata.
+    // Make sure we have all the credentials in the config to update the metadata.
     const hasManagemenentApiCredentials = clientId && clientSecret
 
     // Before persisting, filter out entries from userData.savedLocations with blank addresses.

--- a/lib/actions/user.js
+++ b/lib/actions/user.js
@@ -375,8 +375,8 @@ export function fetchOrInitializeUser(auth0User) {
 /**
  * This convenience method wraps a fetch call to the Auth0 API.
  * @param {string} url The URL to call.
- * @param {object} headers If non-null, the Authorization token to add to request header.
- * @param {object} body If non-null, the API key to add to the Authorization header.
+ * @param {object} headers Header for fetch request.
+ * @param {object} body Body for fetch request.
  * @param {string} method The HTTP method to execute.
  * @return {object} The JSON response or an error object.
  */
@@ -398,8 +398,8 @@ async function secureAuth0Fetch(url, headers, body, method) {
 /**
  * Updates the user's preferred language in the Auth0 user metadata so that
  * Auth0 emails (e.g. password reset emails) are sent in the correct language.
- * @param userData the user entry to persist.
- * @param auth0Config the auth0 client confirguration from config.yml
+ * @param userData the user information.
+ * @param auth0Config the auth0 client configuration from config.yml
  */
 async function setAuth0UserLocale(userData, auth0Config) {
   const { auth0UserId } = userData
@@ -453,6 +453,10 @@ export function createOrUpdateUser(userData, intl, updateMetadata = false) {
     const { id } = userData // Middleware ID, NOT auth0 (or similar) id.
     let method, requestUrl
     const auth0Config = getState().otp.config.persistence.auth0
+    const { managementApi } = auth0Config
+    const { clientId, clientSecret } = managementApi || {}
+    // Make sure we have all the credentials in the config to update the metatdata.
+    const hasManagemenentApiCredentials = clientId && clientSecret
 
     // Before persisting, filter out entries from userData.savedLocations with blank addresses.
     userData.savedLocations = userData.savedLocations.filter(
@@ -461,7 +465,7 @@ export function createOrUpdateUser(userData, intl, updateMetadata = false) {
     const isCreatingUser = isNewUser(loggedInUser)
 
     // Update user language in auth0 when first creating user or when language changes
-    if (updateMetadata || isCreatingUser) {
+    if (hasManagemenentApiCredentials && (updateMetadata || isCreatingUser)) {
       setAuth0UserLocale(userData, auth0Config)
     }
 

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -98,6 +98,10 @@ export interface Auth0Config {
   audience: string
   clientId: string
   domain: string
+  managementApi?: {
+    clientId: string
+    clientSecret: string
+  }
 }
 
 /** Local persistence setting */


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Auth0 can translate account emails into different languages, but only if it has the user's preferred language set in the account metadata. This new method fetches a token from the management API, and uses that token to set the user's account metadata to include the preferred language. This is fired whenever a user creates a new account or if the language changes.

THINGS TO CONSIDER:
- Should this new fetch method be combined with `secureFetch`?
- The account token fetched from the management API expires after 24 hours. Should this be cached in the user info in the middleware? It seems unlikely a user will be changing their language multiple times a day.


<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

