### PR TITLE
Only format en-US.yml

### DIFF
--- a/package.json
+++ b/package.json
@@ -240,7 +240,7 @@
     "*.{js,jsx,ts,tsx}": [
       "eslint --fix"
     ],
-    "i18n/*.{yml,yaml}": [
+    "i18n/en-US.yml": [
       "yaml-sort --quotingStyle double --input"
     ]
   },


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

This PR removes formatting-on-commit for all language files except `en-US.yml`.
This is to reduce formatting-only changes in PRs from Weblate (see e.g. #1476),
as Weblate uses its own formatting tool that seems to bypass the formatting hook that was previously set up.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

