### PR TITLE
create `allowFlexWithoutTransit` setting, clean up flex duplication support

### DIFF
--- a/example/example-config.yml
+++ b/example/example-config.yml
@@ -238,6 +238,7 @@ geocoder:
 
 # Use this mode config for the enhanced Transit+ config
 modes:
+  # allowFlexWithoutTransit: true # True by default
   ### Optional number of itineraries to return by default - Defaults to 3.
   # numItineraries: 3
   # Definition for the mode buttons to display in trip form

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -1177,7 +1177,13 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
     // this removes superfluous flex requests.
     combinations = combinations.filter((c) => {
       const flexCount = countFlexModes(c.modes)
-      // We need either all 3 flex modes or none! Anything in-between is invalid
+      // Slight hack to remove combinations that feature 3 flex modes and no transit
+      if (
+        config.modes?.allowFlexWithoutTransit === false &&
+        flexCount > 0 &&
+        c.modes.every((m) => SIMPLIFICATIONS[m.mode] !== 'TRANSIT')
+      )
+        return false
       return flexCount === 0 || flexCount === 3
     })
 

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -64,7 +64,7 @@ export const doMergeItineraries = memoize((itineraries, defaultFareType) => {
         itinerariesAreEqual(itin, cur, defaultFareType)
       )
       // If no duplicate, push full itinerary to output
-      if (duplicateIndex === -1 || cur.legs.some(isFlex)) {
+      if (duplicateIndex === -1) {
         updatedItineraries.push(updatedItinerary)
       } else if (
         // Only process itineraries less than 24 hours in the future

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -342,6 +342,7 @@ export interface TransitModeConfig {
 
 export interface ModesConfig {
   accessModes: TransitModeConfig[]
+  allowFlexWithoutTransit?: boolean
   initialState?: {
     enabledModeButtons?: string[]
     modeSettingValues?: ModeSettingValues


### PR DESCRIPTION
There should be no changes to requests generated unless `allowFlexWithoutTransit` is enabled.

Removing the restriction on merging flex trips together should help with cleanliness