### PR TITLE
Calltaker Config for Copy Itinerary URL, Remove Router ID Code

### DIFF
--- a/lib/components/form/error-message.tsx
+++ b/lib/components/form/error-message.tsx
@@ -41,7 +41,6 @@ const ErrorMessage = ({
         </IconWithText>
       </div>
       <div className="message">{message}</div>
-      {/* @ts-expect-error TODO: typescript TripTools */}
       {!warning && <TripTools buttonTypes={['START_OVER', 'REPORT_ISSUE']} />}
     </div>
   )

--- a/lib/components/narrative/trip-tools.js
+++ b/lib/components/narrative/trip-tools.js
@@ -11,11 +11,14 @@ import { Undo } from '@styled-icons/fa-solid/Undo'
 import { withRouter } from 'react-router'
 import bowser from 'bowser'
 import copyToClipboard from 'copy-to-clipboard'
+import coreUtils from '@opentripplanner/core-utils'
 import PropTypes from 'prop-types'
+import qs from 'qs'
 import React, { Component, useContext, useMemo } from 'react'
 
 import * as uiActions from '../../actions/ui'
 import { ComponentContext } from '../../util/contexts'
+import { getModuleConfig, Modules } from '../../util/config'
 import { IconWithText } from '../util/styledIcon'
 import InvisibleA11yLabel from '../util/invisible-a11y-label'
 import PopupTriggerText from '../app/popup-trigger-text'
@@ -46,6 +49,11 @@ class CopyUrlButton extends Component {
           routerId
         )
       }
+    }
+    if (this.props.copyItineraryUrl) {
+      // Copy query params without sessionId.
+      const params = { ...coreUtils.query.getUrlParams(), sessionId: undefined }
+      url = `${this.props.copyItineraryUrl}/#/?${qs.stringify(params)}`
     }
     copyToClipboard(url)
     this.setState({ showCopied: true })
@@ -79,6 +87,10 @@ class CopyUrlButton extends Component {
       </div>
     )
   }
+}
+
+CopyUrlButton.propTypes = {
+  copyItineraryUrl: PropTypes.string
 }
 
 // Print Button Component
