### PR TITLE
Modify Leg ID for FIFA-Altered Routes

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,4 +16,4 @@ jobs:
           # skip git, yarn, pixel test script and HAR file, and all i18n resources.
           # Also, the a11y test file has a false positive and the ignore list does not work
           # see https://github.com/opentripplanner/otp-react-redux/pull/436/checks?check_run_id=3369380014
-          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./a11y/mocks,./percy/percy.test.js,./percy/mock.har,./i18n,./__tests__/mocks,otpSchema.json,./percy/mocks/*.json
+          skip: ./.git,yarn.lock,./a11y/a11y.test.js,./a11y/mocks,./percy/percy.test.js,./percy/mock.har,./i18n,./__tests__/mocks,otpSchema.json,./percy/mocks/*.json,./lib/util/stop-adjustments.ts

--- a/lib/util/STOP_ADJUSTMENTS.md
+++ b/lib/util/STOP_ADJUSTMENTS.md
@@ -4,7 +4,7 @@ The goal of the stop adjustments feature is to allow for agencies to implement c
 
 Within the code, these stop adjustments are used by the `updateItinerariesWithStopAdjustments` function within [stop-adjustments](./stop-adjustments.ts). When itineraries are returned from the OTP backend, this function can take those itineraries and use the stop adjustment rules to augment them, returning the updated itineraries. These updated itineraries can then be fed forward to the frontend UI for display just like the normal itineraries.
 
-Agencies can set rules using specific types that live in the [stop-adjustments.ts](./stop-adjustments.ts) file. What follows is a high-level overview of theses types. See the types themselves for more specific comments.
+Agencies can set rules using specific types that live in the [stop-adjustments.ts](./stop-adjustments.ts) file. What follows is a high-level overview of these types. See the types themselves for more specific comments.
 
 ## Custom Routing Zones
 
@@ -126,7 +126,7 @@ The optional intermediate stops to remove property specifies how many stops shou
 
 #### `legGeometry`
 
-The leg geometry property specifies which changes need to be made to the `legGeometry` property of the revelant transit leg in the itinerary. The leg geometry changes are what allow the route preview to show correctly in the trip planner.
+The leg geometry property specifies which changes need to be made to the `legGeometry` property of the relevant transit leg in the itinerary. The leg geometry changes are what allow the route preview to show correctly in the trip planner.
 
 This property contains the following fields:
 

--- a/lib/util/stop-adjustments.ts
+++ b/lib/util/stop-adjustments.ts
@@ -716,6 +716,29 @@ const itineraryIsInZoneTimeRange = (
   )
 }
 
+const updateLegIdWithNewStop = (
+  leg: Leg,
+  adjustment: StopAdjustment
+): string | undefined => {
+  const oldLegId = leg.id
+  const oldStopCode = leg.to.stop?.gtfsId
+  const newStopCode = adjustment.newStop.gtfsId
+  if (oldLegId && oldStopCode) {
+    try {
+      const bytes = Uint8Array.fromBase64(oldLegId, {
+        alphabet: 'base64url'
+      })
+      const decoded = new TextDecoder().decode(bytes)
+      const updatedDecoded = decoded.replace(oldStopCode, newStopCode)
+      const updatedEncoded = new TextEncoder().encode(updatedDecoded)
+      return updatedEncoded.toBase64()
+    } catch (error) {
+      console.warn('error updating leg ID with new stop', error)
+    }
+  }
+  return oldLegId
+}
+
 /**
  * Takes a set of custom routing zones and an itinerary and extracts the relevant origin and/or
  * destination rule and zone names
@@ -816,6 +839,8 @@ export const adjustItinerary = (
       for (let i = 0; i <= updatedItinerary.legs.length; i++) {
         const leg = updatedItinerary.legs[i]
         if (leg.transitLeg) {
+          const newLegId = updateLegIdWithNewStop(leg, adjustment)
+          updatedLeg.id = newLegId
           updatedItinerary.legs[i] = updatedLeg
           break
         }
@@ -855,6 +880,8 @@ export const adjustItinerary = (
       for (let i = updatedItinerary.legs.length - 1; i >= 0; i--) {
         const leg = updatedItinerary.legs[i]
         if (leg.transitLeg) {
+          const newLegId = updateLegIdWithNewStop(leg, adjustment)
+          updatedLeg.id = newLegId
           updatedItinerary.legs[i] = updatedLeg
           break
         }

--- a/lib/util/stop-adjustments.ts
+++ b/lib/util/stop-adjustments.ts
@@ -730,6 +730,11 @@ const updateLegIdWithNewStop = (
       })
       const decoded = new TextDecoder().decode(bytes)
       const updatedDecoded = decoded.replace(oldStopCode, newStopCode)
+      const duplicateCheck = updatedDecoded.indexOf(oldStopCode)
+      if (duplicateCheck !== -1) {
+        console.warn('leg ID contains duplicate stop codes')
+        return oldLegId
+      }
       const updatedEncoded = new TextEncoder().encode(updatedDecoded)
       return updatedEncoded.toBase64()
     } catch (error) {


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
This PR updates the FIFA stop adjustment logic, adding logic to update the leg ID of the altered transit leg so that it accurately reflects the new transit leg's stops. Because the only change to the transit leg is the new origin/destination stop, it's possible to just replace the old stop code with the new one in the decoded leg ID, then re-encode it.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

