### PR TITLE
Correct Nearby View Stop Card Headsign Merging Behavior

### DIFF
--- a/lib/components/viewers/nearby/stop.tsx
+++ b/lib/components/viewers/nearby/stop.tsx
@@ -63,6 +63,8 @@ export const patternArrayforStops = (
   return stopData?.stoptimesForPatterns
     ?.reduce<PatternStopTime[]>((acc, cur) => {
       const currentHeadsign = extractHeadsignFromPattern(cur.pattern)
+      // TODO: Extract routes out
+      // https://github.com/opentripplanner/otp-react-redux/pull/1533#discussion_r2844679701
       const dupe = acc.findIndex((p) => {
         // TODO: use OTP_generated ids
         let sameRoute = false

--- a/lib/components/viewers/nearby/stop.tsx
+++ b/lib/components/viewers/nearby/stop.tsx
@@ -69,13 +69,15 @@ export const patternArrayforStops = (
         if (p.pattern.route?.shortName && cur.pattern.route?.shortName) {
           sameRoute =
             p.pattern.route?.shortName === cur.pattern.route?.shortName
-        } else if (p.pattern.route?.longName && cur.pattern.route?.longName) {
-          sameRoute = p.pattern.route?.longName === cur.pattern.route?.longName
-        } else if (
-          p?.stoptimes?.[0]?.headsign &&
-          cur?.stoptimes?.[0]?.headsign
-        ) {
+        }
+        if (p.pattern.route?.longName && cur.pattern.route?.longName) {
           sameRoute =
+            sameRoute &&
+            p.pattern.route?.longName === cur.pattern.route?.longName
+        }
+        if (p?.stoptimes?.[0]?.headsign && cur?.stoptimes?.[0]?.headsign) {
+          sameRoute =
+            sameRoute &&
             p?.stoptimes?.[0]?.headsign === cur?.stoptimes?.[0]?.headsign
         }
         return (


### PR DESCRIPTION
Previously, this behavior relied on a complicated `if else` tree. This tree turned out not to work the way I expected. Instead of working our way down the tree, we instead skipped out at the first branch that passed. I removed the `else`s, and replicated that behavior by adding an additional check for past checks to also have passed.

I'm sure there's a cleaner way to represent these series of checks, and would appreciate an alternative.