### PR TITLE
Recheck trip existence

### DIFF
--- a/__tests__/reducers/__snapshots__/create-user-reducer.js.snap
+++ b/__tests__/reducers/__snapshots__/create-user-reducer.js.snap
@@ -3,7 +3,6 @@
 exports[`lib > reducers > create-user-reducer should be able to create the initial state 1`] = `
 Object {
   "accessToken": null,
-  "itineraryExistence": null,
   "lastPhoneSmsRequest": Object {
     "number": null,
     "status": null,

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -656,6 +656,7 @@ components:
     travelingAt: Traveling at {milesPerHour}
     vehicleName: Vehicle {vehicleNumber}
   TripBasicsPane:
+    checkAgain: Check again
     checkingItineraryExistence: Checking itinerary existence for each day of the week...
     indicatesRequiredFields: Fields marked with an asterisk (*) are required.
     onlyOnDate: Only on {date, date, ::eeeee yyyyMMdd}

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -696,6 +696,7 @@ components:
     travelingAt: "Vitesse : {milesPerHour}"
     vehicleName: Véhicule {vehicleNumber}
   TripBasicsPane:
+    checkAgain: Revérifier
     checkingItineraryExistence: Vérification du trajet pour chaque jour de la 
       semaine...
     indicatesRequiredFields: Les champs marqués d'une astérisque (*) sont 

--- a/lib/actions/user.js
+++ b/lib/actions/user.js
@@ -50,8 +50,6 @@ const setCurrentUserTripRequests = createAction(
 const setDependentUserInfo = createAction('SET_DEPENDENT_USER_INFO')
 const setLastPhoneSmsRequest = createAction('SET_LAST_PHONE_SMS_REQUEST')
 export const setPathBeforeSignIn = createAction('SET_PATH_BEFORE_SIGNIN')
-export const clearItineraryExistence = createAction('CLEAR_ITINERARY_EXISTENCE')
-const setitineraryExistence = createAction('SET_ITINERARY_EXISTENCE')
 
 // localStorage user actions
 export const deleteLocalUserRecentPlace = createAction(
@@ -688,14 +686,11 @@ export function verifyPhoneNumber(code, intl) {
 /**
  * Check itinerary existence for the given monitored trip.
  */
-export function checkItineraryExistence(trip, intl) {
+export function checkItineraryExistence(trip) {
   return async function (dispatch, getState) {
     const state = getState()
     const { accessToken, apiBaseUrl, apiKey } = getMiddlewareVariables(state)
     const requestUrl = `${apiBaseUrl}${API_MONITORED_TRIP_PATH}/checkitinerary`
-
-    // Empty state before performing the checks.
-    dispatch(clearItineraryExistence())
 
     const { data, status } = await secureFetch(
       requestUrl,
@@ -706,14 +701,7 @@ export function checkItineraryExistence(trip, intl) {
         body: JSON.stringify(trip)
       }
     )
-
-    if (status === 'success' && data) {
-      dispatch(setitineraryExistence(data))
-    } else {
-      alert(
-        intl.formatMessage({ id: 'actions.user.itineraryExistenceCheckFailed' })
-      )
-    }
+    return status === 'success' && data ? data : null
   }
 }
 

--- a/lib/components/user/monitored-trip/trip-basics-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-basics-pane.tsx
@@ -1,12 +1,11 @@
+import { connect } from 'react-redux'
 import {
-  Button,
   ControlLabel,
   FormControl,
   FormGroup,
   HelpBlock,
   Radio
 } from 'react-bootstrap'
-import { connect } from 'react-redux'
 import { Field, FormikProps } from 'formik'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import { Prompt } from 'react-router'

--- a/lib/components/user/monitored-trip/trip-basics-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-basics-pane.tsx
@@ -401,6 +401,25 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
       /* Hack: because the selected days checkboxes are not grouped, we need to assign this error to one of the 
       checkboxes so that the FormikErrorFocus works. */
       const selectOneDayError = errorStates.monday
+      const dayButtons = (
+        <>
+          <RenderAvailableDays
+            errorCheckingTrip={errorCheckingTrip}
+            errorSelectingDays={
+              disableSingleItineraryDays ? selectOneDayError : undefined
+            }
+            finalItineraryExistence={finalItineraryExistence}
+            isReadOnly={isReadOnly}
+            monitoredTrip={monitoredTrip}
+          />
+          {!isCreating && (
+            <Button onClick={this._handleRecheckItineraryExistence}>
+              Check again
+            </Button>
+          )}
+        </>
+      )
+
       return (
         <div>
           {/* TODO: This component does not block navigation on reload or using the back button.
@@ -448,18 +467,7 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
                 <FormattedMessage id="components.TripBasicsPane.tripDaysPrompt" />
                 {!isReadOnly && <RequiredIndicator>*</RequiredIndicator>}
               </ControlLabel>
-              <RenderAvailableDays
-                errorCheckingTrip={errorCheckingTrip}
-                errorSelectingDays={selectOneDayError}
-                finalItineraryExistence={finalItineraryExistence}
-                isReadOnly={isReadOnly}
-                monitoredTrip={monitoredTrip}
-              />
-              {!isCreating && (
-                <Button onClick={this._handleRecheckItineraryExistence}>
-                  Check again
-                </Button>
-              )}
+              {dayButtons}
             </FormGroup>
           ) : (
             <FormGroup>
@@ -473,21 +481,7 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
               >
                 <FormattedMessage id="components.TripBasicsPane.recurringEachWeek" />
               </Radio>
-              {!isOneTime && (
-                <>
-                  <RenderAvailableDays
-                    errorCheckingTrip={errorCheckingTrip}
-                    finalItineraryExistence={finalItineraryExistence}
-                    isReadOnly={isReadOnly}
-                    monitoredTrip={monitoredTrip}
-                  />
-                  {!isCreating && (
-                    <Button onClick={this._handleRecheckItineraryExistence}>
-                      Check again
-                    </Button>
-                  )}
-                </>
-              )}
+              {!isOneTime && dayButtons}
               <Radio
                 checked={isOneTime}
                 disabled={isReadOnly}

--- a/lib/components/user/monitored-trip/trip-basics-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-basics-pane.tsx
@@ -219,7 +219,7 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
               disabled={isRecheckingExistence}
               onClick={this._handleRecheckItineraryExistence}
             >
-              Check again
+              <FormattedMessage id="components.TripBasicsPane.checkAgain" />
             </Button>
           )}
         </>

--- a/lib/components/user/monitored-trip/trip-basics-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-basics-pane.tsx
@@ -1,6 +1,6 @@
 import { Ban } from '@styled-icons/fa-solid/Ban'
-import { connect } from 'react-redux'
 import {
+  Button,
   ControlLabel,
   FormControl,
   FormGroup,
@@ -8,6 +8,7 @@ import {
   ProgressBar,
   Radio
 } from 'react-bootstrap'
+import { connect } from 'react-redux'
 import { Field, FormikProps } from 'formik'
 import { FormattedMessage, injectIntl, useIntl } from 'react-intl'
 import { Prompt } from 'react-router'
@@ -196,7 +197,6 @@ const RenderAvailableDays = ({
               title={notAvailableText}
             >
               <Field
-                // TODO: improve checking trip availability.
                 disabled={isDayDisabled}
                 id={day}
                 name={day}
@@ -340,6 +340,18 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
     this.props.clearItineraryExistence()
   }
 
+  _handleRecheckItineraryExistence = () => {
+    // Check itinerary availability (existence) for all days if not already done.
+    const {
+      checkItineraryExistence,
+      intl,
+      setIsLoading,
+      values: monitoredTrip
+    } = this.props
+    setIsLoading && setIsLoading(true)
+    checkItineraryExistence(monitoredTrip, intl)
+  }
+
   // eslint-disable-next-line complexity
   render() {
     const {
@@ -443,6 +455,11 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
                 isReadOnly={isReadOnly}
                 monitoredTrip={monitoredTrip}
               />
+              {!isCreating && (
+                <Button onClick={this._handleRecheckItineraryExistence}>
+                  Check again
+                </Button>
+              )}
             </FormGroup>
           ) : (
             <FormGroup>
@@ -451,7 +468,6 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
               </ControlLabel>
               <Radio
                 checked={!isOneTime}
-                // FIXME: Temporary solution until itinerary existence check is fixed.
                 disabled={errorCheckingTrip || isReadOnly}
                 onChange={this._handleRecurringTrip}
               >
@@ -465,6 +481,11 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
                     isReadOnly={isReadOnly}
                     monitoredTrip={monitoredTrip}
                   />
+                  {!isCreating && (
+                    <Button onClick={this._handleRecheckItineraryExistence}>
+                      Check again
+                    </Button>
+                  )}
                 </>
               )}
               <Radio

--- a/lib/components/user/monitored-trip/trip-basics-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-basics-pane.tsx
@@ -48,6 +48,7 @@ type TripBasicsProps = WrappedComponentProps &
   }
 
 interface State {
+  isRecheckingExistence: boolean
   selectedDays: string[] | null
 }
 
@@ -70,6 +71,7 @@ function isDisabled(day: string, itineraryExistence?: ItineraryExistence) {
  */
 class TripBasicsPane extends Component<TripBasicsProps, State> {
   state = {
+    isRecheckingExistence: false,
     selectedDays: null
   }
 
@@ -165,7 +167,8 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
     this.props.clearItineraryExistence()
   }
 
-  _handleRecheckItineraryExistence = () => {
+  _handleRecheckItineraryExistence = async () => {
+    this.setState({ isRecheckingExistence: true })
     // Check itinerary availability (existence) for all days if not already done.
     const {
       checkItineraryExistence,
@@ -174,7 +177,8 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
       values: monitoredTrip
     } = this.props
     setIsLoading && setIsLoading(true)
-    checkItineraryExistence(monitoredTrip, intl)
+    await checkItineraryExistence(monitoredTrip, intl)
+    this.setState({ isRecheckingExistence: false })
   }
 
   // eslint-disable-next-line complexity
@@ -192,8 +196,10 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
       values: monitoredTrip
     } = this.props
     const { itinerary } = monitoredTrip
-    const finalItineraryExistence =
-      monitoredTrip.itineraryExistence || itineraryExistence
+    const { isRecheckingExistence } = this.state
+    const finalItineraryExistence = isRecheckingExistence
+      ? undefined
+      : monitoredTrip.itineraryExistence || itineraryExistence
 
     // Prevent user from leaving when form has been changed,
     // but don't show it when they click submit or cancel.
@@ -238,7 +244,10 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
             monitoredTrip={monitoredTrip}
           />
           {!isCreating && (
-            <Button onClick={this._handleRecheckItineraryExistence}>
+            <Button
+              disabled={isRecheckingExistence}
+              onClick={this._handleRecheckItineraryExistence}
+            >
               Check again
             </Button>
           )}

--- a/lib/components/user/monitored-trip/trip-basics-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-basics-pane.tsx
@@ -33,7 +33,7 @@ import TripMonitoredDaySelector, {
   isDisabled
 } from './trip-monitored-day-selector'
 import TripStatus from './trip-status'
-import TripSummaryPane from './trip-summary-pane'
+import TripSummaryPane, { ToggleNotificationButton } from './trip-summary-pane'
 
 type TripBasicsProps = WrappedComponentProps &
   FormikProps<MonitoredTrip> & {
@@ -216,7 +216,7 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
             monitoredTrip={monitoredTrip}
           />
           {!isCreating && (
-            <Button
+            <ToggleNotificationButton
               disabled={isRecheckingExistence}
               onClick={this._handleRecheckItineraryExistence}
             >
@@ -225,7 +225,7 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
               ) : (
                 <FormattedMessage id="components.TripBasicsPane.checkAgain" />
               )}
-            </Button>
+            </ToggleNotificationButton>
           )}
         </>
       )

--- a/lib/components/user/monitored-trip/trip-basics-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-basics-pane.tsx
@@ -14,7 +14,7 @@ import { Prompt } from 'react-router'
 import FormikErrorFocus from 'formik-error-focus'
 import React, { Component, FormEventHandler } from 'react'
 import styled from 'styled-components'
-import type { IntlShape, WrappedComponentProps } from 'react-intl'
+import type { WrappedComponentProps } from 'react-intl'
 
 import * as userActions from '../../../actions/user'
 import {
@@ -36,18 +36,16 @@ type TripBasicsProps = WrappedComponentProps &
   FormikProps<MonitoredTrip> & {
     canceled: boolean
     checkItineraryExistence: (
-      monitoredTrip: MonitoredTrip,
-      intl: IntlShape
-    ) => void
-    clearItineraryExistence: () => void
+      monitoredTrip: MonitoredTrip
+    ) => Promise<ItineraryExistence>
     disableSingleItineraryDays?: boolean
     isCreating: boolean
     isReadOnly: boolean
-    itineraryExistence?: ItineraryExistence
     setIsLoading?: (arg: boolean) => void
   }
 
 interface State {
+  fetchedItineraryExistence: ItineraryExistence | null
   isRecheckingExistence: boolean
   selectedDays: string[] | null
 }
@@ -61,44 +59,26 @@ const RequiredIndicator = styled.span`
   margin-left: 5px;
 `
 
-function isDisabled(day: string, itineraryExistence?: ItineraryExistence) {
+function isDisabled(
+  day: string,
+  itineraryExistence?: ItineraryExistence | null
+) {
   return itineraryExistence && !itineraryExistence[day]?.valid
 }
 
 /**
  * This component shows summary information for a trip
- * and lets the user edit the trip name and day.
+ * and lets the user edit the trip name and monitored day.
  */
 class TripBasicsPane extends Component<TripBasicsProps, State> {
   state = {
+    fetchedItineraryExistence: null,
     isRecheckingExistence: false,
     selectedDays: null
   }
 
-  /**
-   * For new trips only, update the Formik state to
-   * uncheck days for which the itinerary is not available.
-   */
-  _updateNewTripItineraryExistence = (prevProps: TripBasicsProps) => {
-    const { isCreating, itineraryExistence, setFieldValue } = this.props
-
-    if (
-      isCreating &&
-      itineraryExistence &&
-      itineraryExistence !== prevProps.itineraryExistence
-    ) {
-      ALL_DAYS.forEach((day) => {
-        if (!itineraryExistence[day].valid) {
-          setFieldValue(day, false)
-        }
-      })
-    }
-  }
-
   _getDaysFromItineraryExistence = () => {
-    const { itineraryExistence, values: trip } = this.props
-    const finalItineraryExistence =
-      trip.itineraryExistence || itineraryExistence
+    const finalItineraryExistence = this.state.fetchedItineraryExistence
     return ALL_DAYS.filter((day) => finalItineraryExistence?.[day]?.valid)
   }
 
@@ -136,35 +116,14 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
 
   componentDidMount() {
     // Check itinerary availability (existence) for all days if not already done.
-    const {
-      checkItineraryExistence,
-      intl,
-      setIsLoading,
-      values: monitoredTrip
-    } = this.props
+    const { values: monitoredTrip } = this.props
     if (!monitoredTrip.itineraryExistence) {
-      setIsLoading && setIsLoading(true)
-      checkItineraryExistence(monitoredTrip, intl)
+      this._handleRecheckItineraryExistence()
+    } else {
+      this.setState({
+        fetchedItineraryExistence: monitoredTrip.itineraryExistence
+      })
     }
-  }
-
-  componentDidUpdate(prevProps: TripBasicsProps) {
-    this._updateNewTripItineraryExistence(prevProps)
-    const {
-      itineraryExistence,
-      setIsLoading,
-      values: monitoredTrip
-    } = this.props
-    if (
-      (monitoredTrip?.itineraryExistence || itineraryExistence) &&
-      setIsLoading
-    ) {
-      setIsLoading(false)
-    }
-  }
-
-  componentWillUnmount() {
-    this.props.clearItineraryExistence()
   }
 
   _handleRecheckItineraryExistence = async () => {
@@ -172,13 +131,24 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
     // Check itinerary availability (existence) for all days if not already done.
     const {
       checkItineraryExistence,
-      intl,
+      setFieldValue,
       setIsLoading,
       values: monitoredTrip
     } = this.props
     setIsLoading && setIsLoading(true)
-    await checkItineraryExistence(monitoredTrip, intl)
+    const newExistence = await checkItineraryExistence(monitoredTrip)
+    this.setState({
+      fetchedItineraryExistence: newExistence
+    })
+    setIsLoading && setIsLoading(false)
     this.setState({ isRecheckingExistence: false })
+    if (newExistence) {
+      ALL_DAYS.forEach((day) => {
+        if (!newExistence[day].valid) {
+          setFieldValue(day, false)
+        }
+      })
+    }
   }
 
   // eslint-disable-next-line complexity
@@ -192,14 +162,13 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
       isCreating,
       isReadOnly,
       isSubmitting,
-      itineraryExistence,
       values: monitoredTrip
     } = this.props
     const { itinerary } = monitoredTrip
-    const { isRecheckingExistence } = this.state
+    const { fetchedItineraryExistence, isRecheckingExistence } = this.state
     const finalItineraryExistence = isRecheckingExistence
       ? undefined
-      : monitoredTrip.itineraryExistence || itineraryExistence
+      : fetchedItineraryExistence
 
     // Prevent user from leaving when form has been changed,
     // but don't show it when they click submit or cancel.
@@ -340,17 +309,14 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
 // Connect to redux store
 
 const mapStateToProps = (state: AppReduxState) => {
-  const { itineraryExistence } = state.user
   const { disableSingleItineraryDays } = state.otp.config
   return {
-    disableSingleItineraryDays,
-    itineraryExistence
+    disableSingleItineraryDays
   }
 }
 
 const mapDispatchToProps = {
-  checkItineraryExistence: userActions.checkItineraryExistence,
-  clearItineraryExistence: userActions.clearItineraryExistence
+  checkItineraryExistence: userActions.checkItineraryExistence
 }
 
 export default connect(

--- a/lib/components/user/monitored-trip/trip-basics-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-basics-pane.tsx
@@ -71,10 +71,13 @@ function isDisabled(
  * and lets the user edit the trip name and monitored day.
  */
 class TripBasicsPane extends Component<TripBasicsProps, State> {
-  state = {
-    fetchedItineraryExistence: null,
-    isRecheckingExistence: false,
-    selectedDays: null
+  constructor(props: TripBasicsProps) {
+    super(props)
+    this.state = {
+      fetchedItineraryExistence: null,
+      isRecheckingExistence: false,
+      selectedDays: null
+    }
   }
 
   _getDaysFromItineraryExistence = () => {

--- a/lib/components/user/monitored-trip/trip-basics-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-basics-pane.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../../util/monitored-trip'
 import { AppReduxState } from '../../../util/state-types'
 import { getErrorStates } from '../../../util/ui'
+import { InlineLoading } from '../../narrative/loading'
 import { ItineraryExistence, MonitoredTrip } from '../types'
 import { RED_ON_WHITE } from '../../util/colors'
 import FormattedValidationError from '../../util/formatted-validation-error'
@@ -219,7 +220,11 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
               disabled={isRecheckingExistence}
               onClick={this._handleRecheckItineraryExistence}
             >
-              <FormattedMessage id="components.TripBasicsPane.checkAgain" />
+              {isRecheckingExistence ? (
+                <InlineLoading />
+              ) : (
+                <FormattedMessage id="components.TripBasicsPane.checkAgain" />
+              )}
             </Button>
           )}
         </>

--- a/lib/components/user/monitored-trip/trip-basics-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-basics-pane.tsx
@@ -61,6 +61,10 @@ const RequiredIndicator = styled.span`
   margin-left: 5px;
 `
 
+const RecheckTripButton = styled(ToggleNotificationButton)`
+  margin-top: -10px;
+`
+
 /**
  * This component shows summary information for a trip
  * and lets the user edit the trip name and monitored day.
@@ -215,7 +219,9 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
             monitoredTrip={monitoredTrip}
           />
           {!isCreating && (
-            <ToggleNotificationButton
+            <RecheckTripButton
+              // Use same text color as the trip existence text above.
+              className="help-block"
               disabled={isRecheckingExistence}
               onClick={this._handleRecheckItineraryExistence}
             >
@@ -224,7 +230,7 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
               ) : (
                 <FormattedMessage id="components.TripBasicsPane.checkAgain" />
               )}
-            </ToggleNotificationButton>
+            </RecheckTripButton>
           )}
         </>
       )

--- a/lib/components/user/monitored-trip/trip-basics-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-basics-pane.tsx
@@ -148,14 +148,12 @@ const RenderAvailableDays = ({
   errorCheckingTrip,
   errorSelectingDays,
   finalItineraryExistence,
-  isCreating,
   isReadOnly,
   monitoredTrip
 }: {
   errorCheckingTrip: boolean
   errorSelectingDays?: 'error' | null
   finalItineraryExistence?: ItineraryExistence
-  isCreating: boolean
   isReadOnly: boolean
   monitoredTrip: MonitoredTrip
 }) => {
@@ -442,7 +440,6 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
                 errorCheckingTrip={errorCheckingTrip}
                 errorSelectingDays={selectOneDayError}
                 finalItineraryExistence={finalItineraryExistence}
-                isCreating={isCreating}
                 isReadOnly={isReadOnly}
                 monitoredTrip={monitoredTrip}
               />
@@ -465,7 +462,6 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
                   <RenderAvailableDays
                     errorCheckingTrip={errorCheckingTrip}
                     finalItineraryExistence={finalItineraryExistence}
-                    isCreating={isCreating}
                     isReadOnly={isReadOnly}
                     monitoredTrip={monitoredTrip}
                   />

--- a/lib/components/user/monitored-trip/trip-basics-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-basics-pane.tsx
@@ -1,16 +1,14 @@
-import { Ban } from '@styled-icons/fa-solid/Ban'
 import {
   Button,
   ControlLabel,
   FormControl,
   FormGroup,
   HelpBlock,
-  ProgressBar,
   Radio
 } from 'react-bootstrap'
 import { connect } from 'react-redux'
 import { Field, FormikProps } from 'formik'
-import { FormattedMessage, injectIntl, useIntl } from 'react-intl'
+import { FormattedMessage, injectIntl } from 'react-intl'
 import { Prompt } from 'react-router'
 // @ts-expect-error FormikErrorFocus does not support TypeScript yet.
 import FormikErrorFocus from 'formik-error-focus'
@@ -22,20 +20,15 @@ import * as userActions from '../../../actions/user'
 import {
   ALL_DAYS,
   arrayToDayFields,
-  dayFieldsToArray,
-  getFormattedDayOfWeekPlural
+  dayFieldsToArray
 } from '../../../util/monitored-trip'
 import { AppReduxState } from '../../../util/state-types'
-import { FieldSet } from '../styled'
-import { getBaseColor, RED_ON_WHITE } from '../../util/colors'
 import { getErrorStates } from '../../../util/ui'
 import { ItineraryExistence, MonitoredTrip } from '../types'
-import FormattedDayOfWeek from '../../util/formatted-day-of-week'
-import FormattedDayOfWeekCompact from '../../util/formatted-day-of-week-compact'
+import { RED_ON_WHITE } from '../../util/colors'
 import FormattedValidationError from '../../util/formatted-validation-error'
-import InvisibleA11yLabel from '../../util/invisible-a11y-label'
 
-import MonitoredDays, { MonitoredDayCircle } from './trip-monitored-days'
+import TripMonitoredDaySelector from './trip-monitored-day-selector'
 import TripStatus from './trip-status'
 import TripSummaryPane from './trip-summary-pane'
 
@@ -62,80 +55,6 @@ const TripSummaryContainer = styled.div`
   margin: 3em 0;
 `
 
-// Styles.
-const AvailableDays = styled(FieldSet)`
-  display: flex;
-  gap: 4px;
-
-  // Targets the formik checkboxes to provide better contrast on focus styles
-  input {
-    &:focus-visible,
-    &:focus {
-      outline-offset: 0.5px;
-      outline: solid 2px blue;
-      &:checked {
-        outline: solid 2px white;
-      }
-    }
-  }
-  & > span {
-    align-items: center;
-    border-radius: 3rem;
-    box-sizing: border-box;
-    display: inline-flex;
-    flex-direction: row-reverse;
-    height: 3rem;
-    min-width: 4.5rem;
-    position: relative;
-    text-align: center;
-    width: 5rem;
-  }
-  svg {
-    color: ${RED_ON_WHITE};
-    display: none;
-    /* Remove top attribute set by Bootstrap. */
-    top: inherit;
-    width: 1.3rem;
-  }
-
-  input,
-  svg {
-    flex-shrink: 0;
-    /* Remove bootstrap's vertical margin */
-    margin: 0 7px 0 2px;
-  }
-
-  /* Check boxes for disabled days are replaced with the cross mark. */
-  input[disabled] {
-    display: none;
-  }
-  input[disabled] ~ svg {
-    display: block;
-  }
-
-  /* Add oblique strike for disabled days */
-  .disabled-day::after {
-    border-top: 2px solid ${RED_ON_WHITE};
-    content: '';
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 45%;
-    transform: rotate(-30deg);
-    transform-origin: center;
-  }
-
-  label {
-    flex-grow: 1;
-    font-weight: inherit;
-    height: 100%;
-    line-height: 3rem;
-    margin: 0;
-    position: relative;
-    text-align: center;
-  }
-`
-
 const RequiredIndicator = styled.span`
   color: ${RED_ON_WHITE};
   margin-left: 5px;
