### PR TITLE
Remove route short names in headsigns

### DIFF
--- a/__tests__/components/viewers/__snapshots__/stop-schedule-viewer.ts.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-schedule-viewer.ts.snap
@@ -100,8 +100,8 @@ exports[`components > viewers > stop viewer should render with initial stop id a
           }
         >
           <StopScheduleViewer
-            calendarMax="2026-12-31"
-            calendarMin="2025-01-01"
+            calendarMax="2027-12-31"
+            calendarMin="2026-01-01"
             findStopTimesForStop={[Function]}
             homeTimezone="America/Los_Angeles"
             intl={

--- a/__tests__/util/viewer.js
+++ b/__tests__/util/viewer.js
@@ -10,6 +10,14 @@ describe('util > viewer', () => {
       expect(extractHeadsignFromPattern(pattern)).toBe('Sesame Street')
     })
 
+    it('should remove route short name from pattern headsign', () => {
+      const pattern = {
+        // OTP might pile up route short names in the headsign even if is already there.
+        headsign: '101 101 to Sesame Street'
+      }
+      expect(extractHeadsignFromPattern(pattern, '101')).toBe('Sesame Street')
+    })
+
     const prefixes = ['To', 'Toward', 'Towards']
     prefixes
       .flatMap((prefix) => [prefix, prefix.toLowerCase()])

--- a/lib/util/viewer.js
+++ b/lib/util/viewer.js
@@ -60,6 +60,38 @@ export function routeIsValid(route, routeId) {
 }
 
 /**
+ * Try to remove the route short name from the headsign.
+ * Note that the headsign might be added multiple times by OTP, hence a recursive check.
+ */
+function removeRouteShortName(headsign, routeShortName) {
+  let finalHeadsign = headsign
+  if (headsign && routeShortName) {
+    while (finalHeadsign.startsWith(`${routeShortName} `)) {
+      finalHeadsign = finalHeadsign.substring(routeShortName.length + 1)
+    }
+  }
+  return finalHeadsign
+}
+
+/**
+ * Try to remove 'to', 'towards' etc from headsigns.
+ */
+function removeTowards(headsign) {
+  if (headsign) {
+    const headsignLower = headsign.toLowerCase()
+    // Find and remove leading prefix text from headsign (English-specific).
+    const prefixes = ['to ', 'toward ', 'towards ']
+    const matchingPrefix = prefixes.find((prefix) =>
+      headsignLower.startsWith(prefix)
+    )
+    if (matchingPrefix) {
+      return headsign.substring(matchingPrefix.length)
+    }
+  }
+  return headsign
+}
+
+/**
  * Run heuristic on pattern description to extract headsign from pattern description
  * @param {*} pattern        pattern to extract headsign out of
  * @param {*} routeShortName if passed, used to help shorten headsign
@@ -70,16 +102,7 @@ export function extractHeadsignFromPattern(pattern, routeShortName = null) {
   const descNotRouteShortName = routeShortName && desc !== `${routeShortName}`
 
   if (!isBlank(headsign)) {
-    const prefixes = ['to ', 'toward ', 'towards ']
-    const headsignLower = headsign.toLowerCase()
-    // Find and remove leading prefix text from headsign (English-specific).
-    const matchingPrefix = prefixes.find((prefix) =>
-      headsignLower.startsWith(prefix)
-    )
-    if (matchingPrefix) {
-      return headsign.substring(matchingPrefix.length)
-    }
-    return headsign
+    return removeTowards(removeRouteShortName(headsign, routeShortName))
   } else {
     // In case the headsign is blank, extract headsign from the pattern 'desc' attribute
     // by attempting the logic below in order:
@@ -94,7 +117,7 @@ export function extractHeadsignFromPattern(pattern, routeShortName = null) {
       // In this case, we need to rely on the routeShortName to determine what to remove
       (d) =>
         descNotRouteShortName &&
-        d?.match(/^[^(]*$/)?.[0]?.replace(`${routeShortName} `, ''),
+        removeRouteShortName(d?.match(/^[^(]*$/)?.[0], routeShortName),
       // If the headsign is still blank, use the description, if different than routeShortName.
       (d) => descNotRouteShortName && d,
       // If nothing else works, use the name of the last stop in the pattern.


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

This PR fixes headsigns where the route short name is prepended multiple times.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
| ![before screenshot](https://github.com/user-attachments/assets/c413f7dd-47c6-4624-bc2f-05d25137e282) | ![after screenshot](https://github.com/user-attachments/assets/9731e932-4fa7-441a-942e-b84073cb7805) |

