### PR TITLE
hide itin summary overlay if more than 6 routes are present

### DIFF
--- a/lib/components/map/itinerary-summary-overlay.tsx
+++ b/lib/components/map/itinerary-summary-overlay.tsx
@@ -184,7 +184,7 @@ const ItinerarySummaryOverlay = ({
             // TODO: clean up conditionals, move these to a more appropriate place without breaking indexing
             (isDefined(visibleItinerary)
               ? visibleItinerary === mp.itin.index
-              : true) &&
+              : midPoints.length < 6) &&
             mp.uniquePoint && (
               <Marker
                 key={mp.itin.duration}


### PR DESCRIPTION
This overlay needs a lot more work, but this is a quick bandaid that should help quite a bit.