### PR TITLE
Add support for omitCanceled option in config

### DIFF
--- a/example/example-config.yml
+++ b/example/example-config.yml
@@ -379,6 +379,8 @@ itinerary:
   renderRouteNamesInBlocks: true
   # Whether the mode icons should be colored as well
   fillModeIcons: true
+  # Whether to omit trips that involve a transit leg that has been canceled via realtime update
+  omitCanceledTrips: true
   # Allow user to collapse alerts in itinerary body
   allowUserAlertCollapsing: true
   # The medium and rider category selected here will be used to render the total itinerary fare

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -1147,6 +1147,8 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
         config.routeModeOverrides
       )?.join(',')
 
+    const { omitCanceled = true } = config.itinerary || {}
+
     const baseQuery = {
       arriveBy,
       banned: {
@@ -1157,13 +1159,7 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
       from: currentQuery.from,
       modes: modes || activeModes,
       modeSettings,
-      // Need to be careful here: the default value for OTP queries is true. If a config
-      // doesn't include the omitCanceledTrips flag, we need to make sure we keep that true
-      // default value
-      omitCanceled:
-        config.itinerary?.omitCanceledTrips !== undefined
-          ? config.itinerary.omitCanceledTrips
-          : true,
+      omitCanceled,
       time,
       to: currentQuery.to,
       unpreferred,

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -1162,7 +1162,7 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
       // default value
       omitCanceled:
         config.itinerary?.omitCanceledTrips !== undefined
-          ? config.itinerary?.omitCanceledTrips
+          ? config.itinerary.omitCanceledTrips
           : true,
       time,
       to: currentQuery.to,

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -1157,6 +1157,13 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
       from: currentQuery.from,
       modes: modes || activeModes,
       modeSettings,
+      // Need to be careful here: the default value for OTP queries is true. If a config
+      // doesn't include the omitCanceledTrips flag, we need to make sure we keep that true
+      // default value
+      omitCanceled:
+        config.itinerary?.omitCanceledTrips !== undefined
+          ? config.itinerary?.omitCanceledTrips
+          : true,
       time,
       to: currentQuery.to,
       unpreferred,

--- a/lib/util/config-types.ts
+++ b/lib/util/config-types.ts
@@ -299,6 +299,7 @@ export interface ItineraryConfig {
   hideSkeletons?: boolean
   mergeItineraries?: boolean
   mutedErrors?: string[]
+  omitCanceledTrips?: boolean
   onlyShowCountdownForRealtime?: boolean
   previewOverlay?: boolean
   renderRouteNamesInBlocks?: boolean

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@floating-ui/react": "^0.19.2",
     "@opentripplanner/base-map": "7.0.1",
     "@opentripplanner/building-blocks": "3.1.1",
-    "@opentripplanner/core-utils": "16.0.5",
+    "@opentripplanner/core-utils": "16.1.0",
     "@opentripplanner/endpoints-overlay": "5.0.1",
     "@opentripplanner/from-to-location-picker": "4.0.2",
     "@opentripplanner/geocoder": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3598,10 +3598,10 @@
   dependencies:
     "@styled-icons/bootstrap" "^10.47.0"
 
-"@opentripplanner/core-utils@16.0.5", "@opentripplanner/core-utils@^16.0.4":
-  version "16.0.5"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-16.0.5.tgz#b1bc66543a93d25f3191139b7587dd886d311658"
-  integrity sha512-DpXJ5mbmEFlQK3+yWmJ5vzFFTE/0OeIPyaN/RsUVtREX1OeNLv9F4hbFgc2LWflfDriJI/eIM6qLitj2ybgaOA==
+"@opentripplanner/core-utils@16.1.0":
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-16.1.0.tgz#c6cc0c579dfa7fa97c84bef1c125c00400054b37"
+  integrity sha512-x9LhxPhSJxiPdP7IGuS2uLY5UZV/gpE4m7DTW636ygJrcwKFYI99VkhhGF0eBOBT44ypjOC4e+q2NSEzwoBA0g==
   dependencies:
     "@conveyal/lonlat" "^1.4.1"
     "@mapbox/polyline" "^1.1.1"
@@ -3623,6 +3623,23 @@
     "@conveyal/lonlat" "^1.4.1"
     "@mapbox/polyline" "^1.1.1"
     "@opentripplanner/geocoder" "^3.1.0"
+    "@styled-icons/foundation" "^10.34.0"
+    "@turf/along" "^7.3.1"
+    chroma-js "^3.2.0"
+    date-fns "^3.6.0"
+    date-fns-tz "^3.2.0"
+    graphql "^16.6.0"
+    lodash.clonedeep "^4.5.0"
+    qs "^6.9.1"
+
+"@opentripplanner/core-utils@^16.0.4":
+  version "16.0.5"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/core-utils/-/core-utils-16.0.5.tgz#b1bc66543a93d25f3191139b7587dd886d311658"
+  integrity sha512-DpXJ5mbmEFlQK3+yWmJ5vzFFTE/0OeIPyaN/RsUVtREX1OeNLv9F4hbFgc2LWflfDriJI/eIM6qLitj2ybgaOA==
+  dependencies:
+    "@conveyal/lonlat" "^1.4.1"
+    "@mapbox/polyline" "^1.1.1"
+    "@opentripplanner/geocoder" "^3.1.2"
     "@styled-icons/foundation" "^10.34.0"
     "@turf/along" "^7.3.1"
     chroma-js "^3.2.0"


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Adds support for the `omitCanceled` option of the [OTP Plan query](https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/queries/plan), via the config file. Requires version bump after merging/deploying opentripplanner/otp-ui#971

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

