### PR TITLE
Display map with open itinerary on mobile

### DIFF
--- a/__tests__/util/ui.ts
+++ b/__tests__/util/ui.ts
@@ -17,12 +17,12 @@ describe('util > ui', () => {
     })
     it('returns a full itinerary view if URL contains ui_activeItinerary that is not -1', () => {
       expect(getItineraryView({ ui_activeItinerary: 2 })).toBe(
-        ItineraryView.FULL
+        ItineraryView.ITINERARY_OPEN
       )
     })
     it('returns an itinerary list view if URL contains ui_activeItinerary=-1 regardless of ui_itineraryView', () => {
       const expectedValues = {
-        [ItineraryView.FULL]: ItineraryView.LIST,
+        [ItineraryView.ITINERARY_OPEN]: ItineraryView.LIST,
         [ItineraryView.LEG]: ItineraryView.LIST,
         [ItineraryView.LEG_HIDDEN]: ItineraryView.LIST,
         [ItineraryView.LIST]: ItineraryView.LIST,

--- a/lib/components/mobile/batch-results-screen.js
+++ b/lib/components/mobile/batch-results-screen.js
@@ -12,6 +12,7 @@ import {
   getResponsesWithErrors
 } from '../../util/state'
 import { getItineraryView, ItineraryView } from '../../util/ui'
+import { TOGGLE_MAP_BUTTON_HEIGHT } from '../narrative/map-expansion-button'
 import Map from '../map/map'
 import NarrativeItineraries from '../narrative/narrative-itineraries'
 
@@ -35,7 +36,6 @@ const StyledMobileContainer = styled(MobileContainer)`
 `
 
 const NARRATIVE_SPLIT_TOP_PERCENT = 41
-export const TOGGLE_MAP_BUTTON_HEIGHT = 6.3
 
 // Styles for the results map also include prop-independent styles copied from mobile.css.
 const ResultsMap = styled.div`
@@ -43,7 +43,6 @@ const ResultsMap = styled.div`
     props.expanded
       ? `${TOGGLE_MAP_BUTTON_HEIGHT}%`
       : `${100 - NARRATIVE_SPLIT_TOP_PERCENT}%`};
-  display: ${(props) => (props.visible ? 'inherit' : 'none')};
   left: 0;
   position: fixed;
   right: 0;
@@ -53,9 +52,7 @@ const ResultsMap = styled.div`
 const narrativeCss = css`
   top: ${(props) =>
     props.visible
-      ? props.expanded
-        ? '100px'
-        : `${NARRATIVE_SPLIT_TOP_PERCENT}%`
+      ? `${NARRATIVE_SPLIT_TOP_PERCENT}%`
       : `${100 - TOGGLE_MAP_BUTTON_HEIGHT}%`};
   transition: top 300ms;
 `
@@ -82,8 +79,9 @@ const BatchMobileResultsScreen = ({
   const hasErrorsAndNoResult = itineraries.length === 0 && errors.length > 0
   const mapExpanded =
     itineraryView === ItineraryView.LEG_HIDDEN ||
-    itineraryView === ItineraryView.LIST_HIDDEN
-  const itineraryExpanded = itineraryView === ItineraryView.FULL
+    itineraryView === ItineraryView.LIST_HIDDEN ||
+    itineraryView === ItineraryView.ITINERARY_HIDDEN
+  const itineraryExpanded = itineraryView === ItineraryView.ITINERARY_OPEN
 
   const { default: map } = useMap()
   // Trigger map resize when the map expanded variable changes.
@@ -94,7 +92,7 @@ const BatchMobileResultsScreen = ({
   return (
     <StyledMobileContainer>
       <ResultsHeader />
-      <ResultsMap expanded={mapExpanded} visible={!itineraryExpanded}>
+      <ResultsMap expanded={mapExpanded}>
         <Map
           onClickLayerSelector={() => {
             // The layer selector menu can be occluded on smaller screens, so expand

--- a/lib/components/mobile/batch-results-screen.js
+++ b/lib/components/mobile/batch-results-screen.js
@@ -92,7 +92,7 @@ const BatchMobileResultsScreen = ({
   return (
     <StyledMobileContainer>
       <ResultsHeader />
-      <ResultsMap expanded={mapExpanded}>
+      <ResultsMap className="mobile-results-map" expanded={mapExpanded}>
         <Map
           onClickLayerSelector={() => {
             // The layer selector menu can be occluded on smaller screens, so expand

--- a/lib/components/narrative/map-expansion-button.tsx
+++ b/lib/components/narrative/map-expansion-button.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 
 import { StyledIconWrapper } from '../util/styledIcon'
 
-export const TOGGLE_MAP_BUTTON_HEIGHT = 7
+export const TOGGLE_MAP_BUTTON_HEIGHT = 5
 
 const StyledMapExpansionButton = styled.button`
   align-items: center;
@@ -48,7 +48,7 @@ const MapExpansionButton = ({
       onClick={onClickExpansionButton}
       title={mapExpansionText}
     >
-      <StyledIconWrapper>
+      <StyledIconWrapper style={{ marginTop: '3px' }}>
         <UnicodeChevron expanded={mapExpanded}>&#10095;</UnicodeChevron>
       </StyledIconWrapper>
     </StyledMapExpansionButton>

--- a/lib/components/narrative/map-expansion-button.tsx
+++ b/lib/components/narrative/map-expansion-button.tsx
@@ -44,7 +44,7 @@ const MapExpansionButton = ({
       aria-label={mapExpansionText}
       // CSS classes 'base-color-bg' and 'itinerary' let us set the chevron color to the
       // same color as the color used the H3 headings over the narrative background.
-      className="clear-button-formatting base-color-bg itinerary"
+      className="clear-button-formatting itinerary"
       onClick={onClickExpansionButton}
       title={mapExpansionText}
     >

--- a/lib/components/narrative/map-expansion-button.tsx
+++ b/lib/components/narrative/map-expansion-button.tsx
@@ -1,0 +1,58 @@
+import { IntlShape } from 'react-intl'
+import React, { useMemo } from 'react'
+import styled from 'styled-components'
+
+import { StyledIconWrapper } from '../util/styledIcon'
+
+export const TOGGLE_MAP_BUTTON_HEIGHT = 7
+
+const StyledMapExpansionButton = styled.button`
+  align-items: center;
+  background-color: transparent !important;
+  display: flex;
+  height: ${TOGGLE_MAP_BUTTON_HEIGHT}vh;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 100%;
+`
+
+const UnicodeChevron = styled.div<{ expanded: boolean }>`
+  transform: rotate(${(props) => (props.expanded ? '270' : '90')}deg) scaleY(2)
+    scaleX(1.5);
+`
+
+const MapExpansionButton = ({
+  intl,
+  mapExpanded,
+  onClickExpansionButton
+}: {
+  intl: IntlShape
+  mapExpanded: boolean
+  onClickExpansionButton: () => void
+}): JSX.Element => {
+  const mapExpansionText = useMemo(() => {
+    return mapExpanded
+      ? intl.formatMessage({
+          id: 'components.BatchResultsScreen.showResults'
+        })
+      : intl.formatMessage({
+          id: 'components.BatchResultsScreen.expandMap'
+        })
+  }, [intl, mapExpanded])
+  return (
+    <StyledMapExpansionButton
+      aria-label={mapExpansionText}
+      // CSS classes 'base-color-bg' and 'itinerary' let us set the chevron color to the
+      // same color as the color used the H3 headings over the narrative background.
+      className="clear-button-formatting base-color-bg itinerary"
+      onClick={onClickExpansionButton}
+      title={mapExpansionText}
+    >
+      <StyledIconWrapper>
+        <UnicodeChevron expanded={mapExpanded}>&#10095;</UnicodeChevron>
+      </StyledIconWrapper>
+    </StyledMapExpansionButton>
+  )
+}
+
+export default MapExpansionButton

--- a/lib/components/narrative/metro/metro-itinerary.tsx
+++ b/lib/components/narrative/metro/metro-itinerary.tsx
@@ -313,7 +313,7 @@ class MetroItinerary extends NarrativeItinerary {
     const handleClick = () => {
       setActiveItinerary(itinerary)
       setActiveLeg(null, null)
-      setItineraryView(ItineraryView.FULL)
+      setItineraryView(ItineraryView.ITINERARY_OPEN)
       // Reset the scroll. Refs would be the more
       // appropriate way to do this, but they don't work
       setTimeout(

--- a/lib/components/narrative/narrative-itineraries-header.tsx
+++ b/lib/components/narrative/narrative-itineraries-header.tsx
@@ -4,14 +4,13 @@ import { Dropdown } from '@opentripplanner/building-blocks'
 import { FormattedMessage, useIntl } from 'react-intl'
 import { SortAmountDown } from '@styled-icons/fa-solid/SortAmountDown'
 import { SortAmountUp } from '@styled-icons/fa-solid/SortAmountUp'
-import React, { useContext, useMemo } from 'react'
+import React, { useContext } from 'react'
 import styled from 'styled-components'
 
 import { ComponentContext } from '../../util/contexts'
 import { IconWithText, StyledIconWrapper } from '../util/styledIcon'
 import { ItinerarySortOption } from '../../util/config-types'
 import { sortOptions } from '../util/sortOptions'
-import { TOGGLE_MAP_BUTTON_HEIGHT } from '../mobile/batch-results-screen'
 import { UnstyledButton } from '../util/unstyled-button'
 import InvisibleA11yLabel from '../util/invisible-a11y-label'
 import PopupTriggerText from '../app/popup-trigger-text'
@@ -33,27 +32,11 @@ const SortResultsDropdown = styled(Dropdown)`
   line-height: normal;
 `
 
-const UnicodeChevron = styled.div<{ expanded: boolean }>`
-  transform: rotate(${(props) => (props.expanded ? '270' : '90')}deg) scaleY(2)
-    scaleX(1.5);
-`
-
-const MapExpansionButton = styled.button`
-  align-items: center;
-  display: flex;
-  height: ${TOGGLE_MAP_BUTTON_HEIGHT}vh;
-  justify-content: center;
-  margin: -10px 0 0;
-  width: 100%;
-`
-
 export default function NarrativeItinerariesHeader({
   customBatchUiBackground,
   enabledSortModes,
   itineraries,
   itineraryIsExpanded,
-  mapExpanded,
-  onClickExpansionButton = undefined,
   onSortChange,
   onSortDirChange,
   onViewAllOptions,
@@ -68,7 +51,6 @@ export default function NarrativeItinerariesHeader({
   itineraries: unknown[]
   itineraryIsExpanded: boolean
   mapExpanded: boolean
-  onClickExpansionButton?: () => void
   onSortChange: (type: string) => VoidFunction
   onSortDirChange: () => void
   onViewAllOptions: () => void
@@ -108,16 +90,6 @@ export default function NarrativeItinerariesHeader({
 
   const sortOptionsArr = sortOptions(intl, enabledSortModes)
   const sortText = sortOptionsArr.find((x) => x.value === sort.type)?.text
-
-  const mapExpansionText = useMemo(() => {
-    return mapExpanded
-      ? intl.formatMessage({
-          id: 'components.BatchResultsScreen.showResults'
-        })
-      : intl.formatMessage({
-          id: 'components.BatchResultsScreen.expandMap'
-        })
-  }, [intl, mapExpanded])
 
   return (
     <div
@@ -184,20 +156,6 @@ export default function NarrativeItinerariesHeader({
             // The "n Itineraries Found" a11y header is an <h2> element
             // because it falls under the "Plan your trip" <h1> header.
             <InvisibleA11yLabel as="h2">{itinerariesFound}</InvisibleA11yLabel>
-          )}
-          {onClickExpansionButton && (
-            <MapExpansionButton
-              aria-label={mapExpansionText}
-              // CSS classes 'base-color-bg' and 'itinerary' let us set the chevron color to the
-              // same color as the color used the H3 headings over the narrative background.
-              className="clear-button-formatting base-color-bg itinerary"
-              onClick={onClickExpansionButton}
-              title={mapExpansionText}
-            >
-              <StyledIconWrapper>
-                <UnicodeChevron expanded={mapExpanded}>&#10095;</UnicodeChevron>
-              </StyledIconWrapper>
-            </MapExpansionButton>
           )}
           <ItinerariesHeaderContainer showHeaderText={showHeaderText}>
             {popupTarget && (

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -2,7 +2,7 @@
 import { connect } from 'react-redux'
 import { differenceInDays } from 'date-fns'
 import { FormattedMessage, injectIntl } from 'react-intl'
-import { isFlex, isTransitLeg } from '@opentripplanner/core-utils/lib/itinerary'
+import { isTransitLeg } from '@opentripplanner/core-utils/lib/itinerary'
 import clone from 'clone'
 import coreUtils from '@opentripplanner/core-utils'
 import memoize from 'lodash.memoize'
@@ -43,6 +43,7 @@ import * as S from './styled'
 import { getItineraryDescription } from './default/itinerary-description'
 import ErrorRenderer from './metro/metro-error-renderer'
 import Loading from './loading'
+import MapExpansionButton from './map-expansion-button'
 import NarrativeItinerariesHeader from './narrative-itineraries-header'
 
 /** Creates a start time object for the given itinerary. */
@@ -194,7 +195,7 @@ class NarrativeItineraries extends Component {
       // If clicking on the same leg again, reset it to null,
       // and show the full itinerary (both desktop and mobile view)
       setActiveLeg(null, null)
-      setItineraryView(ItineraryView.FULL)
+      setItineraryView(ItineraryView.ITINERARY_OPEN)
     } else {
       // Focus on the newly selected leg.
       setActiveLeg(index, leg)
@@ -204,7 +205,9 @@ class NarrativeItineraries extends Component {
 
   _toggleDetailedItinerary = () => {
     const { setActiveLeg, setItineraryView, showDetails } = this.props
-    const newView = showDetails ? ItineraryView.LIST : ItineraryView.FULL
+    const newView = showDetails
+      ? ItineraryView.LIST
+      : ItineraryView.ITINERARY_OPEN
     setItineraryView(newView)
     // Reset the active leg.
     setActiveLeg(null, null)
@@ -434,6 +437,11 @@ class NarrativeItineraries extends Component {
         <PageTitle
           title={summarizeQuery(activeSearch.query, intl, user.savedLocations)}
         />
+        <MapExpansionButton
+          intl={intl}
+          mapExpanded={mapExpanded}
+          onClickExpansionButton={onClickExpansionButton}
+        />
         <NarrativeItinerariesHeader
           customBatchUiBackground={customBatchUiBackground}
           enabledSortModes={enabledSortModes}
@@ -441,7 +449,6 @@ class NarrativeItineraries extends Component {
           itinerary={itinerary}
           itineraryIsExpanded={itineraryIsExpanded}
           mapExpanded={mapExpanded}
-          onClickExpansionButton={onClickExpansionButton}
           onSortChange={this._onSortChange}
           onSortDirChange={this._onSortDirChange}
           onViewAllOptions={this._onViewAllOptions}
@@ -530,7 +537,7 @@ const mapStateToProps = (state) => {
   const urlParams = coreUtils.query.getUrlParams()
   const itineraryView = getItineraryView(urlParams)
   const showDetails =
-    itineraryView === ItineraryView.FULL ||
+    itineraryView === ItineraryView.ITINERARY_OPEN ||
     itineraryView === ItineraryView.LEG ||
     itineraryView === ItineraryView.LEG_HIDDEN
   const {

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -437,11 +437,13 @@ class NarrativeItineraries extends Component {
         <PageTitle
           title={summarizeQuery(activeSearch.query, intl, user.savedLocations)}
         />
-        <MapExpansionButton
-          intl={intl}
-          mapExpanded={mapExpanded}
-          onClickExpansionButton={onClickExpansionButton}
-        />
+        {onClickExpansionButton && (
+          <MapExpansionButton
+            intl={intl}
+            mapExpanded={mapExpanded}
+            onClickExpansionButton={onClickExpansionButton}
+          />
+        )}
         <NarrativeItinerariesHeader
           customBatchUiBackground={customBatchUiBackground}
           enabledSortModes={enabledSortModes}

--- a/lib/util/ui.ts
+++ b/lib/util/ui.ts
@@ -115,7 +115,6 @@ export function getItineraryView({
   ui_activeItinerary,
   ui_itineraryView
 }: UrlParams): ItineraryView {
-  console.log(ui_itineraryView)
   return (
     ((ui_activeItinerary === null ||
       ui_activeItinerary === undefined ||

--- a/lib/util/ui.ts
+++ b/lib/util/ui.ts
@@ -76,8 +76,10 @@ export function getPathFromParts(...parts: string[]): string {
  * Enum to describe the layout of the itinerary view.
  */
 export enum ItineraryView {
-  /** One itinerary is shown. (In mobile view, the map is hidden.) */
-  FULL = 'full',
+  /** The selected itinerary is hidden. (In mobile view, the map is expanded.) */
+  ITINERARY_HIDDEN = 'itin-hidden',
+  /** One itinerary is shown. (The mobile view is split.) */
+  ITINERARY_OPEN = 'itin-open',
   /** One itinerary is shown, itinerary and map are focused on a leg. (The mobile view is split.) */
   LEG = 'leg',
   /** One itinerary leg is hidden. (In mobile view, the map is expanded.) */
@@ -113,6 +115,7 @@ export function getItineraryView({
   ui_activeItinerary,
   ui_itineraryView
 }: UrlParams): ItineraryView {
+  console.log(ui_itineraryView)
   return (
     ((ui_activeItinerary === null ||
       ui_activeItinerary === undefined ||
@@ -121,7 +124,8 @@ export function getItineraryView({
         ? ItineraryView.LIST_HIDDEN
         : ItineraryView.LIST)) ||
     ui_itineraryView ||
-    (isDefinedAndNotEqual(ui_activeItinerary, -1) && ItineraryView.FULL) ||
+    (isDefinedAndNotEqual(ui_activeItinerary, -1) &&
+      ItineraryView.ITINERARY_OPEN) ||
     ItineraryView.LIST
   )
 }
@@ -139,6 +143,10 @@ export function getMapToggleNewItineraryView(
       return ItineraryView.LIST_HIDDEN
     case ItineraryView.LEG_HIDDEN:
       return ItineraryView.LEG
+    case ItineraryView.ITINERARY_OPEN:
+      return ItineraryView.ITINERARY_HIDDEN
+    case ItineraryView.ITINERARY_HIDDEN:
+      return ItineraryView.ITINERARY_OPEN
     default:
       return ItineraryView.LIST
   }


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Previously there was no way to see the itinerary you choose on the map in mobile view. This PR maintains the map movement of the results screen through to the itinerary view.

Because we're moving the button out of a parent container, the positioning is a little different which is triggering a diff in the percy tests. These changes look fine to me but happy to discuss if anyone disagrees!



<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
| Before | After |
|--------|-------|
|<img width="342" height="739" alt="image" src="https://github.com/user-attachments/assets/ff2b07ac-5800-487b-9aaf-009e04171f61" />|<img width="342" height="739" alt="image" src="https://github.com/user-attachments/assets/249f70df-afcf-46d8-b550-804eedc3661d" />|

