### PR TITLE
Show Vehicles of Subpatterns in Viewed Pattern

### DIFF
--- a/__tests__/util/pattern-viewer.ts
+++ b/__tests__/util/pattern-viewer.ts
@@ -93,7 +93,7 @@ describe('util > pattern-viewer', () => {
 
   describe('sortAndRemoveSubpatterns', () => {
     it('should sort and remove subpatterns', () => {
-      // Consider the following patterns P1...P6 of the same route:
+      // Consider the following patterns of the same route:
       // Stops S1 S2 S3 S4 S5 S6 S7 --> direction of travel
       // P1:   o--o--o--o--o
       // P2:         o--o-----o--o
@@ -101,9 +101,10 @@ describe('util > pattern-viewer', () => {
       // P4:   o-----o--o--o
       // P5:   o--o--o--o--o
       // P6: <undefined stops>
+      // P7:         o--o--o
       //
       // One of P1 or P5 should be removed because both have the exact same stops.
-      // P3 should be removed because it is a subset of P1, P4, and P5.
+      // P3 and P7 should be removed because they are a subset of P1, P4, and P5.
       // P1, P2, and P4 should be kept.
       const patterns: Pattern[] = [
         {
@@ -171,6 +172,17 @@ describe('util > pattern-viewer', () => {
           },
           route,
           stops: undefined
+        },
+        {
+          desc: 'P7 Pattern name',
+          headsign,
+          id: 'P7',
+          patternGeometry: {
+            length: 987,
+            points: 'p7-points'
+          },
+          route,
+          stops: createStops(['S3', 'S4', 'S5'])
         }
       ]
       const { containingPatterns, filteredPatterns } =

--- a/__tests__/util/pattern-viewer.ts
+++ b/__tests__/util/pattern-viewer.ts
@@ -98,7 +98,7 @@ describe('util > pattern-viewer', () => {
       // P1:   o--o--o--o--o
       // P2:         o--o-----o--o
       // P3:         o--o--o
-      // P3:   o-----o--o--o
+      // P4:   o-----o--o--o
       //
       // P3 should be removed because it is a subset of P1 and P3.
       // P1, P2, and P4 should be kept.
@@ -148,11 +148,15 @@ describe('util > pattern-viewer', () => {
           stops: createStops(['S1', 'S3', 'S4', 'S5'])
         }
       ]
-      const filteredPatterns = sortAndRemoveSubpatterns(patterns)
+      const { filteredPatterns, subPatterns } =
+        sortAndRemoveSubpatterns(patterns)
       expect(filteredPatterns.length).toBe(3)
       expect(filteredPatterns[0]).toBe(patterns[0])
       expect(filteredPatterns[1]).toBe(patterns[3])
       expect(filteredPatterns[2]).toBe(patterns[1])
+      expect(subPatterns.P1).toContain('P3')
+      expect(subPatterns.P3).toBe(undefined)
+      expect(subPatterns.P4).toBe(undefined)
     })
   })
 })

--- a/__tests__/util/pattern-viewer.ts
+++ b/__tests__/util/pattern-viewer.ts
@@ -173,18 +173,23 @@ describe('util > pattern-viewer', () => {
           stops: undefined
         }
       ]
-      const { filteredPatterns, subPatterns } =
+      const { containingPatterns, filteredPatterns, subPatterns } =
         sortAndRemoveSubpatterns(patterns)
       expect(filteredPatterns.length).toBe(3)
-      expect([patterns[0], patterns[4]]).toContain(filteredPatterns[0])
+      expect(['P1', 'P5']).toContain(filteredPatterns[0].id)
       expect(filteredPatterns[1]).toBe(patterns[3])
       expect(filteredPatterns[2]).toBe(patterns[1])
       expect(subPatterns.P1).toContain('P3')
+      expect(['P1', 'P5']).toContain(containingPatterns.P3)
       expect(subPatterns.P3).toBe(undefined)
       expect(subPatterns.P4).toContain('P3')
+      expect(containingPatterns.P4).toBe(undefined)
       expect(subPatterns.P5).toContain('P3')
       expect(
-        subPatterns.P1.includes('P5') || subPatterns.P5.includes('P1')
+        subPatterns.P1.includes('P5') && subPatterns.P5.includes('P1')
+      ).toBeTruthy()
+      expect(
+        containingPatterns.P1 === 'P5' || containingPatterns.P5 === 'P1'
       ).toBeTruthy()
     })
   })

--- a/__tests__/util/pattern-viewer.ts
+++ b/__tests__/util/pattern-viewer.ts
@@ -1,14 +1,33 @@
-import '../test-utils/mock-window-url'
-import { extractMainHeadsigns } from '../../lib/util/pattern-viewer'
+import { Stop } from '@opentripplanner/types'
 
-function createStops(ids) {
+import '../test-utils/mock-window-url'
+import {
+  extractMainHeadsigns,
+  sortAndRemoveSubpatterns
+} from '../../lib/util/pattern-viewer'
+import { Pattern } from '../../lib/components/util/types'
+
+interface TestPattern {
+  headsign: string
+  id: string
+  lastStop?: string
+  name: string
+  patternGeometry: {
+    length: number
+    points: string
+  }
+  stops: Stop[]
+}
+
+function createStops(ids: string[]): Stop[] {
   return ids.map((id) => ({
+    gtfsId: id,
     id,
     name: id
   }))
 }
 
-function editHeadsign(pattern) {
+function editHeadsign(pattern: TestPattern) {
   pattern.headsign = `${pattern.headsign} (${pattern.lastStop})`
 }
 
@@ -27,7 +46,7 @@ describe('util > pattern-viewer', () => {
       // pre-sorting happened before extractMainHeadsigns is invoked (key order matters).
       const headsign = 'Everett via Lynnwood'
       const route = '512'
-      const patterns = {
+      const patterns: Record<string, TestPattern> = {
         P1: {
           headsign,
           id: 'P1',
@@ -63,6 +82,69 @@ describe('util > pattern-viewer', () => {
       expect(headsignData.length).toBe(2)
       expect(headsignData[0].headsign).toBe(headsign)
       expect(headsignData[1].headsign).toBe(`${headsign} (S7)`)
+    })
+  })
+
+  describe('sortAndRemoveSubpatterns', () => {
+    it('should sort and remove subpatterns', () => {
+      // Consider the following patterns P1, P2, P3, P4 of the same route:
+      // Stops S1 S2 S3 S4 S5 S6 S7 --> direction of travel
+      // P1:   o--o--o--o--o
+      // P2:         o--o-----o--o
+      // P3:         o--o--o
+      // P3:   o-----o--o--o
+      //
+      // P3 should be removed because it is a subset of P1 and P3.
+      // P1, P2, and P4 should be kept.
+      const headsign = 'Everett via Lynnwood'
+      const patterns: TestPattern[] = [
+        {
+          headsign,
+          id: 'P1',
+          name: 'P1 Pattern name',
+          patternGeometry: {
+            length: 1404,
+            points: 'p1-points'
+          },
+          stops: createStops(['S1', 'S2', 'S3', 'S4', 'S5'])
+        },
+        {
+          headsign,
+          id: 'P2',
+          name: 'P2 Pattern name',
+          patternGeometry: {
+            length: 1072,
+            points: 'p2-points'
+          },
+          stops: createStops(['S3', 'S4', 'S6', 'S7'])
+        },
+        {
+          headsign,
+          id: 'P3',
+          name: 'P3 Pattern name',
+          patternGeometry: {
+            length: 987,
+            points: 'p3-points'
+          },
+          stops: createStops(['S3', 'S4', 'S5'])
+        },
+        {
+          headsign,
+          id: 'P4',
+          name: 'P4 Pattern name',
+          patternGeometry: {
+            length: 1404,
+            points: 'p4-points'
+          },
+          stops: createStops(['S1', 'S3', 'S4', 'S5'])
+        }
+      ]
+      const filteredPatterns = sortAndRemoveSubpatterns(patterns)
+      expect(filteredPatterns.length).toBe(3)
+      console.log(filteredPatterns)
+      expect(filteredPatterns[0]).toBe(patterns[0])
+      expect(filteredPatterns[1]).toBe(patterns[3])
+      expect(filteredPatterns[2]).toBe(patterns[1])
     })
   })
 })

--- a/__tests__/util/pattern-viewer.ts
+++ b/__tests__/util/pattern-viewer.ts
@@ -93,7 +93,7 @@ describe('util > pattern-viewer', () => {
 
   describe('sortAndRemoveSubpatterns', () => {
     it('should sort and remove subpatterns', () => {
-      // Consider the following patterns of the same route:
+      // Consider the following patterns P1...P6 of the same route:
       // Stops S1 S2 S3 S4 S5 S6 S7 --> direction of travel
       // P1:   o--o--o--o--o
       // P2:         o--o-----o--o
@@ -101,10 +101,9 @@ describe('util > pattern-viewer', () => {
       // P4:   o-----o--o--o
       // P5:   o--o--o--o--o
       // P6: <undefined stops>
-      // P7:         o--o--o
       //
       // One of P1 or P5 should be removed because both have the exact same stops.
-      // P3 and P7 should be removed because they are a subset of P1, P4, and P5.
+      // P3 should be removed because it is a subset of P1, P4, and P5.
       // P1, P2, and P4 should be kept.
       const patterns: Pattern[] = [
         {
@@ -172,17 +171,6 @@ describe('util > pattern-viewer', () => {
           },
           route,
           stops: undefined
-        },
-        {
-          desc: 'P7 Pattern name',
-          headsign,
-          id: 'P7',
-          patternGeometry: {
-            length: 987,
-            points: 'p7-points'
-          },
-          route,
-          stops: createStops(['S3', 'S4', 'S5'])
         }
       ]
       const { containingPatterns, filteredPatterns } =

--- a/__tests__/util/pattern-viewer.ts
+++ b/__tests__/util/pattern-viewer.ts
@@ -1,23 +1,12 @@
-import { Stop } from '@opentripplanner/types'
+import { Route, Stop } from '@opentripplanner/types'
 
 import '../test-utils/mock-window-url'
 import {
   extractMainHeadsigns,
+  PatternSummary,
   sortAndRemoveSubpatterns
 } from '../../lib/util/pattern-viewer'
 import { Pattern } from '../../lib/components/util/types'
-
-interface TestPattern {
-  headsign: string
-  id: string
-  lastStop?: string
-  name: string
-  patternGeometry: {
-    length: number
-    points: string
-  }
-  stops: Stop[]
-}
 
 function createStops(ids: string[]): Stop[] {
   return ids.map((id) => ({
@@ -27,8 +16,19 @@ function createStops(ids: string[]): Stop[] {
   }))
 }
 
-function editHeadsign(pattern: TestPattern) {
+function editHeadsign(pattern: PatternSummary) {
   pattern.headsign = `${pattern.headsign} (${pattern.lastStop})`
+}
+
+const headsign = 'Everett via Lynnwood'
+const route: Route = {
+  agency: {
+    id: 'agnecy'
+  },
+  id: 'route-id',
+  shortName: '512',
+  sortOrder: 0,
+  sortOrderSet: false
 }
 
 describe('util > pattern-viewer', () => {
@@ -44,41 +44,47 @@ describe('util > pattern-viewer', () => {
       // P1 and P2 should be kept.
       // Patterns are assumed in descending length order because
       // pre-sorting happened before extractMainHeadsigns is invoked (key order matters).
-      const headsign = 'Everett via Lynnwood'
-      const route = '512'
-      const patterns: Record<string, TestPattern> = {
+      const routeShortName = '512'
+      const patterns: Record<string, Pattern> = {
         P1: {
+          desc: 'P1 Pattern name',
           headsign,
           id: 'P1',
-          name: 'P1 Pattern name',
           patternGeometry: {
             length: 1404,
             points: 'p1-points'
           },
+          route,
           stops: createStops(['S1', 'S2', 'S3', 'S4', 'S5'])
         },
         P2: {
+          desc: 'P2 Pattern name',
           headsign,
           id: 'P2',
-          name: 'P2 Pattern name',
           patternGeometry: {
             length: 1072,
             points: 'p2-points'
           },
+          route,
           stops: createStops(['S3', 'S4', 'S6', 'S7'])
         },
         P3: {
+          desc: 'P3 Pattern name',
           headsign,
           id: 'P3',
-          name: 'P3 Pattern name',
           patternGeometry: {
             length: 987,
             points: 'p3-points'
           },
+          route,
           stops: createStops(['S3', 'S4', 'S5'])
         }
       }
-      const headsignData = extractMainHeadsigns(patterns, route, editHeadsign)
+      const headsignData = extractMainHeadsigns(
+        patterns,
+        routeShortName,
+        editHeadsign
+      )
       expect(headsignData.length).toBe(2)
       expect(headsignData[0].headsign).toBe(headsign)
       expect(headsignData[1].headsign).toBe(`${headsign} (S7)`)
@@ -96,46 +102,49 @@ describe('util > pattern-viewer', () => {
       //
       // P3 should be removed because it is a subset of P1 and P3.
       // P1, P2, and P4 should be kept.
-      const headsign = 'Everett via Lynnwood'
-      const patterns: TestPattern[] = [
+      const patterns: Pattern[] = [
         {
+          desc: 'P1 Pattern name',
           headsign,
           id: 'P1',
-          name: 'P1 Pattern name',
           patternGeometry: {
             length: 1404,
             points: 'p1-points'
           },
+          route,
           stops: createStops(['S1', 'S2', 'S3', 'S4', 'S5'])
         },
         {
+          desc: 'P2 Pattern name',
           headsign,
           id: 'P2',
-          name: 'P2 Pattern name',
           patternGeometry: {
             length: 1072,
             points: 'p2-points'
           },
+          route,
           stops: createStops(['S3', 'S4', 'S6', 'S7'])
         },
         {
+          desc: 'P3 Pattern name',
           headsign,
           id: 'P3',
-          name: 'P3 Pattern name',
           patternGeometry: {
             length: 987,
             points: 'p3-points'
           },
+          route,
           stops: createStops(['S3', 'S4', 'S5'])
         },
         {
+          desc: 'P4 Pattern name',
           headsign,
           id: 'P4',
-          name: 'P4 Pattern name',
           patternGeometry: {
             length: 1404,
             points: 'p4-points'
           },
+          route,
           stops: createStops(['S1', 'S3', 'S4', 'S5'])
         }
       ]

--- a/__tests__/util/pattern-viewer.ts
+++ b/__tests__/util/pattern-viewer.ts
@@ -146,6 +146,17 @@ describe('util > pattern-viewer', () => {
           },
           route,
           stops: createStops(['S1', 'S3', 'S4', 'S5'])
+        },
+        {
+          desc: 'Pattern without stops',
+          headsign,
+          id: 'P6',
+          patternGeometry: {
+            length: 0,
+            points: ''
+          },
+          route,
+          stops: undefined
         }
       ]
       const { filteredPatterns, subPatterns } =

--- a/__tests__/util/pattern-viewer.ts
+++ b/__tests__/util/pattern-viewer.ts
@@ -177,8 +177,8 @@ describe('util > pattern-viewer', () => {
         sortAndRemoveSubpatterns(patterns)
       expect(filteredPatterns.length).toBe(3)
       expect(['P1', 'P5']).toContain(filteredPatterns[0].id)
-      expect(filteredPatterns[1]).toBe(patterns[3])
-      expect(filteredPatterns[2]).toBe(patterns[1])
+      expect(filteredPatterns).toContain(patterns[1])
+      expect(filteredPatterns).toContain(patterns[3])
       expect(['P1', 'P5']).toContain(containingPatterns.P3)
       expect(containingPatterns.P4).toBe(undefined)
       expect(

--- a/__tests__/util/pattern-viewer.ts
+++ b/__tests__/util/pattern-viewer.ts
@@ -173,21 +173,14 @@ describe('util > pattern-viewer', () => {
           stops: undefined
         }
       ]
-      const { containingPatterns, filteredPatterns, subPatterns } =
+      const { containingPatterns, filteredPatterns } =
         sortAndRemoveSubpatterns(patterns)
       expect(filteredPatterns.length).toBe(3)
       expect(['P1', 'P5']).toContain(filteredPatterns[0].id)
       expect(filteredPatterns[1]).toBe(patterns[3])
       expect(filteredPatterns[2]).toBe(patterns[1])
-      expect(subPatterns.P1).toContain('P3')
       expect(['P1', 'P5']).toContain(containingPatterns.P3)
-      expect(subPatterns.P3).toBe(undefined)
-      expect(subPatterns.P4).toContain('P3')
       expect(containingPatterns.P4).toBe(undefined)
-      expect(subPatterns.P5).toContain('P3')
-      expect(
-        subPatterns.P1.includes('P5') && subPatterns.P5.includes('P1')
-      ).toBeTruthy()
       expect(
         containingPatterns.P1 === 'P5' || containingPatterns.P5 === 'P1'
       ).toBeTruthy()

--- a/__tests__/util/pattern-viewer.ts
+++ b/__tests__/util/pattern-viewer.ts
@@ -93,14 +93,17 @@ describe('util > pattern-viewer', () => {
 
   describe('sortAndRemoveSubpatterns', () => {
     it('should sort and remove subpatterns', () => {
-      // Consider the following patterns P1, P2, P3, P4 of the same route:
+      // Consider the following patterns P1...P6 of the same route:
       // Stops S1 S2 S3 S4 S5 S6 S7 --> direction of travel
       // P1:   o--o--o--o--o
       // P2:         o--o-----o--o
       // P3:         o--o--o
       // P4:   o-----o--o--o
+      // P5:   o--o--o--o--o
+      // P6: <undefined stops>
       //
-      // P3 should be removed because it is a subset of P1 and P3.
+      // One of P1 or P5 should be removed because both have the exact same stops.
+      // P3 should be removed because it is a subset of P1, P4, and P5.
       // P1, P2, and P4 should be kept.
       const patterns: Pattern[] = [
         {
@@ -148,6 +151,17 @@ describe('util > pattern-viewer', () => {
           stops: createStops(['S1', 'S3', 'S4', 'S5'])
         },
         {
+          desc: 'P5 Pattern name (same stops as P1)',
+          headsign,
+          id: 'P5',
+          patternGeometry: {
+            length: 1404,
+            points: 'p5-points'
+          },
+          route,
+          stops: createStops(['S1', 'S2', 'S3', 'S4', 'S5'])
+        },
+        {
           desc: 'Pattern without stops',
           headsign,
           id: 'P6',
@@ -162,12 +176,16 @@ describe('util > pattern-viewer', () => {
       const { filteredPatterns, subPatterns } =
         sortAndRemoveSubpatterns(patterns)
       expect(filteredPatterns.length).toBe(3)
-      expect(filteredPatterns[0]).toBe(patterns[0])
+      expect([patterns[0], patterns[4]]).toContain(filteredPatterns[0])
       expect(filteredPatterns[1]).toBe(patterns[3])
       expect(filteredPatterns[2]).toBe(patterns[1])
       expect(subPatterns.P1).toContain('P3')
       expect(subPatterns.P3).toBe(undefined)
-      expect(subPatterns.P4).toBe(undefined)
+      expect(subPatterns.P4).toContain('P3')
+      expect(subPatterns.P5).toContain('P3')
+      expect(
+        subPatterns.P1.includes('P5') || subPatterns.P5.includes('P1')
+      ).toBeTruthy()
     })
   })
 })

--- a/__tests__/util/pattern-viewer.ts
+++ b/__tests__/util/pattern-viewer.ts
@@ -150,7 +150,6 @@ describe('util > pattern-viewer', () => {
       ]
       const filteredPatterns = sortAndRemoveSubpatterns(patterns)
       expect(filteredPatterns.length).toBe(3)
-      console.log(filteredPatterns)
       expect(filteredPatterns[0]).toBe(patterns[0])
       expect(filteredPatterns[1]).toBe(patterns[3])
       expect(filteredPatterns[2]).toBe(patterns[1])

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -830,7 +830,9 @@ export const findRoute = (params) =>
             const routePatterns = {}
 
             // Sort and remove all patterns that are subsets of larger patterns.
-            const filteredPatterns = sortAndRemoveSubpatterns(newRoute.patterns)
+            const { filteredPatterns, subPatterns } = sortAndRemoveSubpatterns(
+              newRoute.patterns
+            )
             filteredPatterns.forEach((pattern) => {
               const patternStops = pattern.stops.map((stop) => {
                 const color =
@@ -843,7 +845,8 @@ export const findRoute = (params) =>
                 ...pattern,
                 desc: pattern.name,
                 geometry: pattern?.patternGeometry || { length: 0, points: '' },
-                stops: patternStops
+                stops: patternStops,
+                subPatterns: subPatterns[pattern.id]
               }
             })
             newRoute.origColor = newRoute.color

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -833,7 +833,7 @@ export const findRoute = (params) =>
             const routePatterns = {}
 
             // Sort and remove all patterns that are subsets of larger patterns.
-            const { containingPatterns, filteredPatterns, subPatterns } =
+            const { containingPatterns, filteredPatterns } =
               sortAndRemoveSubpatterns(newRoute.patterns)
             filteredPatterns.forEach((pattern) => {
               const patternStops = pattern.stops.map((stop) => {
@@ -847,8 +847,7 @@ export const findRoute = (params) =>
                 ...pattern,
                 desc: pattern.name,
                 geometry: pattern?.patternGeometry || { length: 0, points: '' },
-                stops: patternStops,
-                subPatterns: subPatterns[pattern.id]
+                stops: patternStops
               }
             })
             newRoute.origColor = newRoute.color

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -804,6 +804,9 @@ export const findRoute = (params) =>
               geometries {
                 geoJson
               }
+              parentStation {
+                id: gtfsId
+              }
               routes {
                 textColor
                 color

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -25,7 +25,6 @@ import {
 import {
   getActiveItinerary,
   getRouteOperator,
-  isValidSubsequence,
   queryIsValid
 } from '../util/state'
 import { getCurrentServiceWeek } from '../util/current-service-week'
@@ -36,6 +35,7 @@ import {
   routeIsValid
 } from '../util/viewer'
 import { isLastStop } from '../util/stop-times'
+import { sortAndRemoveSubpatterns } from '../util/pattern-viewer'
 
 import { addToRecentSearches, rememberPlace } from './user'
 import { countFlexModes } from './api-utils'
@@ -829,37 +829,9 @@ export const findRoute = (params) =>
             const newRoute = clone(route)
             const routePatterns = {}
 
-            // Sort patterns by length to make algorithm below more efficient
-            const patternsSortedByLength = newRoute.patterns.sort(
-              (a, b) => a.stops.length - b.stops.length
-            )
-
-            // Remove all patterns that are subsets of larger patterns
-            const filteredPatterns = patternsSortedByLength
-              // Start with the largest for performance
-              .reverse()
-              .filter((pattern) => {
-                // Compare to all other patterns TODO: make this beat O(n^2)
-                return !patternsSortedByLength.find((p) => {
-                  // Don't compare against ourself
-                  if (p.id === pattern.id) return false
-
-                  // If our pattern is longer, it's not a subset
-                  if (p.stops.length <= pattern.stops.length) return false
-
-                  return isValidSubsequence(
-                    p.stops.map((s) => s.id),
-                    pattern.stops.map((s) => s.id)
-                  )
-                })
-              })
-
-            // Fallback for if the filtering leaves us with a silly number of patterns
-            // If this happens, it is not possible to know which pattern to keep
-            ;(filteredPatterns.length > 1
-              ? filteredPatterns
-              : newRoute.patterns
-            ).forEach((pattern) => {
+            // Sort and remove all patterns that are subsets of larger patterns.
+            const filteredPatterns = sortAndRemoveSubpatterns(newRoute.patterns)
+            filteredPatterns.forEach((pattern) => {
               const patternStops = pattern.stops.map((stop) => {
                 const color =
                   stop.routes?.length > 0 &&

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -833,9 +833,8 @@ export const findRoute = (params) =>
             const routePatterns = {}
 
             // Sort and remove all patterns that are subsets of larger patterns.
-            const { filteredPatterns, subPatterns } = sortAndRemoveSubpatterns(
-              newRoute.patterns
-            )
+            const { containingPatterns, filteredPatterns, subPatterns } =
+              sortAndRemoveSubpatterns(newRoute.patterns)
             filteredPatterns.forEach((pattern) => {
               const patternStops = pattern.stops.map((stop) => {
                 const color =
@@ -865,6 +864,7 @@ export const findRoute = (params) =>
             ).split('#')?.[1]
 
             newRoute.patterns = routePatterns
+            newRoute.containingPatterns = containingPatterns
             // TODO: avoid explicit behavior shift like this
             newRoute.v2 = true
             newRoute.mode = checkForRouteModeOverride(

--- a/lib/components/map/connected-transit-vehicle-overlay.js
+++ b/lib/components/map/connected-transit-vehicle-overlay.js
@@ -124,11 +124,11 @@ const IconContainer = withRouteColorBackground(CaretTouchingBorder, {
 const mapStateToProps = (state) => {
   const viewedRoute = state.otp.ui.viewedRoute
   const route = state.otp.transitIndex?.routes?.[viewedRoute?.routeId]
+  const { maxRealtimeVehicleAge, vehicleIconHighlight, vehicleIconPadding } =
+    state.otp.config.routeViewer || {}
 
   const ConfiguredIconContainer =
-    state.otp.config?.routeViewer?.vehicleIconHighlight === false
-      ? CaretTouchingBorder
-      : IconContainer
+    vehicleIconHighlight === false ? CaretTouchingBorder : IconContainer
 
   let vehicleList = []
 
@@ -159,8 +159,8 @@ const mapStateToProps = (state) => {
   return {
     color: route?.color ? '#' + route.color : null,
     IconContainer: ConfiguredIconContainer,
-    iconPadding: state.otp.config?.routeViewer?.vehicleIconPadding,
-    maxVehicleAge: state.otp.config?.routeViewer?.maxRealtimeVehicleAge,
+    iconPadding: vehicleIconPadding,
+    maxVehicleAge: maxRealtimeVehicleAge,
     // Note: with OTP2, we are showing route stops along with the route alignment,
     // and vehicle direction arrows become difficult to distinguish from the stop circles.
     TooltipSlot: injectIntl(VehicleTooltip),
@@ -168,9 +168,4 @@ const mapStateToProps = (state) => {
   }
 }
 
-const mapDispatchToProps = {}
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TransitVehicleOverlay)
+export default connect(mapStateToProps)(TransitVehicleOverlay)

--- a/lib/components/map/connected-transit-vehicle-overlay.js
+++ b/lib/components/map/connected-transit-vehicle-overlay.js
@@ -12,7 +12,9 @@
  * 5) This overlay has a custom popup on vehicle hover
  */
 
+import { connect } from 'react-redux'
 import { FormattedMessage, FormattedNumber, injectIntl } from 'react-intl'
+import React from 'react'
 import TransitVehicleOverlay, {
   Circle,
   withCaret,
@@ -20,12 +22,9 @@ import TransitVehicleOverlay, {
 } from '@opentripplanner/transit-vehicle-overlay'
 
 import { capitalizeFirst } from '../../util/ui'
-import { connect } from 'react-redux'
 import { DEFAULT_ROUTE_COLOR } from '../util/colors'
 import { formatDuration } from '../util/formatted-duration'
 import FormattedTransitVehicleStatus from '../util/formatted-transit-vehicle-status'
-
-import React from 'react'
 
 function VehicleTooltip(props) {
   const { intl, vehicle } = props
@@ -123,7 +122,8 @@ const IconContainer = withRouteColorBackground(CaretTouchingBorder, {
 
 const mapStateToProps = (state) => {
   const viewedRoute = state.otp.ui.viewedRoute
-  const route = state.otp.transitIndex?.routes?.[viewedRoute?.routeId]
+  const { patternId, routeId } = viewedRoute || {}
+  const route = state.otp.transitIndex?.routes?.[routeId]
   const { maxRealtimeVehicleAge, vehicleIconHighlight, vehicleIconPadding } =
     state.otp.config.routeViewer || {}
 
@@ -133,7 +133,7 @@ const mapStateToProps = (state) => {
   let vehicleList = []
 
   // Add missing fields to vehicle list
-  if (viewedRoute?.routeId) {
+  if (routeId) {
     vehicleList = route?.vehicles?.map((vehicle) => {
       vehicle.routeType = route?.mode
       vehicle.routeColor =
@@ -144,19 +144,17 @@ const mapStateToProps = (state) => {
       vehicle.routeShortName = vehicle.routeShortName || route?.shortName
       vehicle.routeLongName = vehicle.routeLongName || route?.longName
       vehicle.textColor = route?.routeTextColor
-
       vehicle.lastUpdated = vehicle?.seconds
       return vehicle
     })
 
     // Remove all vehicles not on pattern being currently viewed.
     // Also include vehicles in hidden subpatterns of the pattern being viewed.
-    if (viewedRoute.patternId && vehicleList) {
+    if (patternId && vehicleList) {
       vehicleList = vehicleList.filter(
         (vehicle) =>
-          vehicle.patternId === viewedRoute.patternId ||
-          route.containingPatterns?.[vehicle.patternId] ===
-            viewedRoute.patternId
+          vehicle.patternId === patternId ||
+          route.containingPatterns?.[vehicle.patternId] === patternId
       )
     }
   }

--- a/lib/components/map/connected-transit-vehicle-overlay.js
+++ b/lib/components/map/connected-transit-vehicle-overlay.js
@@ -149,10 +149,14 @@ const mapStateToProps = (state) => {
       return vehicle
     })
 
-    // Remove all vehicles not on pattern being currently viewed
+    // Remove all vehicles not on pattern being currently viewed.
+    // Also include vehicles in hidden subpatterns of the pattern being viewed.
     if (viewedRoute.patternId && vehicleList) {
       vehicleList = vehicleList.filter(
-        (vehicle) => vehicle.patternId === viewedRoute.patternId
+        (vehicle) =>
+          vehicle.patternId === viewedRoute.patternId ||
+          route.containingPatterns?.[vehicle.patternId] ===
+            viewedRoute.patternId
       )
     }
   }

--- a/lib/components/map/connected-transit-vehicle-overlay.js
+++ b/lib/components/map/connected-transit-vehicle-overlay.js
@@ -13,7 +13,7 @@
  */
 
 import { connect } from 'react-redux'
-import { FormattedMessage, FormattedNumber, injectIntl } from 'react-intl'
+import { FormattedMessage, FormattedNumber, useIntl } from 'react-intl'
 import React from 'react'
 import TransitVehicleOverlay, {
   Circle,
@@ -27,7 +27,8 @@ import { formatDuration } from '../util/formatted-duration'
 import FormattedTransitVehicleStatus from '../util/formatted-transit-vehicle-status'
 
 function VehicleTooltip(props) {
-  const { intl, vehicle } = props
+  const { vehicle } = props
+  const intl = useIntl()
 
   const scopedVehicleId = vehicle?.vehicleId?.split(':')?.[1]
 
@@ -165,7 +166,7 @@ const mapStateToProps = (state) => {
     maxVehicleAge: maxRealtimeVehicleAge,
     // Note: with OTP2, we are showing route stops along with the route alignment,
     // and vehicle direction arrows become difficult to distinguish from the stop circles.
-    TooltipSlot: injectIntl(VehicleTooltip),
+    TooltipSlot: VehicleTooltip,
     vehicles: vehicleList
   }
 }

--- a/lib/components/map/connected-transit-vehicle-overlay.tsx
+++ b/lib/components/map/connected-transit-vehicle-overlay.tsx
@@ -1,5 +1,3 @@
-// TODO: Typescript
-/* eslint-disable react/prop-types */
 /**
  * This overlay is similar to gtfs-rt-vehicle-overlay in that it shows
  * realtime positions of vehicles on a route using the otp-ui/transit-vehicle-overlay.
@@ -14,6 +12,7 @@
 
 import { connect } from 'react-redux'
 import { FormattedMessage, FormattedNumber, useIntl } from 'react-intl'
+import { TransitVehicle } from '@opentripplanner/types'
 import React from 'react'
 import TransitVehicleOverlay, {
   Circle,
@@ -21,13 +20,26 @@ import TransitVehicleOverlay, {
   withRouteColorBackground
 } from '@opentripplanner/transit-vehicle-overlay'
 
+import { AppReduxState } from '../../util/state-types'
 import { capitalizeFirst } from '../../util/ui'
 import { DEFAULT_ROUTE_COLOR } from '../util/colors'
 import { formatDuration } from '../util/formatted-duration'
 import FormattedTransitVehicleStatus from '../util/formatted-transit-vehicle-status'
 
-function VehicleTooltip(props) {
-  const { vehicle } = props
+interface TransitVehicleExt extends TransitVehicle {
+  label?: string
+  nextStopName?: string
+  patternId?: string
+  speed: number
+  stopStatus?: string
+  textColor?: string
+}
+
+interface VehicleTooltipProps {
+  vehicle: TransitVehicleExt
+}
+
+function VehicleTooltip({ vehicle }: VehicleTooltipProps): React.ReactNode {
   const intl = useIntl()
 
   const scopedVehicleId = vehicle?.vehicleId?.split(':')?.[1]
@@ -39,8 +51,8 @@ function VehicleTooltip(props) {
   // Otherwise, the label itself is enough
   //   (this is TriMet-specific, when label contains text such as "MAX Green").
   if (
-    vehicleLabel !== null &&
-    (vehicleLabel?.length <= 5 || scopedVehicleId || vehicle?.vehicleId)
+    !!vehicleLabel &&
+    (vehicleLabel.length <= 5 || scopedVehicleId || vehicle?.vehicleId)
   ) {
     vehicleLabel = intl.formatMessage(
       { id: 'components.TransitVehicleOverlay.vehicleName' },
@@ -52,9 +64,6 @@ function VehicleTooltip(props) {
 
   const stopStatus = vehicle?.stopStatus || 'in_transit_to'
 
-  // FIXME: This may not be timezone adjusted as reported seconds may be in the wrong timezone.
-  // All needed info to fix this is available via route.agency.timezone
-  // However, the needed coreUtils methods are not updated to support this
   return (
     <>
       {/* FIXME: move back to core-utils for time handling */}
@@ -67,7 +76,7 @@ function VehicleTooltip(props) {
             { id: 'common.time.durationAgo' },
             {
               duration: formatDuration(
-                Math.floor(Date.now() / 1000 - vehicle?.seconds),
+                Math.floor(Date.now() / 1000 - (vehicle?.seconds || 0)),
                 intl,
                 true
               )
@@ -75,7 +84,7 @@ function VehicleTooltip(props) {
           )
         )}
       </div>
-      {stopStatus !== 'STOPPED_AT' && vehicle?.speed > 0 && (
+      {stopStatus !== 'STOPPED_AT' && vehicle.speed > 0 && (
         <div>
           <FormattedMessage
             id="components.TransitVehicleOverlay.travelingAt"
@@ -114,6 +123,7 @@ const CaretTouchingBorder = withCaret(Circle, {
 
 // Round vehicle symbol with arrow/caret on the border,
 // and showing the route color with a transparent effect on hover.
+// @ts-expect-error This visual component does not deal with vehicle data directly.
 const IconContainer = withRouteColorBackground(CaretTouchingBorder, {
   alphaHex: 'aa',
   display: 'onhover'
@@ -121,7 +131,7 @@ const IconContainer = withRouteColorBackground(CaretTouchingBorder, {
 
 // connect to the redux store
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state: AppReduxState) => {
   const viewedRoute = state.otp.ui.viewedRoute
   const { patternId, routeId } = viewedRoute || {}
   const route = state.otp.transitIndex?.routes?.[routeId]
@@ -135,7 +145,7 @@ const mapStateToProps = (state) => {
 
   // Add missing fields to vehicle list
   if (routeId) {
-    vehicleList = route?.vehicles?.map((vehicle) => {
+    vehicleList = route?.vehicles?.map((vehicle: TransitVehicleExt) => {
       vehicle.routeType = route?.mode
       vehicle.routeColor =
         route.color && !route.color.includes('#')
@@ -153,9 +163,9 @@ const mapStateToProps = (state) => {
     // Also include vehicles in hidden subpatterns of the pattern being viewed.
     if (patternId && vehicleList) {
       vehicleList = vehicleList.filter(
-        (vehicle) =>
+        (vehicle: TransitVehicleExt) =>
           vehicle.patternId === patternId ||
-          route.containingPatterns?.[vehicle.patternId] === patternId
+          route.containingPatterns?.[vehicle.patternId || ''] === patternId
       )
     }
   }
@@ -171,4 +181,5 @@ const mapStateToProps = (state) => {
   }
 }
 
+// @ts-expect-error Type error is unclear on what type ReactNode conflicts with.
 export default connect(mapStateToProps)(TransitVehicleOverlay)

--- a/lib/components/map/connected-transit-vehicle-overlay.tsx
+++ b/lib/components/map/connected-transit-vehicle-overlay.tsx
@@ -35,11 +35,11 @@ interface TransitVehicleExt extends TransitVehicle {
   textColor?: string
 }
 
-interface VehicleTooltipProps {
+function VehicleTooltip({
+  vehicle
+}: {
   vehicle: TransitVehicleExt
-}
-
-function VehicleTooltip({ vehicle }: VehicleTooltipProps): React.ReactNode {
+}): React.ReactNode {
   const intl = useIntl()
 
   const scopedVehicleId = vehicle?.vehicleId?.split(':')?.[1]

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -99,6 +99,9 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
         // Don't compare against ourself
         if (p.id === pattern.id) return false
 
+        // If the pattern has no stops, exclude it.
+        if (!p.stops || p.stops.length === 0) return false
+
         // If our pattern is longer, it's not a subset
         if ((p.stops?.length || 0) <= (pattern.stops?.length || 0)) return false
 

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -1,3 +1,5 @@
+import { Stop } from '@opentripplanner/types'
+
 import { Pattern } from '../components/util/types'
 
 import { extractHeadsignFromPattern } from './viewer'
@@ -13,6 +15,10 @@ export interface PatternSummary {
 export interface SubPatternInfo {
   filteredPatterns: Pattern[]
   subPatterns: Record<string, string[]>
+}
+
+export interface StopWithParent extends Stop {
+  parentStation?: Stop
 }
 
 export function extractMainHeadsigns(
@@ -73,6 +79,13 @@ export function extractMainHeadsigns(
 }
 
 /**
+ * Obtains the parent stop id, if available, or the stop id.
+ */
+export function getParentStopOrStopGtfsId(stop: StopWithParent): string {
+  return stop.parentStation?.gtfsId || stop.gtfsId
+}
+
+/**
  * Returns a list of patterns, in descending length order, in which none is a subpattern of any other.
  * In the patterns below, only Patterns 1, 2, 5 should be retained:
  *   Pattern 1: Stops A, B, C, D
@@ -110,8 +123,8 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
         if (p.stops.length < (pattern.stops?.length || 0)) return
 
         const isSubpattern = isValidSubsequence(
-          p.stops?.map((s) => s.id) || [],
-          pattern.stops?.map((s) => s.id) || []
+          p.stops?.map(getParentStopOrStopGtfsId) || [],
+          pattern.stops?.map(getParentStopOrStopGtfsId) || []
         )
 
         if (isSubpattern) {

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -13,6 +13,7 @@ export interface PatternSummary {
 }
 
 export interface SubPatternInfo {
+  containingPatterns: Record<string, string>
   filteredPatterns: Pattern[]
   subPatterns: Record<string, string[]>
 }
@@ -101,6 +102,7 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
     .sort((a, b) => (a.stops?.length || 0) - (b.stops?.length || 0))
 
   const subPatterns: Record<string, string[]> = {}
+  const containingPatterns: Record<string, string> = {}
 
   // Keep patterns that are not subsets of larger patterns
   const filteredPatterns = patternsSortedByLength
@@ -116,9 +118,6 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
         // If the pattern has no stops, exclude it.
         if (!p.stops || p.stops.length === 0) return
 
-        // Exclude patterns higher in the list to avoid circular references among patterns of same length.
-        if (index > patternIndex) return
-
         // If our pattern is longer, it's not a subset
         if (p.stops.length < (pattern.stops?.length || 0)) return
 
@@ -128,21 +127,25 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
         const isSubpattern = isValidSubsequence(pStops, patternStops)
 
         if (isSubpattern) {
-          includePattern = false
+          // Include pattern if it has not been referenced before among patterns of same stops.
+          includePattern = index > patternIndex
           // Populate a list of subpatterns for the larger pattern.
           if (!subPatterns[p.id]) {
             subPatterns[p.id] = []
           }
           subPatterns[p.id].push(pattern.id)
+          // Populate the highest containing pattern.
+          if (!containingPatterns[pattern.id]) {
+            containingPatterns[pattern.id] = p.id
+          }
         }
-
-        return isSubpattern
       })
 
       return includePattern
     })
 
   return {
+    containingPatterns,
     // Fallback for if the filtering leaves us with a silly number of patterns
     // If this happens, it is not possible to know which pattern to keep.
     filteredPatterns: filteredPatterns.length > 1 ? filteredPatterns : patterns,

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -15,7 +15,6 @@ export interface PatternSummary {
 export interface SubPatternInfo {
   containingPatterns: Record<string, string>
   filteredPatterns: Pattern[]
-  subPatterns: Record<string, string[]>
 }
 
 export interface StopWithParent extends Stop {
@@ -101,7 +100,6 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
     .filter((pattern) => pattern.stops?.length)
     .sort((a, b) => (a.stops?.length || 0) - (b.stops?.length || 0))
 
-  const subPatterns: Record<string, string[]> = {}
   const containingPatterns: Record<string, string> = {}
 
   // Keep patterns that are not subsets of larger patterns
@@ -129,11 +127,6 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
         if (isSubpattern) {
           // Include pattern if it has not been referenced before among patterns of same stops.
           includePattern = index > patternIndex
-          // Populate a list of subpatterns for the larger pattern.
-          if (!subPatterns[p.id]) {
-            subPatterns[p.id] = []
-          }
-          subPatterns[p.id].push(pattern.id)
           // Populate the highest containing pattern.
           if (!containingPatterns[pattern.id]) {
             containingPatterns[pattern.id] = p.id
@@ -148,7 +141,6 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
     containingPatterns,
     // Fallback for if the filtering leaves us with a silly number of patterns
     // If this happens, it is not possible to know which pattern to keep.
-    filteredPatterns: filteredPatterns.length > 1 ? filteredPatterns : patterns,
-    subPatterns
+    filteredPatterns: filteredPatterns.length > 1 ? filteredPatterns : patterns
   }
 }

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -83,27 +83,31 @@ export function extractMainHeadsigns(
  */
 export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
   // Sort patterns by length to make algorithm below more efficient
-  const patternsSortedByLength = [...patterns].sort(
-    (a, b) => (a.stops?.length || 0) - (b.stops?.length || 0)
-  )
+  const patternsSortedByLength = [...patterns]
+    .filter((pattern) => pattern.stops?.length)
+    .sort((a, b) => (a.stops?.length || 0) - (b.stops?.length || 0))
 
   const subPatterns: Record<string, string[]> = {}
 
-  // Remove all patterns that are subsets of larger patterns
+  // Keep patterns that are not subsets of larger patterns
   const filteredPatterns = patternsSortedByLength
     // Start with the largest for performance
     .reverse()
-    .filter((pattern) => {
+    .filter((pattern, patternIndex) => {
       // Compare to all other patterns TODO: make this beat O(n^2)
-      return !patternsSortedByLength.find((p) => {
+      let includePattern = true
+      patternsSortedByLength.forEach((p, index) => {
         // Don't compare against ourself
-        if (p.id === pattern.id) return false
+        if (p.id === pattern.id) return
 
         // If the pattern has no stops, exclude it.
-        if (!p.stops || p.stops.length === 0) return false
+        if (!p.stops || p.stops.length === 0) return
+
+        // Exclude patterns higher in the list to avoid circular references among patterns of same length.
+        if (index > patternIndex) return
 
         // If our pattern is longer, it's not a subset
-        if ((p.stops?.length || 0) <= (pattern.stops?.length || 0)) return false
+        if (p.stops.length < (pattern.stops?.length || 0)) return
 
         const isSubpattern = isValidSubsequence(
           p.stops?.map((s) => s.id) || [],
@@ -111,6 +115,7 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
         )
 
         if (isSubpattern) {
+          includePattern = false
           // Populate a list of subpatterns for the larger pattern.
           if (!subPatterns[p.id]) {
             subPatterns[p.id] = []
@@ -120,6 +125,8 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
 
         return isSubpattern
       })
+
+      return includePattern
     })
 
   return {

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -90,13 +90,18 @@ export function getParentStopOrStopId(stop: StopWithParent): string {
 }
 
 /**
- * Returns a list of patterns, in descending length order, in which none is a subpattern of any other.
- * In the patterns below, only Patterns 1, 2, 5 should be retained:
+ * Computes a list of patterns, in descending length order, in which none is a subpattern of any other.
+ * In the patterns below, only Patterns 1, 2, 5 should be retained.
+ * In addition, Pattern 1 is designated as containing pattern for Pattern 3.
+ * The containing pattern for Pattern 4 could be Pattern 1 or 2,
+ * however whichever is actually picked does not really matter.
  *   Pattern 1: Stops A, B, C, D
  *   Pattern 2: Stops    B, C, D, E, F
  *   Pattern 3: Stops A, B, C
  *   Pattern 4: Stops       C, D, E
  *   Pattern 5: Stops A,    C, D, E
+ * @returns An object with a filteredPatterns field with the filtered (largest) patterns,
+ *   and a containingPatterns field with a map of the containing pattern for each pattern.
  */
 export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
   // Sort patterns by length to make algorithm below more efficient

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -107,7 +107,7 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
   const containingPatterns: Record<string, string> = {}
 
   // Filter out patterns with no stops.
-  const patternsWithStops = [...patterns].filter(
+  const patternsWithStops = patterns.filter(
     (pattern) => pattern.stops?.length
   ) as PatternWithStops[]
 
@@ -119,7 +119,7 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
     .filter((pattern, patternIndex) => {
       // Compare to all other patterns TODO: make this beat O(n^2)
       let includePattern = true
-      const patternStops = pattern.stops?.map(getParentStopOrStopId) || []
+      const patternStops = pattern.stops.map(getParentStopOrStopId) || []
 
       patternsWithStops.forEach((p, index) => {
         // Don't compare against ourself

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -10,6 +10,11 @@ export interface PatternSummary {
   lastStop?: string
 }
 
+export interface SubPatternInfo {
+  filteredPatterns: Pattern[]
+  subPatterns: Record<string, string[]>
+}
+
 export function extractMainHeadsigns(
   patterns: Record<string, Pattern>,
   shortName: string,
@@ -76,11 +81,13 @@ export function extractMainHeadsigns(
  *   Pattern 4: Stops       C, D, E
  *   Pattern 5: Stops A,    C, D, E
  */
-export function sortAndRemoveSubpatterns(patterns: Pattern[]): Pattern[] {
+export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
   // Sort patterns by length to make algorithm below more efficient
   const patternsSortedByLength = [...patterns].sort(
     (a, b) => (a.stops?.length || 0) - (b.stops?.length || 0)
   )
+
+  const subPatterns: Record<string, string[]> = {}
 
   // Remove all patterns that are subsets of larger patterns
   const filteredPatterns = patternsSortedByLength
@@ -95,14 +102,27 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): Pattern[] {
         // If our pattern is longer, it's not a subset
         if ((p.stops?.length || 0) <= (pattern.stops?.length || 0)) return false
 
-        return isValidSubsequence(
+        const isSubpattern = isValidSubsequence(
           p.stops?.map((s) => s.id) || [],
           pattern.stops?.map((s) => s.id) || []
         )
+
+        if (isSubpattern) {
+          // Populate a list of subpatterns for the larger pattern.
+          if (!subPatterns[p.id]) {
+            subPatterns[p.id] = []
+          }
+          subPatterns[p.id].push(pattern.id)
+        }
+
+        return isSubpattern
       })
     })
 
-  // Fallback for if the filtering leaves us with a silly number of patterns
-  // If this happens, it is not possible to know which pattern to keep.
-  return filteredPatterns.length > 1 ? filteredPatterns : patterns
+  return {
+    // Fallback for if the filtering leaves us with a silly number of patterns
+    // If this happens, it is not possible to know which pattern to keep.
+    filteredPatterns: filteredPatterns.length > 1 ? filteredPatterns : patterns,
+    subPatterns
+  }
 }

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -12,7 +12,7 @@ export interface PatternSummary {
   lastStop?: string
 }
 
-export interface SubPatternInfo {
+export interface ProcessedPatterns {
   containingPatterns: Record<string, string>
   filteredPatterns: Pattern[]
 }
@@ -94,7 +94,9 @@ export function getParentStopOrStopId(stop: StopWithParent): string {
  *   Pattern 4: Stops       C, D, E
  *   Pattern 5: Stops A,    C, D, E
  */
-export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
+export function sortAndRemoveSubpatterns(
+  patterns: Pattern[]
+): ProcessedPatterns {
   // Sort patterns by length to make algorithm below more efficient
   const patternsSortedByLength = [...patterns]
     .filter((pattern) => pattern.stops?.length)
@@ -124,11 +126,11 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
         const pStops = p.stops.map(getParentStopOrStopId)
         const isSubpattern = isValidSubsequence(pStops, patternStops)
         if (isSubpattern) {
-          // Include pattern if it has not been referenced before among patterns of same stops.
-          includePattern = index > patternIndex
           // Populate the highest containing pattern.
           if (!containingPatterns[pattern.id]) {
             containingPatterns[pattern.id] = p.id
+            // Include pattern if it has not been referenced before among patterns of same stops.
+            includePattern = index > patternIndex
           }
         }
       })

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -104,24 +104,24 @@ export function getParentStopOrStopId(stop: StopWithParent): string {
  *   and a containingPatterns field with a map of the containing pattern for each pattern.
  */
 export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
-  // Sort patterns by length to make algorithm below more efficient
-  const patternsSortedByLength = [...patterns].filter(
-    (pattern) => pattern.stops?.length
-  ) as PatternWithStops[]
-  patternsSortedByLength.sort((a, b) => a.stops.length - b.stops.length)
-
   const containingPatterns: Record<string, string> = {}
 
-  // Keep patterns that are not subsets of larger patterns
-  const filteredPatterns = patternsSortedByLength
-    // Start with the largest for performance
-    .reverse()
+  // Filter out patterns with no stops.
+  const patternsWithStops = [...patterns].filter(
+    (pattern) => pattern.stops?.length
+  ) as PatternWithStops[]
+
+  // Keep patterns that are not subsets of larger patterns.
+  // Assign a containing pattern to each sub pattern.
+  const filteredPatterns = patternsWithStops
+    // Sort patterns by descending length (most stops first) for efficiency.
+    .sort((a, b) => b.stops.length - a.stops.length)
     .filter((pattern, patternIndex) => {
       // Compare to all other patterns TODO: make this beat O(n^2)
       let includePattern = true
       const patternStops = pattern.stops?.map(getParentStopOrStopId) || []
 
-      patternsSortedByLength.forEach((p, index) => {
+      patternsWithStops.forEach((p, index) => {
         // Don't compare against ourself
         if (p.id === pattern.id) return
 

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -1,6 +1,7 @@
 import { Pattern } from '../components/util/types'
 
 import { extractHeadsignFromPattern } from './viewer'
+import { isValidSubsequence } from './state'
 
 export interface PatternSummary {
   geometryLength: number
@@ -64,4 +65,44 @@ export function extractMainHeadsigns(
     }
     return amended
   }, [])
+}
+
+/**
+ * Returns a list of patterns, in descending length order, in which none is a subpattern of any other.
+ * In the patterns below, only Patterns 1, 2, 5 should be retained:
+ *   Pattern 1: Stops A, B, C, D
+ *   Pattern 2: Stops    B, C, D, E, F
+ *   Pattern 3: Stops A, B, C
+ *   Pattern 4: Stops       C, D, E
+ *   Pattern 5: Stops A,    C, D, E
+ */
+export function sortAndRemoveSubpatterns(patterns: Pattern[]): Pattern[] {
+  // Sort patterns by length to make algorithm below more efficient
+  const patternsSortedByLength = [...patterns].sort(
+    (a, b) => (a.stops?.length || 0) - (b.stops?.length || 0)
+  )
+
+  // Remove all patterns that are subsets of larger patterns
+  const filteredPatterns = patternsSortedByLength
+    // Start with the largest for performance
+    .reverse()
+    .filter((pattern) => {
+      // Compare to all other patterns TODO: make this beat O(n^2)
+      return !patternsSortedByLength.find((p) => {
+        // Don't compare against ourself
+        if (p.id === pattern.id) return false
+
+        // If our pattern is longer, it's not a subset
+        if ((p.stops?.length || 0) <= (pattern.stops?.length || 0)) return false
+
+        return isValidSubsequence(
+          p.stops?.map((s) => s.id) || [],
+          pattern.stops?.map((s) => s.id) || []
+        )
+      })
+    })
+
+  // Fallback for if the filtering leaves us with a silly number of patterns
+  // If this happens, it is not possible to know which pattern to keep.
+  return filteredPatterns.length > 1 ? filteredPatterns : patterns
 }

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -81,8 +81,8 @@ export function extractMainHeadsigns(
 /**
  * Obtains the parent stop id, if available, or the stop id.
  */
-export function getParentStopOrStopGtfsId(stop: StopWithParent): string {
-  return stop.parentStation?.gtfsId || stop.gtfsId
+export function getParentStopOrStopId(stop: StopWithParent): string {
+  return stop.parentStation?.id || stop.id
 }
 
 /**
@@ -122,10 +122,10 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
         // If our pattern is longer, it's not a subset
         if (p.stops.length < (pattern.stops?.length || 0)) return
 
-        const isSubpattern = isValidSubsequence(
-          p.stops?.map(getParentStopOrStopGtfsId) || [],
-          pattern.stops?.map(getParentStopOrStopGtfsId) || []
-        )
+        const pStops = p.stops?.map(getParentStopOrStopId) || []
+        const patternStops = pattern.stops?.map(getParentStopOrStopId) || []
+
+        const isSubpattern = isValidSubsequence(pStops, patternStops)
 
         if (isSubpattern) {
           includePattern = false

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -12,7 +12,7 @@ export interface PatternSummary {
   lastStop?: string
 }
 
-export interface ProcessedPatterns {
+export interface SubPatternInfo {
   containingPatterns: Record<string, string>
   filteredPatterns: Pattern[]
 }
@@ -94,9 +94,7 @@ export function getParentStopOrStopId(stop: StopWithParent): string {
  *   Pattern 4: Stops       C, D, E
  *   Pattern 5: Stops A,    C, D, E
  */
-export function sortAndRemoveSubpatterns(
-  patterns: Pattern[]
-): ProcessedPatterns {
+export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
   // Sort patterns by length to make algorithm below more efficient
   const patternsSortedByLength = [...patterns]
     .filter((pattern) => pattern.stops?.length)
@@ -126,11 +124,11 @@ export function sortAndRemoveSubpatterns(
         const pStops = p.stops.map(getParentStopOrStopId)
         const isSubpattern = isValidSubsequence(pStops, patternStops)
         if (isSubpattern) {
+          // Include pattern if it has not been referenced before among patterns of same stops.
+          includePattern = index > patternIndex
           // Populate the highest containing pattern.
           if (!containingPatterns[pattern.id]) {
             containingPatterns[pattern.id] = p.id
-            // Include pattern if it has not been referenced before among patterns of same stops.
-            includePattern = index > patternIndex
           }
         }
       })

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -109,6 +109,8 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
     .filter((pattern, patternIndex) => {
       // Compare to all other patterns TODO: make this beat O(n^2)
       let includePattern = true
+      const patternStops = pattern.stops?.map(getParentStopOrStopId) || []
+
       patternsSortedByLength.forEach((p, index) => {
         // Don't compare against ourself
         if (p.id === pattern.id) return
@@ -117,13 +119,10 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
         if (!p.stops || p.stops.length === 0) return
 
         // If our pattern is longer, it's not a subset
-        if (p.stops.length < (pattern.stops?.length || 0)) return
+        if (p.stops.length < patternStops.length) return
 
-        const pStops = p.stops?.map(getParentStopOrStopId) || []
-        const patternStops = pattern.stops?.map(getParentStopOrStopId) || []
-
+        const pStops = p.stops.map(getParentStopOrStopId)
         const isSubpattern = isValidSubsequence(pStops, patternStops)
-
         if (isSubpattern) {
           // Include pattern if it has not been referenced before among patterns of same stops.
           includePattern = index > patternIndex

--- a/lib/util/pattern-viewer.ts
+++ b/lib/util/pattern-viewer.ts
@@ -21,6 +21,10 @@ export interface StopWithParent extends Stop {
   parentStation?: Stop
 }
 
+interface PatternWithStops extends Pattern {
+  stops: Stop[]
+}
+
 export function extractMainHeadsigns(
   patterns: Record<string, Pattern>,
   shortName: string,
@@ -96,9 +100,10 @@ export function getParentStopOrStopId(stop: StopWithParent): string {
  */
 export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
   // Sort patterns by length to make algorithm below more efficient
-  const patternsSortedByLength = [...patterns]
-    .filter((pattern) => pattern.stops?.length)
-    .sort((a, b) => (a.stops?.length || 0) - (b.stops?.length || 0))
+  const patternsSortedByLength = [...patterns].filter(
+    (pattern) => pattern.stops?.length
+  ) as PatternWithStops[]
+  patternsSortedByLength.sort((a, b) => a.stops.length - b.stops.length)
 
   const containingPatterns: Record<string, string> = {}
 
@@ -114,9 +119,6 @@ export function sortAndRemoveSubpatterns(patterns: Pattern[]): SubPatternInfo {
       patternsSortedByLength.forEach((p, index) => {
         // Don't compare against ourself
         if (p.id === pattern.id) return
-
-        // If the pattern has no stops, exclude it.
-        if (!p.stops || p.stops.length === 0) return
 
         // If our pattern is longer, it's not a subset
         if (p.stops.length < patternStops.length) return


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

This PR changes the pattern viewer so that vehicles in patterns equal or contained in the viewed pattern are displayed.
Previously, these vehicles would not be displayed except when viewing the entire route.

Behind the scene, each pattern in a route is mapped to the largest containing pattern in that route.
To resolve internal pattern duplication, different stops in the same parent station are considered the same.
Note that patterns previously hidden might emerge from this fix (e.g. "Beacon Hill" in Sound Transit in the screenshot below, which is an actual partial terminus of the 1-Line).

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
| ![before screenshot](https://github.com/user-attachments/assets/010f708c-27f3-4206-aebc-9c48f2fbe401) | ![after screenshot](https://github.com/user-attachments/assets/cdb66928-7285-4dad-bbed-8317c4081d4a) |

