### PR TITLE
Fix Route Renderer Data

### DIFF
--- a/__tests__/components/viewers/__snapshots__/nearby-view.js.snap
+++ b/__tests__/components/viewers/__snapshots__/nearby-view.js.snap
@@ -12926,14 +12926,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "45",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "45",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -13752,14 +13763,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "62",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "62",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -14508,14 +14530,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "79",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "79",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -19744,14 +19777,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Sound Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "40:40",
+                                                      "name": "Sound Transit",
+                                                    },
                                                     "mode": "TRAM",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": "28813F",
-                                                    "routeLongName": "Northgate - Angle Lake",
-                                                    "routeShortName": "1 Line",
-                                                    "routeTextColor": "FFFFFF",
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "40:40",
+                                                        "name": "Sound Transit",
+                                                      },
+                                                      "color": "28813F",
+                                                      "longName": "Northgate - Angle Lake",
+                                                      "mode": "TRAM",
+                                                      "shortName": "1 Line",
+                                                      "textColor": "FFFFFF",
+                                                      "type": 0,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -20443,14 +20487,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Sound Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "40:40",
+                                                      "name": "Sound Transit",
+                                                    },
                                                     "mode": "TRAM",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": "28813F",
-                                                    "routeLongName": "Northgate - Angle Lake",
-                                                    "routeShortName": "1 Line",
-                                                    "routeTextColor": "FFFFFF",
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "40:40",
+                                                        "name": "Sound Transit",
+                                                      },
+                                                      "color": "28813F",
+                                                      "longName": "Northgate - Angle Lake",
+                                                      "mode": "TRAM",
+                                                      "shortName": "1 Line",
+                                                      "textColor": "FFFFFF",
+                                                      "type": 0,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -20945,14 +21000,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Sound Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "40:40",
+                                                      "name": "Sound Transit",
+                                                    },
                                                     "mode": "TRAM",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": "28813F",
-                                                    "routeLongName": "Northgate - Angle Lake",
-                                                    "routeShortName": "1 Line",
-                                                    "routeTextColor": "FFFFFF",
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "40:40",
+                                                        "name": "Sound Transit",
+                                                      },
+                                                      "color": "28813F",
+                                                      "longName": "Northgate - Angle Lake",
+                                                      "mode": "TRAM",
+                                                      "shortName": "1 Line",
+                                                      "textColor": "FFFFFF",
+                                                      "type": 0,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -30614,14 +30680,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "45",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "45",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -31453,14 +31530,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "62",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "62",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -32214,14 +32302,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "79",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "79",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -32913,14 +33012,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "988",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "988",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -40009,14 +40119,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "67",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "67",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -40830,14 +40951,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "73",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "73",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -41529,14 +41661,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "984",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "984",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -48959,14 +49102,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Sound Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "40:40",
+                                                      "name": "Sound Transit",
+                                                    },
                                                     "mode": "TRAM",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": "28813F",
