### PR TITLE
Calltaker: Make trinetReDirect optional

### DIFF
--- a/example/example-config.yml
+++ b/example/example-config.yml
@@ -306,9 +306,8 @@ modes:
     - mode: BICYCLE
       label: Transit + Bike
 
-# # The following modules require the datastoreUrl and trinetReDirect properties
-# # to be set. Note: Most of these components are currently only configured for
-# # TriMet.
+# # The following modules require the datastoreUrl to be set.
+# # trinetReDirect is optional, however omitting it requires pre-configured sessions.
 # datastoreUrl: https://localhost:9000
 # trinetReDirect: https://localhost:9001
 # modules:

--- a/lib/actions/call-taker.js
+++ b/lib/actions/call-taker.js
@@ -107,7 +107,6 @@ export function initializeModules(intl) {
     const { datastoreUrl, trinetReDirect } = getState().otp.config
     // Initialize session if datastore enabled.
     if (datastoreUrl) {
-      // TODO: Generalize for non-TriNet instances.
       const sessionId = getUrlParams().sessionId
       if (sessionId) {
         // Initialize the session if found in URL query params.

--- a/lib/actions/call-taker.js
+++ b/lib/actions/call-taker.js
@@ -63,15 +63,13 @@ function newSession(datastoreUrl, verifyLoginUrl, redirect) {
   fetch(datastoreUrl + '/auth/newSession')
     .then((res) => res.json())
     .then((data) => {
-      if (!isBlank(verifyLoginUrl)) {
-        const { sessionId: session } = data
-        const windowUrl = `${verifyLoginUrl}?${qs.stringify({
-          redirect,
-          session
-        })}`
-        // Redirect to login url.
-        window.location = windowUrl
-      }
+      const { sessionId: session } = data
+      const windowUrl = `${verifyLoginUrl}?${qs.stringify({
+        redirect,
+        session
+      })}`
+      // Redirect to login url.
+      window.location = windowUrl
     })
     .catch((error) => {
       console.error('newSession error', error)
@@ -114,9 +112,11 @@ export function initializeModules(intl) {
       if (sessionId) {
         // Initialize the session if found in URL query params.
         dispatch(checkSession(datastoreUrl, sessionId, intl))
-      } else {
+      } else if (!isBlank(trinetReDirect)) {
         // No sessionId was passed in, so we must request one from server.
         newSession(datastoreUrl, trinetReDirect, window.location.origin)
+      } else {
+        alert('A session ID is required to use Call Taker.')
       }
     }
   }

--- a/lib/actions/call-taker.js
+++ b/lib/actions/call-taker.js
@@ -4,6 +4,7 @@ import { serialize } from 'object-to-formdata'
 import qs from 'qs'
 
 import { getISOLikeTimestamp } from '../util/state'
+import { isBlank } from '../util/ui'
 import { isModuleEnabled, Modules } from '../util/config'
 import { searchToQuery, sessionIsInvalid } from '../util/call-taker'
 
@@ -62,13 +63,15 @@ function newSession(datastoreUrl, verifyLoginUrl, redirect) {
   fetch(datastoreUrl + '/auth/newSession')
     .then((res) => res.json())
     .then((data) => {
-      const { sessionId: session } = data
-      const windowUrl = `${verifyLoginUrl}?${qs.stringify({
-        redirect,
-        session
-      })}`
-      // Redirect to login url.
-      window.location = windowUrl
+      if (!isBlank(verifyLoginUrl)) {
+        const { sessionId: session } = data
+        const windowUrl = `${verifyLoginUrl}?${qs.stringify({
+          redirect,
+          session
+        })}`
+        // Redirect to login url.
+        window.location = windowUrl
+      }
     })
     .catch((error) => {
       console.error('newSession error', error)
@@ -105,7 +108,7 @@ export function initializeModules(intl) {
   return function (dispatch, getState) {
     const { datastoreUrl, trinetReDirect } = getState().otp.config
     // Initialize session if datastore enabled.
-    if (datastoreUrl && trinetReDirect) {
+    if (datastoreUrl) {
       // TODO: Generalize for non-TriNet instances.
       const sessionId = getUrlParams().sessionId
       if (sessionId) {


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

This PR makes the `trinetReDirect` config param optional.

As a result, for the call button and call history and Field Trip list to appear, a preconfigured `sessionId` must be passed in the web URL. (An alert is shown otherwise.)

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)? => Not really needed for Calltaker.
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

