### PR TITLE
Update itineraries to show canceled trip warning

### DIFF
--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -115,6 +115,7 @@ common:
     submitting: Submitting…
     "yes": "Yes"
   itineraryDescriptions:
+    containsCanceledTrip: Contains canceled trip
     fareUnknown: No fare information
     noDefaultFareTypeConfigured: Multiple fares apply
     noItineraryToDisplay: No itinerary to display.

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -133,7 +133,7 @@ common:
     submitting: Envoi en cours…
     "yes": Oui
   itineraryDescriptions:
-    containsCanceledTrip: Annulé
+    containsCanceledTrip: Contient un voyage annulé
     fareUnknown: Tarif inconnu
     noDefaultFareTypeConfigured: Multiple fares apply
     noItineraryToDisplay: Aucun trajet à afficher.

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -133,6 +133,7 @@ common:
     submitting: Envoi en cours…
     "yes": Oui
   itineraryDescriptions:
+    containsCanceledTrip: Annulé
     fareUnknown: Tarif inconnu
     noDefaultFareTypeConfigured: Multiple fares apply
     noItineraryToDisplay: Aucun trajet à afficher.

--- a/lib/actions/apiV2.js
+++ b/lib/actions/apiV2.js
@@ -1147,7 +1147,7 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
         config.routeModeOverrides
       )?.join(',')
 
-    const { omitCanceled = true } = config.itinerary || {}
+    const { omitCanceledTrips = true } = config.itinerary || {}
 
     const baseQuery = {
       arriveBy,
@@ -1159,7 +1159,7 @@ export function routingQuery(searchId = null, updateSearchInReducer) {
       from: currentQuery.from,
       modes: modes || activeModes,
       modeSettings,
-      omitCanceled,
+      omitCanceled: omitCanceledTrips,
       time,
       to: currentQuery.to,
       unpreferred,

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -89,6 +89,10 @@ const ItinerarySummaryWrapper = styled.div`
   justify-content: space-between;
 `
 
+const CanceledTripMessage = styled.div`
+  color: rgb(183, 38, 32);
+`
+
 const ITINERARY_ATTRIBUTES = [
   {
     alias: 'best',
@@ -335,6 +339,10 @@ class DefaultItinerary extends NarrativeItinerary {
       )
     }
 
+    const containsCanceledTrip = itinerary.legs?.some(
+      (leg) => leg.realtimeState === 'CANCELED'
+    )
+
     return (
       <div
         className={`option default-itin${visible ? ' active' : ''}${
@@ -359,6 +367,11 @@ class DefaultItinerary extends NarrativeItinerary {
               </h3>
             )}
             <ItinerarySummary itinerary={itinerary} LegIcon={LegIcon} />
+            {containsCanceledTrip && (
+              <CanceledTripMessage>
+                <FormattedMessage id="common.itineraryDescriptions.containsCanceledTrip" />
+              </CanceledTripMessage>
+            )}
             {itineraryHasAccessibilityScore(itinerary) && (
               <AccessibilityRating
                 gradationMap={localizedGradationMapWithIcons}

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -11,6 +11,7 @@ import {
 } from 'react-intl'
 import { Leaf } from '@styled-icons/fa-solid/Leaf'
 import clone from 'clone'
+import colors from '@opentripplanner/building-blocks'
 import coreUtils from '@opentripplanner/core-utils'
 import React from 'react'
 import styled from 'styled-components'
@@ -90,7 +91,7 @@ const ItinerarySummaryWrapper = styled.div`
 `
 
 const CanceledTripMessage = styled.div`
-  color: rgb(183, 38, 32);
+  color: ${colors.red[700]};
 `
 
 const ITINERARY_ATTRIBUTES = [

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -345,10 +345,9 @@ class DefaultItinerary extends NarrativeItinerary {
       )
     }
 
-    // const containsCanceledTrip = itinerary.legs?.some(
-    //   (leg) => leg.realtimeState === 'CANCELED'
-    // )
-    const containsCanceledTrip = true
+    const containsCanceledTrip = itinerary.legs?.some(
+      (leg) => leg.realtimeState === 'CANCELED'
+    )
 
     return (
       <div

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -2,6 +2,7 @@
 // in a separate PR.
 import { AccessibilityRating } from '@opentripplanner/itinerary-body'
 import { connect } from 'react-redux'
+import { ExclamationTriangle } from '@styled-icons/fa-solid/ExclamationTriangle'
 import {
   FormattedList,
   FormattedMessage,
@@ -22,7 +23,11 @@ import {
   getFirstLegStartTime,
   getTotalTimeForMode
 } from '../../../util/itinerary'
-import { Icon, StyledIconWrapperTextAlign } from '../../util/styledIcon'
+import {
+  Icon,
+  IconWithText,
+  StyledIconWrapperTextAlign
+} from '../../util/styledIcon'
 import { itineraryHasAccessibilityScore } from '../../../util/accessibility-routing'
 import { localizeGradationMap } from '../utils'
 import FieldTripGroupSize from '../../admin/field-trip-itinerary-group-size'
@@ -340,9 +345,10 @@ class DefaultItinerary extends NarrativeItinerary {
       )
     }
 
-    const containsCanceledTrip = itinerary.legs?.some(
-      (leg) => leg.realtimeState === 'CANCELED'
-    )
+    // const containsCanceledTrip = itinerary.legs?.some(
+    //   (leg) => leg.realtimeState === 'CANCELED'
+    // )
+    const containsCanceledTrip = true
 
     return (
       <div
@@ -370,6 +376,7 @@ class DefaultItinerary extends NarrativeItinerary {
             <ItinerarySummary itinerary={itinerary} LegIcon={LegIcon} />
             {containsCanceledTrip && (
               <CanceledTripMessage>
+                <IconWithText Icon={ExclamationTriangle} />
                 <FormattedMessage id="common.itineraryDescriptions.containsCanceledTrip" />
               </CanceledTripMessage>
             )}


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Adds a warning to the itinerary summary if an itinerary contains a canceled trip. Note that including canceled trips [requires a config flag](https://github.com/opentripplanner/otp-react-redux/pull/1598), so these updates will not show up for any implementation until they turn on that config flag.

## Example

<img width="533" height="126" alt="image" src="https://github.com/user-attachments/assets/e6b1a048-774d-439b-8aa6-1ed093371b67" />


<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

