### PR TITLE
Populate feeds even if OTP2 returns errors.

### DIFF
--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -1044,7 +1044,9 @@ export function findFeeds() {
           noThrottle: true,
           rewritePayload: (payload) => {
             if (payload.errors) {
-              return dispatch(findFeedsError(payload.errors))
+              // Even if the call to fetch feeds is successful,
+              // OTP2 can return errors/warnings in addition to the rest of the feed data.
+              dispatch(findFeedsError(payload.errors))
             }
             return payload?.data?.feeds || []
           }


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**

This PR lets OTP-RR load and use feed info, especially clicking a stop from the OTP2TileOverlay, even if OTP2 returns errors for some of these feeds (e.g. missing publisher field).

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

