### PR TITLE
Pass closed stops info to itinerary

### DIFF
--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -30,6 +30,7 @@ import {
   rentalVehicleQuery
 } from '../../actions/api'
 import { ComponentContext } from '../../util/contexts'
+import { flattenStopClosures } from '../../util/itinerary'
 import { getActiveItinerary, getActiveSearch } from '../../util/state'
 import {
   getCurrentPosition,
@@ -397,9 +398,9 @@ class DefaultMap extends Component<DefaultMapProps> {
 
     // Closed stops are stored as a map with route ID as the key; we just want a set
     // of all the stop values
-    const closedStopsSet = new Set(
-      closedStops?.values().flatMap((v) => v.values())
-    )
+    const closedStopsSet = closedStops
+      ? flattenStopClosures(closedStops)
+      : new Set()
 
     const scooters = rentalVehicles.filter(
       (vehicle) => vehicle.vehicleType?.formFactor === 'SCOOTER'

--- a/lib/components/map/default-map.tsx
+++ b/lib/components/map/default-map.tsx
@@ -398,7 +398,7 @@ class DefaultMap extends Component<DefaultMapProps> {
 
     // Closed stops are stored as a map with route ID as the key; we just want a set
     // of all the stop values
-    const closedStopsSet = closedStops
+    const closedStopIds = closedStops
       ? flattenStopClosures(closedStops)
       : new Set()
 
@@ -557,7 +557,7 @@ class DefaultMap extends Component<DefaultMapProps> {
                   config.companies,
                   this.getEntityPrefix,
                   feeds,
-                  closedStopsSet
+                  closedStopIds
                 )
               default:
                 return null

--- a/lib/components/narrative/line-itin/connected-itinerary-body.js
+++ b/lib/components/narrative/line-itin/connected-itinerary-body.js
@@ -19,6 +19,7 @@ import styled from 'styled-components'
 import TransitLegSummary from '@opentripplanner/itinerary-body/lib/defaults/transit-leg-summary'
 
 import { ComponentContext } from '../../../util/contexts'
+import { flattenStopClosures } from '../../../util/itinerary'
 import { formatDuration } from '../../../components/util/formatted-duration'
 import { MainPanelContent } from '../../../actions/ui-constants'
 import { setLegDiagram, setMapillaryId } from '../../../actions/map'
@@ -71,6 +72,7 @@ class ConnectedItineraryBody extends Component {
   render() {
     const {
       accessibilityScoreGradationMap,
+      closedStops,
       config,
       diagramVisible,
       itinerary,
@@ -83,6 +85,9 @@ class ConnectedItineraryBody extends Component {
     } = this.props
     const { RouteDescriptionFooter } = this.context
     const clonedItinerary = clone(itinerary)
+    const closedStopIds = closedStops
+      ? flattenStopClosures(closedStops)
+      : new Set()
 
     const showViewTripButton = !config?.itinerary?.hideViewTripButton
     const allowUserAlertCollapsing = config?.itinerary?.allowUserAlertCollapsing
@@ -126,6 +131,7 @@ class ConnectedItineraryBody extends Component {
           accessibilityScoreGradationMap={accessibilityScoreGradationMap}
           alwaysCollapseAlerts={allowUserAlertCollapsing}
           className="itin-body"
+          closedStopIds={closedStopIds}
           config={config}
           diagramVisible={diagramVisible}
           itinerary={clonedItinerary}
@@ -167,6 +173,7 @@ class ConnectedItineraryBody extends Component {
 
 const mapStateToProps = (state) => {
   return {
+    closedStops: state.otp.ui.stopClosures.closedStops,
     config: state.otp.config,
     diagramVisible: state.otp.ui.diagramLeg
   }

--- a/lib/components/narrative/narrative-itineraries.js
+++ b/lib/components/narrative/narrative-itineraries.js
@@ -160,6 +160,7 @@ class NarrativeItineraries extends Component {
     activeLeg: PropTypes.object,
     activeSearch: PropTypes.object,
     activeStep: PropTypes.object,
+    closedStops: PropTypes.array,
     containerStyle: PropTypes.object,
     customBatchUiBackground: PropTypes.bool,
     enabledSortModes: PropTypes.object,
@@ -269,6 +270,7 @@ class NarrativeItineraries extends Component {
       activeItinerary,
       activeLeg,
       activeStep,
+      closedStops,
       itineraryIsExpanded,
       realtimeEffects,
       setActiveItinerary,
@@ -303,6 +305,7 @@ class NarrativeItineraries extends Component {
           active={active}
           activeLeg={activeLeg}
           activeStep={activeStep}
+          closedStops={closedStops}
           expanded={showDetails}
           index={itinerary.index}
           itinerary={itinerary}
@@ -530,7 +533,7 @@ class NarrativeItineraries extends Component {
 
 // connect to the redux store
 const mapStateToProps = (state) => {
-  const { config, filter } = state.otp
+  const { config, filter, ui } = state.otp
   const { co2, itinerary, modes } = config
   const { sort } = filter
 
@@ -580,6 +583,7 @@ const mapStateToProps = (state) => {
     activeLeg: activeSearch?.activeLeg,
     activeSearch,
     activeStep: activeSearch?.activeStep,
+    closedStops: ui.stopClosures.closedStops,
     co2Config: co2,
     customBatchUiBackground,
     enabledSortModes: sortModes,

--- a/lib/util/itinerary.tsx
+++ b/lib/util/itinerary.tsx
@@ -461,3 +461,12 @@ export function copyAndRemoveRouteModeOverrides(
     }))
   }
 }
+
+/** Take a Map<string, Set<string>> of routes and their closed stops
+ * and flatten to a Set<string> of just stop IDs
+ */
+export function flattenStopClosures(
+  map: Map<string, Set<string>>
+): Set<string> {
+  return new Set(map.values().flatMap((v) => v.values()))
+}

--- a/lib/util/itinerary.tsx
+++ b/lib/util/itinerary.tsx
@@ -468,5 +468,7 @@ export function copyAndRemoveRouteModeOverrides(
 export function flattenStopClosures(
   map: Map<string, Set<string>>
 ): Set<string> {
-  return new Set(map.values().flatMap((v) => v.values()))
+  return new Set(
+    Array.from(map.values()).flatMap((v) => Array.from(v.values()))
+  )
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@opentripplanner/geocoder": "^3.1.2",
     "@opentripplanner/humanize-distance": "^2.1.1",
     "@opentripplanner/icons": "4.1.4",
-    "@opentripplanner/itinerary-body": "9.6.0",
+    "@opentripplanner/itinerary-body": "9.7.0",
     "@opentripplanner/location-field": "4.1.7",
     "@opentripplanner/location-icon": "^2.0.0",
     "@opentripplanner/map-popup": "8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3174,10 +3174,10 @@
     "@opentripplanner/core-utils" "^16.0.3"
     prop-types "^15.7.2"
 
-"@opentripplanner/itinerary-body@9.6.0", "@opentripplanner/itinerary-body@^9.3.1":
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/itinerary-body/-/itinerary-body-9.6.0.tgz#4dddd7087d64acb305b5f805054516433f1f8df4"
-  integrity sha512-drW1f6aWOeh0ooTKIjalpGiLJ05vdVqEh4aAXQwVAf6F6S3Eh5qccMvg49OI1vLE7hL0Nt7Q2vWAp8BioWtzmA==
+"@opentripplanner/itinerary-body@9.7.0":
+  version "9.7.0"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/itinerary-body/-/itinerary-body-9.7.0.tgz#da96b0f1f3a36b7a36afdd3350e7942021b312f8"
+  integrity sha512-2SMlRscZ+1HtFGJGKIgzA1vTHcJt1Dr9tcJ6gBG60iBcL+S6sd+wHUXSAxcQSqqxMC52J/mtTqjOqD/dhWlAQQ==
   dependencies:
     "@opentripplanner/building-blocks" "^3.2.0"
     "@opentripplanner/core-utils" "^16.1.0"
@@ -3194,7 +3194,7 @@
     react-resize-detector "^4.2.1"
     string-similarity "^4.0.4"
 
-"@opentripplanner/itinerary-body@^9.6.0":
+"@opentripplanner/itinerary-body@^9.3.1", "@opentripplanner/itinerary-body@^9.6.0":
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/@opentripplanner/itinerary-body/-/itinerary-body-9.6.0.tgz#4dddd7087d64acb305b5f805054516433f1f8df4"
   integrity sha512-drW1f6aWOeh0ooTKIjalpGiLJ05vdVqEh4aAXQwVAf6F6S3Eh5qccMvg49OI1vLE7hL0Nt7Q2vWAp8BioWtzmA==


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Passes closed stops information to the updated itinerary view for display in transit itineraries. Requires opentripplanner/otp-ui#986

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

