### PR TITLE
support `vehicleIconCaret` override

### DIFF
--- a/lib/components/map/connected-caret.tsx
+++ b/lib/components/map/connected-caret.tsx
@@ -1,0 +1,25 @@
+import { Circle, withCaret } from '@opentripplanner/transit-vehicle-overlay'
+import { useSelector } from 'react-redux'
+import { VehicleComponentProps } from '@opentripplanner/transit-vehicle-overlay/lib/types'
+import React, { HTMLAttributes } from 'react'
+
+import { AppReduxState } from '../../util/state-types'
+
+const ConnectedCaret = (
+  props: HTMLAttributes<HTMLDivElement> & VehicleComponentProps
+): JSX.Element => {
+  const caretOptions = useSelector(
+    (state: AppReduxState) => state.otp.config.routeViewer?.vehicleIconCaret
+  )
+
+  const CaretTouchingBorder = withCaret(Circle, {
+    height: 5,
+    offset: 1.5,
+    width: 10,
+    ...caretOptions
+  })
+
+  return <CaretTouchingBorder {...props} />
+}
+
+export default ConnectedCaret

--- a/lib/components/map/connected-transit-vehicle-overlay.tsx
+++ b/lib/components/map/connected-transit-vehicle-overlay.tsx
@@ -15,8 +15,6 @@ import { FormattedMessage, FormattedNumber, useIntl } from 'react-intl'
 import { TransitVehicle } from '@opentripplanner/types'
 import React from 'react'
 import TransitVehicleOverlay, {
-  Circle,
-  withCaret,
   withRouteColorBackground
 } from '@opentripplanner/transit-vehicle-overlay'
 
@@ -25,6 +23,8 @@ import { capitalizeFirst } from '../../util/ui'
 import { DEFAULT_ROUTE_COLOR } from '../util/colors'
 import { formatDuration } from '../util/formatted-duration'
 import FormattedTransitVehicleStatus from '../util/formatted-transit-vehicle-status'
+
+import ConnectedCaret from './connected-caret'
 
 interface TransitVehicleExt extends TransitVehicle {
   label?: string
@@ -115,11 +115,7 @@ function VehicleTooltip({
 }
 
 // Settings where caret is touching the border of the circle.
-const CaretTouchingBorder = withCaret(Circle, {
-  height: 5,
-  offset: 1.5,
-  width: 10
-})
+const CaretTouchingBorder = ConnectedCaret
 
 // Round vehicle symbol with arrow/caret on the border,
 // and showing the route color with a transparent effect on hover.

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -376,6 +376,8 @@ export interface RouteViewerConfig {
   sortRoutePatternsByVehicleCount?: boolean
   /** Whether to use the route color as the background color in the pattern viewer */
   useRouteColorAsBackground?: boolean
+  /** Configure the caret on the realtime vehicle bubble (settings from OTP-UI props) */
+  vehicleIconCaret?: { height?: number; offset?: number; width?: number }
   /** Disable vehicle highlight if necessary (e.g. custom or inverted icons) */
   vehicleIconHighlight?: boolean
   /** Customize vehicle icon padding (the default iconPadding is 2px in otp-ui) */

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -377,7 +377,12 @@ export interface RouteViewerConfig {
   /** Whether to use the route color as the background color in the pattern viewer */
   useRouteColorAsBackground?: boolean
   /** Configure the caret on the realtime vehicle bubble (settings from OTP-UI props) */
-  vehicleIconCaret?: { height?: number; offset?: number; width?: number }
+  vehicleIconCaret?: {
+    height?: number
+    offset?: number
+    position?: 'inner' | 'outer'
+    width?: number
+  }
   /** Disable vehicle highlight if necessary (e.g. custom or inverted icons) */
   vehicleIconHighlight?: boolean
   /** Customize vehicle icon padding (the default iconPadding is 2px in otp-ui) */


### PR DESCRIPTION
Some intense refactoring was required to be able to expose the otp-ui caret customization props to the redux state. But the `config.yaml` can now override the caret appearance!