### PR TITLE
[narriative itinerary] Show Bike Time when Bike time exceeds walk time

### DIFF
--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -16,7 +16,11 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { ComponentContext } from '../../../util/contexts'
-import { getFare, getFirstLegStartTime } from '../../../util/itinerary'
+import {
+  getFare,
+  getFirstLegStartTime,
+  getTotalTimeForMode
+} from '../../../util/itinerary'
 import { Icon, StyledIconWrapperTextAlign } from '../../util/styledIcon'
 import { itineraryHasAccessibilityScore } from '../../../util/accessibility-routing'
 import { localizeGradationMap } from '../utils'
@@ -174,20 +178,28 @@ const ITINERARY_ATTRIBUTES = [
         leg.mode = 'WALK'
       }
 
+      // TODO: Handle other types of time? (scooter/car)
+      // TODO: handle bike/walk time check more dynamically?
+      const bikeTime = getTotalTimeForMode(itinerary.legs, 'BICYCLE')
+      const walkTime = itinerary.walkTime
+
+      const mostSignifigantMode = bikeTime > walkTime ? 'BICYCLE' : 'WALK'
+      const mostSignifigantTime =
+        mostSignifigantMode === 'BICYCLE' ? bikeTime : walkTime
+
       const { LegIcon } = options
       return (
-        // FIXME: For CAR mode, walk time considers driving time.
         <>
           <FormattedDuration
             duration={
-              itinerary.walkTime > 0
-                ? ensureAtLeastOneMinute(itinerary.walkTime)
-                : itinerary.walkTime
+              mostSignifigantTime > 0
+                ? ensureAtLeastOneMinute(mostSignifigantTime)
+                : mostSignifigantTime
             }
             includeSeconds={false}
           />
           <LegIconWrapper noSpace>
-            <LegIcon leg={{ ...leg, mode: 'WALK' }} size={5} />
+            <LegIcon leg={{ ...leg, mode: mostSignifigantMode }} size={5} />
           </LegIconWrapper>
         </>
       )

--- a/lib/util/itinerary.tsx
+++ b/lib/util/itinerary.tsx
@@ -121,6 +121,14 @@ export function getLastLegEndTime(legs: Leg[]): number {
   return +legs[legs.length - 1].endTime
 }
 
+// TODO: is there a type for OTP Modes?
+export function getTotalTimeForMode(legs: Leg[], mode: string): number {
+  return legs
+    .filter((l) => l.mode === mode)
+    .map((l) => l.duration)
+    .reduce((acc, cur) => acc + cur, 0)
+}
+
 export function sortStartTimes(
   startTimes: ItineraryStartTime[]
 ): ItineraryStartTime[] {


### PR DESCRIPTION
I'd like to have a cleaner solution that encompasses all modes. However, as the narrative itinerary is not used outside calltaker, this quick patch which only enables bike time felt cleaner. If we find the narrative itinerary seeing heavier use again, we can revisit this to dynamically determine the longest non-transit mode, and display the time for that mode.