### PR TITLE
Omit "haptic" from trip notifications

### DIFF
--- a/lib/components/user/monitored-trip/trip-notifications-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-notifications-pane.tsx
@@ -13,7 +13,8 @@ import {
 } from '../common/dropdown-options'
 import { FieldSet } from '../styled'
 import { IconWithText } from '../../util/styledIcon'
-import { MonitoredTrip } from '../types'
+import { isBlank } from '../../../util/ui'
+import { MonitoredTrip, notificationChannels } from '../types'
 
 // Element styles
 const SettingsList = styled.ul`
@@ -68,7 +69,7 @@ class TripNotificationsPane extends Component<Props> {
   render(): JSX.Element {
     const { isReadOnly, notificationChannel, values } = this.props
     const areNotificationsDisabled =
-      notificationChannel === 'none' || !notificationChannel?.length
+      notificationChannel === 'none' || isBlank(notificationChannel)
     // Define a common trip delay field for simplicity, set to the smallest between the
     // retrieved departure/arrival delay attributes.
     const commonDelayThreshold = Math.min(
@@ -96,7 +97,7 @@ class TripNotificationsPane extends Component<Props> {
     } else {
       const selectedChannels = notificationChannel
         .split(',')
-        .filter((channel) => channel?.length)
+        .filter((channel) => notificationChannels.includes(channel))
         .map((channel) => (
           <FormattedMessage
             id={`common.notifications.${channel}`}

--- a/lib/components/user/notification-prefs-pane.tsx
+++ b/lib/components/user/notification-prefs-pane.tsx
@@ -9,16 +9,13 @@ import { AppReduxState } from '../../util/state-types'
 import { GREY_ON_WHITE } from '../util/colors'
 
 import { FieldSet } from './styled'
-import { User } from './types'
+import { NotificationChannel, notificationChannels, User } from './types'
 import PhoneNumberEditor from './phone-number-editor'
 
 interface Props extends FormikProps<User> {
-  allowedNotificationChannels: string[]
+  allowedNotificationChannels: ReadonlyArray<NotificationChannel>
   loggedInUser: User
 }
-
-const allNotificationChannels = ['email', 'sms', 'push']
-const emailAndSms = ['email', 'sms']
 
 // Styles
 const NotificationOption = styled(ListGroupItem)`
@@ -117,12 +114,12 @@ const mapStateToProps = (state: AppReduxState) => {
   const { persistence } = state.otp.config
   const supportsPushNotifications =
     persistence && 'otp_middleware' in persistence
-      ? persistence.otp_middleware?.supportsPushNotifications
+      ? persistence?.otp_middleware?.supportsPushNotifications
       : false
   return {
     allowedNotificationChannels: supportsPushNotifications
-      ? allNotificationChannels
-      : emailAndSms
+      ? notificationChannels
+      : ['email', 'sms']
   }
 }
 

--- a/lib/components/user/types.ts
+++ b/lib/components/user/types.ts
@@ -49,6 +49,7 @@ export const notificationChannels: ReadonlyArray<string> = [
   'push'
 ]
 
+export type NotificationChannel = typeof notificationChannels[number]
 /**
  * Type definition for an OTP-middleware (OTP-personas) user.
  */
@@ -62,7 +63,7 @@ export interface User {
   id?: string
   isPhoneNumberVerified?: boolean
   mobilityProfile?: MobilityProfile
-  notificationChannel?: string
+  notificationChannel?: NotificationChannel
   phoneNumber?: string
   preferredLocale?: string
   pushDevices?: number

--- a/lib/components/user/types.ts
+++ b/lib/components/user/types.ts
@@ -43,6 +43,12 @@ export interface DependentInfo {
   userId: string
 }
 
+export const notificationChannels: ReadonlyArray<string> = [
+  'email',
+  'sms',
+  'push'
+]
+
 /**
  * Type definition for an OTP-middleware (OTP-personas) user.
  */

--- a/lib/components/user/types.ts
+++ b/lib/components/user/types.ts
@@ -63,7 +63,7 @@ export interface User {
   id?: string
   isPhoneNumberVerified?: boolean
   mobilityProfile?: MobilityProfile
-  notificationChannel?: NotificationChannel
+  notificationChannel?: string
   phoneNumber?: string
   preferredLocale?: string
   pushDevices?: number


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

This PR tweaks the trip notification label to only include known notification channels (email, SMS, push).

If haptic was set via the mobile app (or in Mongo, append `haptic` to the `OtpUser > notificationChannels` attribute (see existing behavior screenshot below), it is now excluded.

<img width="1390" height="322" alt="image" src="https://github.com/user-attachments/assets/72ce9c63-4626-4b0a-a29c-6f1b1c93a3bf" />



<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

