### PR TITLE
fix map attribution in trip preview

### DIFF
--- a/lib/components/app/trip-preview-layout-base.tsx
+++ b/lib/components/app/trip-preview-layout-base.tsx
@@ -34,6 +34,7 @@ type Props = {
 }
 
 type State = {
+  attributionHTML?: string
   mapVisible?: boolean
 }
 
@@ -54,8 +55,13 @@ class TripPreviewLayoutBase extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
     this.state = {
+      attributionHTML: undefined,
       mapVisible: true
     }
+  }
+
+  _setInnerHtml = (innerAttributionContent: string) => {
+    this.setState({ attributionHTML: innerAttributionContent })
   }
 
   _toggleMap = () => {
@@ -88,10 +94,13 @@ class TripPreviewLayoutBase extends Component<Props, State> {
     } = this.props
     const { LegIcon } = this.context
 
-    // The maplibre attribution can interfere with the map visually when printing, so we'll copy the map attribution and inject it instead below the map container.
-    const attributionHTML = document.querySelector(
+    const innerAttributionContent = document.querySelector(
       '.maplibregl-ctrl-attrib-inner'
     )?.innerHTML
+
+    if (innerAttributionContent) {
+      this._setInnerHtml(innerAttributionContent)
+    }
 
     return (
       <div className="otp print-layout">
@@ -131,9 +140,11 @@ class TripPreviewLayoutBase extends Component<Props, State> {
         {/* The map, if visible */}
         {this.state.mapVisible && mapElement}
 
-        {attributionHTML && (
+        {this.state.attributionHTML && this.state.mapVisible && (
           <CustomAttribution>
-            <div dangerouslySetInnerHTML={{ __html: attributionHTML }} />
+            <div
+              dangerouslySetInnerHTML={{ __html: this.state.attributionHTML }}
+            />
           </CustomAttribution>
         )}
 


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
- Makes sure to only show the attribution if the map is visible
- Fixes a bug where the map un-mounting would cause the attribution text to be set to `undefined`

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