@@ -143,100 +62,6 @@ const RequiredIndicator = styled.span`
 
 function isDisabled(day: string, itineraryExistence?: ItineraryExistence) {
   return itineraryExistence && !itineraryExistence[day]?.valid
-}
-
-const RenderAvailableDays = ({
-  errorCheckingTrip,
-  errorSelectingDays,
-  finalItineraryExistence,
-  isReadOnly,
-  monitoredTrip
-}: {
-  errorCheckingTrip: boolean
-  errorSelectingDays?: 'error' | null
-  finalItineraryExistence?: ItineraryExistence
-  isReadOnly: boolean
-  monitoredTrip: MonitoredTrip
-}) => {
-  const intl = useIntl()
-  const baseColor = getBaseColor()
-
-  if (isReadOnly) {
-    return <MonitoredDays days={dayFieldsToArray(monitoredTrip)} />
-  }
-
-  return (
-    <>
-      {errorCheckingTrip && (
-        <>
-          {/* FIXME: Temporary solution until itinerary existence check is fixed. */}
-          <br />
-          <FormattedMessage id="actions.user.itineraryExistenceCheckFailed" />
-        </>
-      )}
-      <AvailableDays>
-        {ALL_DAYS.map((day) => {
-          const isDayDisabled = isDisabled(day, finalItineraryExistence)
-          const labelClass = isDayDisabled ? 'disabled-day' : ''
-          const notAvailableText = isDayDisabled
-            ? intl.formatMessage(
-                {
-                  id: 'components.TripBasicsPane.tripNotAvailableOnDay'
-                },
-                {
-                  repeatedDay: getFormattedDayOfWeekPlural(day, intl)
-                }
-              )
-            : ''
-
-          return (
-            <MonitoredDayCircle
-              baseColor={baseColor}
-              key={day}
-              monitored={!isDayDisabled && monitoredTrip[day]}
-              title={notAvailableText}
-            >
-              <Field
-                disabled={isDayDisabled}
-                id={day}
-                name={day}
-                type="checkbox"
-              />
-              <Ban aria-hidden />
-              <label htmlFor={day}>
-                <InvisibleA11yLabel>
-                  <FormattedDayOfWeek day={day} />
-                </InvisibleA11yLabel>
-                <span aria-hidden className={labelClass}>
-                  {/* The abbreviated text is visual only. Screen readers should read out the full day. */}
-                  <FormattedDayOfWeekCompact day={day} />
-                </span>
-              </label>
-              <InvisibleA11yLabel>{notAvailableText}</InvisibleA11yLabel>
-            </MonitoredDayCircle>
-          )
-        })}
-      </AvailableDays>
-      <HelpBlock role="status">
-        {finalItineraryExistence ? (
-          <FormattedMessage id="components.TripBasicsPane.tripIsAvailableOnDaysIndicated" />
-        ) : (
-          <ProgressBar
-            active
-            label={
-              <FormattedMessage id="components.TripBasicsPane.checkingItineraryExistence" />
-            }
-            now={100}
-          />
-        )}
-      </HelpBlock>
-      <HelpBlock role="alert">
-        {errorSelectingDays && (
-          <FormattedValidationError type="select-at-least-one-day" />
-        )}
-      </HelpBlock>
-    </>
-  )
 }
 
 /**
@@ -403,7 +228,7 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
       const selectOneDayError = errorStates.monday
       const dayButtons = (
         <>
-          <RenderAvailableDays
+          <TripMonitoredDaySelector
             errorCheckingTrip={errorCheckingTrip}
             errorSelectingDays={
               disableSingleItineraryDays ? selectOneDayError : undefined

--- a/lib/components/user/monitored-trip/trip-basics-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-basics-pane.tsx
@@ -28,7 +28,9 @@ import { ItineraryExistence, MonitoredTrip } from '../types'
 import { RED_ON_WHITE } from '../../util/colors'
 import FormattedValidationError from '../../util/formatted-validation-error'
 
-import TripMonitoredDaySelector from './trip-monitored-day-selector'
+import TripMonitoredDaySelector, {
+  isDisabled
+} from './trip-monitored-day-selector'
 import TripStatus from './trip-status'
 import TripSummaryPane from './trip-summary-pane'
 
@@ -59,13 +61,6 @@ const RequiredIndicator = styled.span`
   margin-left: 5px;
 `
 
-function isDisabled(
-  day: string,
-  itineraryExistence?: ItineraryExistence | null
-) {
-  return itineraryExistence && !itineraryExistence[day]?.valid
-}
-
 /**
  * This component shows summary information for a trip
  * and lets the user edit the trip name and monitored day.
@@ -81,8 +76,8 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
   }
 
   _getDaysFromItineraryExistence = () => {
-    const finalItineraryExistence = this.state.fetchedItineraryExistence
-    return ALL_DAYS.filter((day) => finalItineraryExistence?.[day]?.valid)
+    const itineraryExistence = this.state.fetchedItineraryExistence
+    return ALL_DAYS.filter((day) => itineraryExistence?.[day]?.valid)
   }
 
   _handleRecurringTrip: FormEventHandler<Radio> = (e) => {
@@ -145,13 +140,11 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
     })
     setIsLoading && setIsLoading(false)
     this.setState({ isRecheckingExistence: false })
-    if (newExistence) {
-      ALL_DAYS.forEach((day) => {
-        if (!newExistence[day].valid) {
-          setFieldValue(day, false)
-        }
-      })
-    }
+    ALL_DAYS.forEach((day) => {
+      if (isDisabled(day, newExistence)) {
+        setFieldValue(day, false)
+      }
+    })
   }
 
   // eslint-disable-next-line complexity

--- a/lib/components/user/monitored-trip/trip-basics-pane.tsx
+++ b/lib/components/user/monitored-trip/trip-basics-pane.tsx
@@ -129,6 +129,7 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
     // Check itinerary availability (existence) for all days if not already done.
     const {
       checkItineraryExistence,
+      intl,
       setFieldValue,
       setIsLoading,
       values: monitoredTrip
@@ -138,6 +139,11 @@ class TripBasicsPane extends Component<TripBasicsProps, State> {
     this.setState({
       fetchedItineraryExistence: newExistence
     })
+    if (!newExistence) {
+      alert(
+        intl.formatMessage({ id: 'actions.user.itineraryExistenceCheckFailed' })
+      )
+    }
     setIsLoading && setIsLoading(false)
     this.setState({ isRecheckingExistence: false })
     ALL_DAYS.forEach((day) => {

--- a/lib/components/user/monitored-trip/trip-monitored-day-selector.tsx
+++ b/lib/components/user/monitored-trip/trip-monitored-day-selector.tsx
@@ -1,0 +1,195 @@
+import { Ban } from '@styled-icons/fa-solid/Ban'
+import { Field } from 'formik'
+import { FormattedMessage, useIntl } from 'react-intl'
+import { HelpBlock, ProgressBar } from 'react-bootstrap'
+import React from 'react'
+import styled from 'styled-components'
+
+import {
+  ALL_DAYS,
+  dayFieldsToArray,
+  getFormattedDayOfWeekPlural
+} from '../../../util/monitored-trip'
+import { FieldSet } from '../styled'
+import { getBaseColor, RED_ON_WHITE } from '../../util/colors'
+import { ItineraryExistence, MonitoredTrip } from '../types'
+import FormattedDayOfWeek from '../../util/formatted-day-of-week'
+import FormattedDayOfWeekCompact from '../../util/formatted-day-of-week-compact'
+import FormattedValidationError from '../../util/formatted-validation-error'
+import InvisibleA11yLabel from '../../util/invisible-a11y-label'
+
+import MonitoredDays, { MonitoredDayCircle } from './trip-monitored-days'
+
+// Styles.
+const AvailableDays = styled(FieldSet)`
+  display: flex;
+  gap: 4px;
+
+  // Targets the formik checkboxes to provide better contrast on focus styles
+  input {
+    &:focus-visible,
+    &:focus {
+      outline-offset: 0.5px;
+      outline: solid 2px blue;
+      &:checked {
+        outline: solid 2px white;
+      }
+    }
+  }
+  & > span {
+    align-items: center;
+    border-radius: 3rem;
+    box-sizing: border-box;
+    display: inline-flex;
+    flex-direction: row-reverse;
+    height: 3rem;
+    min-width: 4.5rem;
+    position: relative;
+    text-align: center;
+    width: 5rem;
+  }
+  svg {
+    color: ${RED_ON_WHITE};
+    display: none;
+    /* Remove top attribute set by Bootstrap. */
+    top: inherit;
+    width: 1.3rem;
+  }
+
+  input,
+  svg {
+    flex-shrink: 0;
+    /* Remove bootstrap's vertical margin */
+    margin: 0 7px 0 2px;
+  }
+
+  /* Check boxes for disabled days are replaced with the cross mark. */
+  input[disabled] {
+    display: none;
+  }
+  input[disabled] ~ svg {
+    display: block;
+  }
+
+  /* Add oblique strike for disabled days */
+  .disabled-day::after {
+    border-top: 2px solid ${RED_ON_WHITE};
+    content: '';
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 45%;
+    transform: rotate(-30deg);
+    transform-origin: center;
+  }
+
+  label {
+    flex-grow: 1;
+    font-weight: inherit;
+    height: 100%;
+    line-height: 3rem;
+    margin: 0;
+    position: relative;
+    text-align: center;
+  }
+`
+
+function isDisabled(day: string, itineraryExistence?: ItineraryExistence) {
+  return itineraryExistence && !itineraryExistence[day]?.valid
+}
+
+const TripMonitoredDaySelector = ({
+  errorCheckingTrip,
+  errorSelectingDays,
+  finalItineraryExistence,
+  isReadOnly,
+  monitoredTrip
+}: {
+  errorCheckingTrip: boolean
+  errorSelectingDays?: 'error' | null
+  finalItineraryExistence?: ItineraryExistence
+  isReadOnly: boolean
+  monitoredTrip: MonitoredTrip
+}): JSX.Element => {
+  const intl = useIntl()
+  const baseColor = getBaseColor()
+
+  if (isReadOnly) {
+    return <MonitoredDays days={dayFieldsToArray(monitoredTrip)} />
+  }
+
+  return (
+    <>
+      {errorCheckingTrip && (
+        <>
+          {/* FIXME: Temporary solution until itinerary existence check is fixed. */}
+          <br />
+          <FormattedMessage id="actions.user.itineraryExistenceCheckFailed" />
+        </>
+      )}
+      <AvailableDays>
+        {ALL_DAYS.map((day) => {
+          const isDayDisabled = isDisabled(day, finalItineraryExistence)
+          const labelClass = isDayDisabled ? 'disabled-day' : ''
+          const notAvailableText = isDayDisabled
+            ? intl.formatMessage(
+                {
+                  id: 'components.TripBasicsPane.tripNotAvailableOnDay'
+                },
+                {
+                  repeatedDay: getFormattedDayOfWeekPlural(day, intl)
+                }
+              )
+            : ''
+
+          return (
+            <MonitoredDayCircle
+              baseColor={baseColor}
+              key={day}
+              monitored={!isDayDisabled && monitoredTrip[day]}
+              title={notAvailableText}
+            >
+              <Field
+                disabled={isDayDisabled}
+                id={day}
+                name={day}
+                type="checkbox"
+              />
+              <Ban aria-hidden />
+              <label htmlFor={day}>
+                <InvisibleA11yLabel>
+                  <FormattedDayOfWeek day={day} />
+                </InvisibleA11yLabel>
+                <span aria-hidden className={labelClass}>
+                  {/* The abbreviated text is visual only. Screen readers should read out the full day. */}
+                  <FormattedDayOfWeekCompact day={day} />
+                </span>
+              </label>
+              <InvisibleA11yLabel>{notAvailableText}</InvisibleA11yLabel>
+            </MonitoredDayCircle>
+          )
+        })}
+      </AvailableDays>
+      <HelpBlock role="status">
+        {finalItineraryExistence ? (
+          <FormattedMessage id="components.TripBasicsPane.tripIsAvailableOnDaysIndicated" />
+        ) : (
+          <ProgressBar
+            active
+            label={
+              <FormattedMessage id="components.TripBasicsPane.checkingItineraryExistence" />
+            }
+            now={100}
+          />
+        )}
+      </HelpBlock>
+      <HelpBlock role="alert">
+        {errorSelectingDays && (
+          <FormattedValidationError type="select-at-least-one-day" />
+        )}
+      </HelpBlock>
+    </>
+  )
+}
+
+export default TripMonitoredDaySelector

--- a/lib/components/user/monitored-trip/trip-monitored-day-selector.tsx
+++ b/lib/components/user/monitored-trip/trip-monitored-day-selector.tsx
@@ -94,7 +94,10 @@ const AvailableDays = styled(FieldSet)`
   }
 `
 
-function isDisabled(day: string, itineraryExistence?: ItineraryExistence) {
+function isDisabled(
+  day: string,
+  itineraryExistence?: ItineraryExistence | null
+) {
   return itineraryExistence && !itineraryExistence[day]?.valid
 }
 
@@ -107,7 +110,7 @@ const TripMonitoredDaySelector = ({
 }: {
   errorCheckingTrip: boolean
   errorSelectingDays?: 'error' | null
-  finalItineraryExistence?: ItineraryExistence
+  finalItineraryExistence?: ItineraryExistence | null
   isReadOnly: boolean
   monitoredTrip: MonitoredTrip
 }): JSX.Element => {

--- a/lib/components/user/monitored-trip/trip-monitored-day-selector.tsx
+++ b/lib/components/user/monitored-trip/trip-monitored-day-selector.tsx
@@ -177,13 +177,18 @@ const TripMonitoredDaySelector = ({
         {finalItineraryExistence ? (
           <FormattedMessage id="components.TripBasicsPane.tripIsAvailableOnDaysIndicated" />
         ) : (
-          <ProgressBar
-            active
-            label={
+          <>
+            <InvisibleA11yLabel as="div">
               <FormattedMessage id="components.TripBasicsPane.checkingItineraryExistence" />
-            }
-            now={100}
-          />
+            </InvisibleA11yLabel>
+            <ProgressBar
+              active
+              label={
+                <FormattedMessage id="components.TripBasicsPane.checkingItineraryExistence" />
+              }
+              now={100}
+            />
+          </>
         )}
       </HelpBlock>
       <HelpBlock role="alert">

--- a/lib/components/user/monitored-trip/trip-monitored-day-selector.tsx
+++ b/lib/components/user/monitored-trip/trip-monitored-day-selector.tsx
@@ -94,11 +94,11 @@ const AvailableDays = styled(FieldSet)`
   }
 `
 
-function isDisabled(
+export function isDisabled(
   day: string,
   itineraryExistence?: ItineraryExistence | null
-) {
-  return itineraryExistence && !itineraryExistence[day]?.valid
+): boolean {
+  return !!(itineraryExistence && !itineraryExistence[day]?.valid)
 }
 
 const TripMonitoredDaySelector = ({

--- a/lib/reducers/create-user-reducer.js
+++ b/lib/reducers/create-user-reducer.js
@@ -130,7 +130,6 @@ export function getUserInitialState(config) {
 
   return {
     accessToken: null,
-    itineraryExistence: null,
     lastPhoneSmsRequest: {
       number: null,
       status: null,
@@ -188,18 +187,6 @@ function createUserReducer(config) {
       case 'SET_LAST_PHONE_SMS_REQUEST': {
         return update(state, {
           lastPhoneSmsRequest: { $set: action.payload }
-        })
-      }
-
-      case 'SET_ITINERARY_EXISTENCE': {
-        return update(state, {
-          itineraryExistence: { $set: action.payload }
-        })
-      }
-
-      case 'CLEAR_ITINERARY_EXISTENCE': {
-        return update(state, {
-          itineraryExistence: { $set: null }
         })
       }
 


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

This PR adds a button to the trip editor, so that users can manually recheck trip existence if what is shown is incorrect and add days to monitor if those days were not previously monitorable.

Note: With this PR alone, the updated itinerary existence will not be updated server-side. OTP-middleware currently ignores updates to `MonitoredTrip.itineraryExistence`, so when the user refreshes the trip, the unavailable days remain.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
| ![before screenshot](https://github.com/user-attachments/assets/8f7f01f0-cd90-4700-aae5-a01e49fac00b) | ![After screen recording](https://github.com/user-attachments/assets/18eef9ba-844e-482f-887d-b713f3a9e995) |