-                                                    "routeLongName": "Northgate - Angle Lake",
-                                                    "routeShortName": "1 Line",
-                                                    "routeTextColor": "FFFFFF",
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "40:40",
+                                                        "name": "Sound Transit",
+                                                      },
+                                                      "color": "28813F",
+                                                      "longName": "Northgate - Angle Lake",
+                                                      "mode": "TRAM",
+                                                      "shortName": "1 Line",
+                                                      "textColor": "FFFFFF",
+                                                      "type": 0,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -57282,14 +57436,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Sound Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:40",
+                                                      "name": "Sound Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": "2B376E",
-                                                    "routeLongName": null,
-                                                    "routeShortName": "522",
-                                                    "routeTextColor": "FFFFFF",
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:40",
+                                                        "name": "Sound Transit",
+                                                      },
+                                                      "color": "2B376E",
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "522",
+                                                      "textColor": "FFFFFF",
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -58033,14 +58198,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "67",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "67",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -58789,14 +58965,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Sound Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:40",
+                                                      "name": "Sound Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": "2B376E",
-                                                    "routeLongName": null,
-                                                    "routeShortName": "522",
-                                                    "routeTextColor": "FFFFFF",
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:40",
+                                                        "name": "Sound Transit",
+                                                      },
+                                                      "color": "2B376E",
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "522",
+                                                      "textColor": "FFFFFF",
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -59605,14 +59792,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "73",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "73",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -60356,14 +60554,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "322",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "322",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -61081,14 +61290,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "322",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "322",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -69039,14 +69259,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "45",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "45",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -69865,14 +70096,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "62",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "62",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={
@@ -70621,14 +70863,25 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                               <DefaultRouteRenderer
                                                 leg={
                                                   Object {
-                                                    "agencyName": "Metro Transit",
+                                                    "agency": Object {
+                                                      "gtfsId": "kcm:1",
+                                                      "name": "Metro Transit",
+                                                    },
                                                     "mode": "BUS",
                                                     "onColoredBackground": true,
                                                     "origColor": undefined,
-                                                    "routeColor": null,
-                                                    "routeLongName": null,
-                                                    "routeShortName": "79",
-                                                    "routeTextColor": null,
+                                                    "route": Object {
+                                                      "agency": Object {
+                                                        "gtfsId": "kcm:1",
+                                                        "name": "Metro Transit",
+                                                      },
+                                                      "color": null,
+                                                      "longName": null,
+                                                      "mode": "BUS",
+                                                      "shortName": "79",
+                                                      "textColor": null,
+                                                      "type": 3,
+                                                    },
                                                   }
                                                 }
                                                 style={

--- a/__tests__/components/viewers/__snapshots__/stop-schedule-viewer.ts.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-schedule-viewer.ts.snap
@@ -100,8 +100,8 @@ exports[`components > viewers > stop viewer should render with initial stop id a
           }
         >
           <StopScheduleViewer
-            calendarMax="2026-12-31"
-            calendarMin="2025-01-01"
+            calendarMax="2027-12-31"
+            calendarMin="2026-01-01"
             findStopTimesForStop={[Function]}
             homeTimezone="America/Los_Angeles"
             intl={

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -1008,8 +1008,7 @@ export function findRoutes() {
               ).split('#')?.[1]
 
               result[id] = {
-                agencyId: agency.id,
-                agencyName: agency.name,
+                agency,
                 color,
                 id,
                 longName,

--- a/lib/components/viewers/route-name.tsx
+++ b/lib/components/viewers/route-name.tsx
@@ -1,3 +1,4 @@
+import { Route } from '@opentripplanner/types'
 import React, { ComponentType } from 'react'
 import styled from 'styled-components'
 
@@ -30,7 +31,7 @@ const RouteLongNameElement = styled.span`
 
 interface MinimalLeg {
   mode: string
-  routeColor: string
+  route: Route
 }
 
 interface RouteRendererProps {

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -477,9 +477,9 @@ export const getFilteredRoutes = createSelector(
       (route) =>
         (!filter.agency ||
           getAgencyIdsForFilter(filter.agency, transitOperators).includes(
-            route.agencyId
+            route.agency.id
           ) ||
-          filter.agency === route.agencyName) &&
+          filter.agency === route.agency.name) &&
         (!filter.mode || filter.mode === route.mode) &&
         // If user search is active, filter by either the long/short name, or the route description
         (!filter.search ||
@@ -516,9 +516,9 @@ export const getModesForActiveAgencyFilter = createSelector(
               route.mode &&
               (!filter.agency ||
                 getAgencyIdsForFilter(filter.agency, transitOperators).includes(
-                  route.agencyId
+                  route.agency.id
                 ) ||
-                filter.agency === route.agencyName)
+                filter.agency === route.agency.name)
           )
           .map((route) => route.mode)
           .filter((mode) => mode !== undefined)

--- a/lib/util/viewer.js
+++ b/lib/util/viewer.js
@@ -397,10 +397,7 @@ export function generateFakeLegForRouteRenderer(
   onColoredBackground = false
 ) {
   return {
-    // FIXME: try to use route.agency (right now, it is not always populated)
-    agency: {
-      name: route.agencyName || route.agency?.name
-    },
+    agency: route.agency,
     mode: getModeFromRoute(route),
     // Don't render top border when colors are mismatched
     onColoredBackground,

--- a/lib/util/viewer.js
+++ b/lib/util/viewer.js
@@ -396,18 +396,16 @@ export function generateFakeLegForRouteRenderer(
   route,
   onColoredBackground = false
 ) {
-  // RouteRenderer requires a "leg"
   return {
-    agencyName: route?.agencyName || route.agency?.name,
-
+    // FIXME: try to use route.agency (right now, it is not always populated)
+    agency: {
+      name: route.agencyName || route.agency?.name
+    },
     mode: getModeFromRoute(route),
     // Don't render top border when colors are mismatched
     onColoredBackground,
     origColor: route.origColor,
-    routeColor: route.color,
-    routeLongName: route.longName,
-    routeShortName: route.shortName,
-    routeTextColor: route.textColor
+    route
   }
 }
 


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

This PR removes legacy OTP1 fields from the data passed to `RouteRenderer` to address compatibility with custom route renderers that use OTP2-only objects. This is possible because we are already querying the `agency` object with id and name when we query the entire list of routes for the route viewer.

Tested with ST and ATL configs.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

