### PR TITLE
Support OTP2 `via` -- Migrate from deprecated fields

### DIFF
--- a/lib/components/form/intermediate-place-field.tsx
+++ b/lib/components/form/intermediate-place-field.tsx
@@ -34,6 +34,8 @@ class IntermediatePlaceField extends Component<Props> {
       <StyledLocationField
         {...this.props}
         clearLocation={this._removeIntermediatePlace}
+        // @ts-expect-error location-field is incorrectly typed. Why are there two GeocoderConfig types with different contents?
+        geocoderConfig={{ ...this.props.geocoderConfig, layers: 'stops' }}
         locationType={`intermediate-place-${index}`}
       />
     )


### PR DESCRIPTION
Relies on https://github.com/opentripplanner/otp-ui/pull/887

Current issues:
- [ ] seems to not do anything? is the field broken?
- [ ] need to get the feed scope into the function somehow
- [ ] why does the rewrite seem to happen randomly? need to figure out when that's happening and why