### PR TITLE
turn off transit fare sort by default

### DIFF
--- a/lib/components/util/sortOptions.ts
+++ b/lib/components/util/sortOptions.ts
@@ -12,8 +12,8 @@ export const sortOptions = (
     'ARRIVALTIME',
     'WALKTIME',
     'COST',
-    'DEPARTURETIME',
-    'FARE'
+    'DEPARTURETIME'
+    // 'FARE' disabled by default. can be confusing when next to the COST option
     // Emissions is disabled by default, as it does nothing unless CO₂ calculation is enabled
   ]
 ): SortOptionEntry[] => {


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Turns off 'Transit fare' sort option by default. 

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

