### PR TITLE
hide stay-on-board transfers from itinerary summary

### DIFF
--- a/lib/components/narrative/metro/metro-itinerary-routes.tsx
+++ b/lib/components/narrative/metro/metro-itinerary-routes.tsx
@@ -79,9 +79,9 @@ const MetroItineraryRoutes = ({
   showLegDurations
 }: Props): JSX.Element => {
   const intl = useIntl()
-  const routeLegs = showAllWalkLegs
-    ? itinerary.legs
-    : itinerary.legs.filter(removeInsignificantWalkLegs)
+  const routeLegs = itinerary.legs
+    .filter(showAllWalkLegs ? () => true : removeInsignificantWalkLegs)
+    .filter((leg) => !leg.interlineWithPreviousLeg)
   const transitRoutes = getItineraryRoutes(itinerary, intl)
 
   return (


### PR DESCRIPTION
An example of what is now hidden <img width="636" height="472" alt="image" src="https://github.com/user-attachments/assets/fe94fa7d-542f-4b5d-964e-73c56c72dd05" />
