### PR TITLE
Keep Russian from breaking mobile layout

### DIFF
--- a/lib/components/user/phone-change-form.tsx
+++ b/lib/components/user/phone-change-form.tsx
@@ -26,6 +26,7 @@ import { ControlStrip, phoneFieldStyle } from './styled'
 
 // Styles
 const InlinePhoneInput = styled(Input)`
+  margin-top: 5px;
   ${phoneFieldStyle}
 `
 

--- a/lib/components/user/styled.ts
+++ b/lib/components/user/styled.ts
@@ -115,12 +115,16 @@ export const ControlStrip = styled.span`
   & > * {
     margin-right: 4px;
   }
+
+  button {
+    text-wrap: wrap;
+    margin-top: 5px;
+  }
 `
 /** Styles for phone editing fields */
 export const phoneFieldStyle = css`
   display: inline-block;
   vertical-align: middle;
-  width: 14em;
 `
 
 export const UnstyledLink = styled(Link)`


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Tweak some styling in the phone form so that Russian does not break the layout

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
|<img width="376" height="422" alt="image" src="https://github.com/user-attachments/assets/c51c2516-932e-4a31-bce5-d243161b5573" />|<img width="379" height="509" alt="image" src="https://github.com/user-attachments/assets/ff9e60e0-a39f-40e7-bb8f-5644134cf845" />|