@@ -184,6 +196,7 @@ LinkButton.propTypes = {
 
 const TripTools = ({
   buttonTypes,
+  copyItineraryUrl,
   popupTarget,
   reportConfig,
   setPopupContent,
@@ -205,7 +218,9 @@ const TripTools = ({
   buttonTypes.forEach((type) => {
     switch (type) {
       case 'COPY_URL':
-        buttonComponents.push(<CopyUrlButton />)
+        buttonComponents.push(
+          <CopyUrlButton copyItineraryUrl={copyItineraryUrl} />
+        )
         break
       case 'PRINT':
         buttonComponents.push(<PrintButton />)
@@ -258,6 +273,7 @@ const TripTools = ({
 
 TripTools.propTypes = {
   buttonTypes: PropTypes.arrayOf(PropTypes.string),
+  copyItineraryUrl: PropTypes.string,
   popupTarget: PropTypes.string,
   reportConfig: PropTypes.object,
   setPopupContent: PropTypes.func,
@@ -271,7 +287,9 @@ TripTools.defaultProps = {
 // Connect main class to redux store
 
 const mapStateToProps = (state) => {
+  const callTakerConfig = getModuleConfig(state, Modules.CALL_TAKER)
   return {
+    copyItineraryUrl: callTakerConfig?.options?.copyItineraryUrl,
     popupTarget: state.otp.config?.popups?.launchers?.itineraryFooter,
     reportConfig: state.otp.config.reportIssue
   }

--- a/lib/components/narrative/trip-tools.tsx
+++ b/lib/components/narrative/trip-tools.tsx
@@ -165,7 +165,9 @@ interface LinkButtonProps {
 
 class LinkButton extends Component<LinkButtonProps> {
   _onClick = () => {
-    this.props.url && (window.location.href = this.props.url)
+    if (this.props.url) {
+      window.location.href = this.props.url
+    }
   }
 
   render() {
@@ -225,7 +227,7 @@ const TripTools = ({
     return IconComponent
   }, [SvgIcon, popupTarget])
 
-  const buttonComponents = [] as ReactNode[]
+  const buttonComponents: ReactNode[] = []
   buttonTypes.forEach((type) => {
     switch (type) {
       case 'COPY_URL':

--- a/lib/components/narrative/trip-tools.tsx
+++ b/lib/components/narrative/trip-tools.tsx
@@ -1,32 +1,46 @@
-/* eslint-disable no-case-declarations */
 import { Button } from 'react-bootstrap'
 import { Check } from '@styled-icons/fa-solid/Check'
 import { Clipboard } from '@styled-icons/fa-solid/Clipboard'
 import { connect } from 'react-redux'
 import { Flag } from '@styled-icons/fa-solid/Flag'
-import { FormattedMessage, injectIntl } from 'react-intl'
+import { FormattedMessage, injectIntl, WrappedComponentProps } from 'react-intl'
 import { Print } from '@styled-icons/fa-solid/Print'
-import { StyledIconBase } from '@styled-icons/styled-icon'
 import { Undo } from '@styled-icons/fa-solid/Undo'
-import { withRouter } from 'react-router'
 import bowser from 'bowser'
 import copyToClipboard from 'copy-to-clipboard'
 import coreUtils from '@opentripplanner/core-utils'
-import PropTypes from 'prop-types'
 import qs from 'qs'
-import React, { Component, useContext, useMemo } from 'react'
+import React, {
+  Component,
+  ComponentType,
+  CSSProperties,
+  ReactNode,
+  SVGProps,
+  useContext,
+  useMemo
+} from 'react'
 
 import * as uiActions from '../../actions/ui'
+import { AppReduxState } from '../../util/state-types'
 import { ComponentContext } from '../../util/contexts'
 import { getModuleConfig, Modules } from '../../util/config'
 import { IconWithText } from '../util/styledIcon'
+import { ReportIssueConfig } from '../../util/config-types'
 import InvisibleA11yLabel from '../util/invisible-a11y-label'
 import PopupTriggerText from '../app/popup-trigger-text'
 
 // Copy URL Button
 
-class CopyUrlButton extends Component {
-  constructor(props) {
+interface CopyUrlButtonProps {
+  copyItineraryUrl?: string
+}
+
+interface CopyUrlButtonState {
+  showCopied: boolean
+}
+
+class CopyUrlButton extends Component<CopyUrlButtonProps, CopyUrlButtonState> {
+  constructor(props: CopyUrlButtonProps) {
     super(props)
     this.state = { showCopied: false }
   }
@@ -89,17 +103,13 @@ class CopyUrlButton extends Component {
   }
 }
 
-CopyUrlButton.propTypes = {
-  copyItineraryUrl: PropTypes.string
-}
-
 // Print Button Component
 
 class PrintButton extends Component {
   _onClick = () => {
     // Note: this is designed to work only with hash routing.
     const printUrl = window.location.href.replace('#', '#/print')
-    window.location = printUrl
+    window.location.href = printUrl
   }
 
   render() {
@@ -117,7 +127,9 @@ class PrintButton extends Component {
 
 // Report Issue Button Component
 
-class ReportIssueButtonBase extends Component {
+class ReportIssueButtonBase extends Component<
+  ReportIssueConfig & WrappedComponentProps
+> {
   _onClick = () => {
     const { intl, mailto, subject: configuredSubject } = this.props
     const subject =
@@ -146,18 +158,11 @@ class ReportIssueButtonBase extends Component {
     return (
       <Button className="tool-button" onClick={this._onClick}>
         <IconWithText Icon={Flag}>
-          {/* FIXME: Depending on translation, Spanish and French strings may not fit in button width. */}
           <FormattedMessage id="components.TripTools.reportIssue" />
         </IconWithText>
       </Button>
     )
   }
-}
-
-ReportIssueButtonBase.propTypes = {
-  intl: PropTypes.object,
-  mailto: PropTypes.string,
-  subject: PropTypes.string
 }
 
 // The ReportIssueButton component above, with an intl prop
@@ -166,9 +171,16 @@ const ReportIssueButton = injectIntl(ReportIssueButtonBase)
 
 // Link to URL Button
 
-class LinkButton extends Component {
+interface LinkButtonProps {
+  Icon: ComponentType
+  onClick: () => void
+  text: ReactNode
+  url?: string
+}
+
+class LinkButton extends Component<LinkButtonProps> {
   _onClick = () => {
-    window.location.href = this.props.url
+    this.props.url && (window.location.href = this.props.url)
   }
 
   render() {
@@ -187,34 +199,48 @@ class LinkButton extends Component {
   }
 }
 
-LinkButton.propTypes = {
-  Icon: PropTypes.elementType,
-  onClick: PropTypes.func,
-  text: PropTypes.element,
-  url: PropTypes.string
+interface TripToolsProps {
+  buttonTypes?: string[]
+  copyItineraryUrl?: string
+  popupTarget?: string
+  reportConfig?: ReportIssueConfig
+  setPopupContent: (target: string) => void
+  startOverFromInitialUrl: () => void
+}
+
+// FIXME: See app.js for original definition.
+interface SvgIconProps {
+  Fallback?: unknown
+  className?: string
+  iconName?: string
+  style?: CSSProperties
 }
 
 const TripTools = ({
-  buttonTypes,
+  buttonTypes = [
+    'COPY_URL',
+    'PRINT',
+    'REPORT_ISSUE',
+    'START_OVER',
+    'POPUP_LINK'
+  ],
   copyItineraryUrl,
   popupTarget,
   reportConfig,
   setPopupContent,
   startOverFromInitialUrl
-}) => {
-  const { SvgIcon } = useContext(ComponentContext)
+}: TripToolsProps) => {
+  const { SvgIcon } = useContext(ComponentContext) as {
+    SvgIcon: ComponentType<SvgIconProps>
+  }
   const PopupIcon = useMemo(() => {
-    const IconComponent = (componentProps) => {
-      return (
-        <StyledIconBase>
-          <SvgIcon iconName={popupTarget} {...componentProps} />
-        </StyledIconBase>
-      )
-    }
+    const IconComponent = (componentProps: SVGProps<SVGSVGElement>) => (
+      <SvgIcon iconName={popupTarget} {...componentProps} />
+    )
     return IconComponent
   }, [SvgIcon, popupTarget])
 
-  const buttonComponents = []
+  const buttonComponents = [] as ReactNode[]
   buttonTypes.forEach((type) => {
     switch (type) {
       case 'COPY_URL':
@@ -271,22 +297,9 @@ const TripTools = ({
   )
 }
 
-TripTools.propTypes = {
-  buttonTypes: PropTypes.arrayOf(PropTypes.string),
-  copyItineraryUrl: PropTypes.string,
-  popupTarget: PropTypes.string,
-  reportConfig: PropTypes.object,
-  setPopupContent: PropTypes.func,
-  startOverFromInitialUrl: PropTypes.func
-}
-
-TripTools.defaultProps = {
-  buttonTypes: ['COPY_URL', 'PRINT', 'REPORT_ISSUE', 'START_OVER', 'POPUP_LINK']
-}
-
 // Connect main class to redux store
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state: AppReduxState) => {
   const callTakerConfig = getModuleConfig(state, Modules.CALL_TAKER)
   return {
     copyItineraryUrl: callTakerConfig?.options?.copyItineraryUrl,
@@ -299,6 +312,4 @@ const mapDispatchToProps = {
   startOverFromInitialUrl: uiActions.startOverFromInitialUrl
 }
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(TripTools)
-)
+export default connect(mapStateToProps, mapDispatchToProps)(TripTools)

--- a/lib/components/narrative/trip-tools.tsx
+++ b/lib/components/narrative/trip-tools.tsx
@@ -208,7 +208,7 @@ interface TripToolsProps {
   startOverFromInitialUrl: () => void
 }
 
-// FIXME: See app.js for original definition.
+// FIXME: Combine with the same type from app.js when converting that to TS.
 interface SvgIconProps {
   Fallback?: unknown
   className?: string

--- a/lib/components/narrative/trip-tools.tsx
+++ b/lib/components/narrative/trip-tools.tsx
@@ -48,22 +48,7 @@ class CopyUrlButton extends Component<CopyUrlButtonProps, CopyUrlButtonState> {
   _resetState = () => this.setState({ showCopied: false })
 
   _onClick = () => {
-    // If special routerId has been set in session storage, construct copy URL
-    // for itinerary with #/start/ prefix to set routerId on page load.
-    const routerId = window.sessionStorage.getItem('routerId')
     let url = window.location.href
-    if (routerId) {
-      const parts = url.split('#')
-      if (parts.length === 2) {
-        url = `${parts[0]}#/start/x/x/x/${routerId}${parts[1]}`
-      } else {
-        // Console logs are not internationalized.
-        console.warn(
-          'URL not formatted as expected, copied URL will not contain session routerId.',
-          routerId
-        )
-      }
-    }
     if (this.props.copyItineraryUrl) {
       // Copy query params without sessionId.
       const params = { ...coreUtils.query.getUrlParams(), sessionId: undefined }

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -255,6 +255,7 @@ export interface MapConfig {
 /** Settings for reporting issues */
 export interface ReportIssueConfig {
   mailto: string
+  subject?: string
 }
 
 export interface ItineraryCostConfig {


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

This PR adds a new calltaker config param that sets the target host of the "Copy Link" button in the itinerary narrative.
That way, the copied URL can be set to a non-calltaker OTP-RR instance for sharing with the general public.

trip-tools.js is converted to TypeScript in the process, and OTP1 router ID code is removed.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

