### PR TITLE
Support Sort by Emissions

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -381,7 +381,7 @@ components:
     selectCost: Cost
     selectDepartureTime: Departure time
     selectDuration: Duration
-    selectEmissions: CO2 emissions
+    selectEmissions: CO₂ emissions
     selectFare: Transit fare
     selectWalkTime: Walk time
     sortResults: Sort results

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -381,6 +381,7 @@ components:
     selectCost: Cost
     selectDepartureTime: Departure time
     selectDuration: Duration
+    selectEmissions: CO2 emissions
     selectFare: Transit fare
     selectWalkTime: Walk time
     sortResults: Sort results

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -405,6 +405,7 @@ components:
     selectCost: Prix
     selectDepartureTime: Heure de départ
     selectDuration: Durée
+    selectEmissions: Émissions de CO₂
     selectFare: Prix du trajet
     selectWalkTime: Temps de marche
     sortResults: Trier les résultats

--- a/lib/components/util/sortOptions.ts
+++ b/lib/components/util/sortOptions.ts
@@ -14,7 +14,7 @@ export const sortOptions = (
     'COST',
     'DEPARTURETIME',
     'FARE'
-    // Emissions is disabled by default, as it does nothing unless co2 calculation is enabled
+    // Emissions is disabled by default, as it does nothing unless CO₂ calculation is enabled
   ]
 ): SortOptionEntry[] => {
   const sortOptionsArray: SortOptionEntry[] = [

--- a/lib/components/util/sortOptions.ts
+++ b/lib/components/util/sortOptions.ts
@@ -14,6 +14,7 @@ export const sortOptions = (
     'COST',
     'DEPARTURETIME',
     'FARE'
+    // Emissions is disabled by default, as it does nothing unless co2 calculation is enabled
   ]
 ): SortOptionEntry[] => {
   const sortOptionsArray: SortOptionEntry[] = [
@@ -58,6 +59,12 @@ export const sortOptions = (
         id: 'components.NarrativeItinerariesHeader.selectFare'
       }),
       value: 'FARE'
+    },
+    {
+      text: intl.formatMessage({
+        id: 'components.NarrativeItinerariesHeader.selectEmissions'
+      }),
+      value: 'EMISSIONS'
     }
   ]
 

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -271,6 +271,7 @@ export type ItinerarySortOption =
   | 'COST'
   | 'DEPARTURETIME'
   | 'FARE'
+  | 'EMISSIONS'
 
 export interface ItineraryCostWeights {
   driveReluctance: number

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -63,6 +63,8 @@ export function sortItineraries(type, direction, a, b, config) {
       return dirFactor * (a.totalFare - b.totalFare)
     case 'FARE':
       return compareItineraryFare(a.transitFare, b.transitFare, direction)
+    case 'EMISSIONS':
+      return dirFactor * (a.co2 - b.co2)
     default:
       if (type !== 'BEST')
         console.warn(`Sort (${type}) not supported. Defaulting to BEST.`)


### PR DESCRIPTION
Allows sorting by emissions. I won't lie it's a bit confusing which way shows the highest and lowest emissions... 

It's disabled by default as the co2 values are 0 if the co2 calculation is disabled.