### PR TITLE
create `appendParams` mode for popups

### DIFF
--- a/lib/components/app/popup.tsx
+++ b/lib/components/app/popup.tsx
@@ -36,7 +36,7 @@ const isMobile = coreUtils.ui.isMobile()
 const PopupWrapper = ({ content, hideModal }: Props): JSX.Element | null => {
   const intl = useIntl()
 
-  const { appendLocale, id, modal, url } = content || {}
+  const { appendLocale, appendParams, id, modal, url } = content || {}
 
   const closeText = intl.formatMessage({ id: 'common.forms.close' })
 
@@ -46,7 +46,7 @@ const PopupWrapper = ({ content, hideModal }: Props): JSX.Element | null => {
   // appendLocale is true by default, so undefined is true
   const compiledUrl = `${url}${
     appendLocale !== false ? intl.defaultLocale : ''
-  }`
+  }${appendParams === true ? window.location.hash : ''}`
 
   useEffect(() => {
     if (!useIframe && shown) {

--- a/lib/components/narrative/narrative-itineraries-header.tsx
+++ b/lib/components/narrative/narrative-itineraries-header.tsx
@@ -201,7 +201,10 @@ export default function NarrativeItinerariesHeader({
           )}
           <ItinerariesHeaderContainer showHeaderText={showHeaderText}>
             {popupTarget && (
-              <button onClick={() => setPopupContent(popupTarget)}>
+              <button
+                className="popup-button"
+                onClick={() => setPopupContent(popupTarget)}
+              >
                 <PopupTriggerText compact popupTarget={popupTarget} />
               </button>
             )}

--- a/lib/reducers/create-otp-reducer.js
+++ b/lib/reducers/create-otp-reducer.js
@@ -1045,6 +1045,7 @@ function createOtpReducer(config) {
           ui: {
             popup: {
               appendLocale: { $set: target?.appendLocale },
+              appendParams: { $set: target?.appendParams },
               id: { $set: action.payload },
               // Explicit check done so that `true` is default
               modal: { $set: target?.modal !== false },

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -141,6 +141,7 @@ export type PersistenceConfig = (
 /** Popup target settings */
 export interface PopupTargetConfig {
   appendLocale?: boolean
+  appendParams?: boolean
   modal?: boolean
   url?: string
 }


### PR DESCRIPTION
Allows for popup links to have all current URL params copied to the poup