### PR TITLE
Include annotation on closed stops in nearby view

### DIFF
--- a/__tests__/components/viewers/__snapshots__/nearby-view.js.snap
+++ b/__tests__/components/viewers/__snapshots__/nearby-view.js.snap
@@ -6072,6 +6072,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                     tabIndex={0}
                   >
                     <Connect(Stop)
+                      closed={false}
                       fromToSlot={
                         <Memo(Connect(FromToPicker))
                           place={
@@ -7213,6 +7214,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       }
                     >
                       <Stop
+                        closed={false}
                         dispatch={[Function]}
                         fromToSlot={
                           <Memo(Connect(FromToPicker))
@@ -8379,6 +8381,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                   id="components.StopViewer.viewSchedule"
                                 />
                               }
+                              closed={false}
                               fromToSlot={
                                 <Memo(Connect(FromToPicker))
                                   place={
@@ -9538,6 +9541,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                     id="components.StopViewer.viewSchedule"
                                   />
                                 }
+                                closed={false}
                                 dispatch={[Function]}
                                 fromToSlot={
                                   <Memo(Connect(FromToPicker))
@@ -15220,6 +15224,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                     tabIndex={0}
                   >
                     <Connect(Stop)
+                      closed={false}
                       fromToSlot={
                         <Memo(Connect(FromToPicker))
                           place={
@@ -15959,6 +15964,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       }
                     >
                       <Stop
+                        closed={false}
                         dispatch={[Function]}
                         fromToSlot={
                           <Memo(Connect(FromToPicker))
@@ -16723,6 +16729,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                   id="components.StopViewer.viewSchedule"
                                 />
                               }
+                              closed={false}
                               fromToSlot={
                                 <Memo(Connect(FromToPicker))
                                   place={
@@ -17480,6 +17487,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                     id="components.StopViewer.viewSchedule"
                                   />
                                 }
+                                closed={false}
                                 dispatch={[Function]}
                                 fromToSlot={
                                   <Memo(Connect(FromToPicker))
@@ -22989,6 +22997,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                     tabIndex={0}
                   >
                     <Connect(Stop)
+                      closed={false}
                       fromToSlot={
                         <Memo(Connect(FromToPicker))
                           place={
@@ -24284,6 +24293,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       }
                     >
                       <Stop
+                        closed={false}
                         dispatch={[Function]}
                         fromToSlot={
                           <Memo(Connect(FromToPicker))
@@ -25604,6 +25614,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                   id="components.StopViewer.viewSchedule"
                                 />
                               }
+                              closed={false}
                               fromToSlot={
                                 <Memo(Connect(FromToPicker))
                                   place={
@@ -26917,6 +26928,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                     id="components.StopViewer.viewSchedule"
                                   />
                                 }
+                                closed={false}
                                 dispatch={[Function]}
                                 fromToSlot={
                                   <Memo(Connect(FromToPicker))
@@ -35563,6 +35575,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                     tabIndex={0}
                   >
                     <Connect(Stop)
+                      closed={false}
                       fromToSlot={
                         <Memo(Connect(FromToPicker))
                           place={
@@ -36302,6 +36315,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       }
                     >
                       <Stop
+                        closed={false}
                         dispatch={[Function]}
                         fromToSlot={
                           <Memo(Connect(FromToPicker))
@@ -37066,6 +37080,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                   id="components.StopViewer.viewSchedule"
                                 />
                               }
+                              closed={false}
                               fromToSlot={
                                 <Memo(Connect(FromToPicker))
                                   place={
@@ -37823,6 +37838,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                     id="components.StopViewer.viewSchedule"
                                   />
                                 }
+                                closed={false}
                                 dispatch={[Function]}
                                 fromToSlot={
                                   <Memo(Connect(FromToPicker))
@@ -42488,6 +42504,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                     tabIndex={0}
                   >
                     <Connect(Stop)
+                      closed={false}
                       fromToSlot={
                         <Memo(Connect(FromToPicker))
                           place={
@@ -43577,6 +43594,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       }
                     >
                       <Stop
+                        closed={false}
                         dispatch={[Function]}
                         fromToSlot={
                           <Memo(Connect(FromToPicker))
@@ -44691,6 +44709,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                   id="components.StopViewer.viewSchedule"
                                 />
                               }
+                              closed={false}
                               fromToSlot={
                                 <Memo(Connect(FromToPicker))
                                   place={
@@ -45798,6 +45817,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                     id="components.StopViewer.viewSchedule"
                                   />
                                 }
+                                closed={false}
                                 dispatch={[Function]}
                                 fromToSlot={
                                   <Memo(Connect(FromToPicker))
@@ -49828,6 +49848,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                     tabIndex={0}
                   >
                     <Connect(Stop)
+                      closed={false}
                       fromToSlot={
                         <Memo(Connect(FromToPicker))
                           place={
@@ -51123,6 +51144,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       }
                     >
                       <Stop
+                        closed={false}
                         dispatch={[Function]}
                         fromToSlot={
                           <Memo(Connect(FromToPicker))
@@ -52443,6 +52465,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                   id="components.StopViewer.viewSchedule"
                                 />
                               }
+                              closed={false}
                               fromToSlot={
                                 <Memo(Connect(FromToPicker))
                                   place={
@@ -53756,6 +53779,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                     id="components.StopViewer.viewSchedule"
                                   />
                                 }
+                                closed={false}
                                 dispatch={[Function]}
                                 fromToSlot={
                                   <Memo(Connect(FromToPicker))
@@ -62437,6 +62461,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                     tabIndex={0}
                   >
                     <Connect(Stop)
+                      closed={false}
                       fromToSlot={
                         <Memo(Connect(FromToPicker))
                           place={
@@ -63578,6 +63603,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                       }
                     >
                       <Stop
+                        closed={false}
                         dispatch={[Function]}
                         fromToSlot={
                           <Memo(Connect(FromToPicker))
@@ -64744,6 +64770,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                   id="components.StopViewer.viewSchedule"
                                 />
                               }
+                              closed={false}
                               fromToSlot={
                                 <Memo(Connect(FromToPicker))
                                   place={
@@ -65903,6 +65930,7 @@ exports[`components > viewers > nearby view renders proper scooter dates 1`] = `
                                     id="components.StopViewer.viewSchedule"
                                   />
                                 }
+                                closed={false}
                                 dispatch={[Function]}
                                 fromToSlot={
                                   <Memo(Connect(FromToPicker))

--- a/__tests__/components/viewers/__snapshots__/stop-schedule-viewer.ts.snap
+++ b/__tests__/components/viewers/__snapshots__/stop-schedule-viewer.ts.snap
@@ -177,7 +177,7 @@ exports[`components > viewers > stop viewer should render with initial stop id a
               >
                 <styled.div>
                   <div
-                    className="sc-jNMcJZ gfdJGc"
+                    className="sc-dOSRxR cQrpcq"
                   >
                     <styled.div>
                       <div

--- a/i18n/en-US.yml
+++ b/i18n/en-US.yml
@@ -42,6 +42,7 @@ actions:
       expired. Please request a new code and try again.
     tripDeleted: Your trip has been deleted.
 common:
+  closedStop: Closed Stop
   coordinates: "{lat}, {lon}"
   currentlySelected: " (Currently selected)"
   dateExpressions:

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -55,6 +55,7 @@ actions:
       réessayez.
     tripDeleted: Votre trajet a été supprimé.
 common:
+  closedStop: Closed Stop
   coordinates: "{lat}; {lon}"
   currentlySelected: " (actuellement sélectionné)"
   dateExpressions:

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -12,11 +12,11 @@ import {
 } from 'react-intl'
 import { Leaf } from '@styled-icons/fa-solid/Leaf'
 import clone from 'clone'
-import colors from '@opentripplanner/building-blocks'
 import coreUtils from '@opentripplanner/core-utils'
 import React from 'react'
 import styled from 'styled-components'
 
+import { CANCELED_TRIP_RED } from '../../util/colors'
 import { ComponentContext } from '../../../util/contexts'
 import {
   getFare,
@@ -95,7 +95,7 @@ const ItinerarySummaryWrapper = styled.div`
 `
 
 const CanceledTripMessage = styled.div`
-  color: ${colors.red[700]};
+  color: ${CANCELED_TRIP_RED};
 `
 
 const ITINERARY_ATTRIBUTES = [

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -16,8 +16,8 @@ import coreUtils from '@opentripplanner/core-utils'
 import React from 'react'
 import styled from 'styled-components'
 
-import { CANCELED_TRIP_RED } from '../../util/colors'
 import { ComponentContext } from '../../../util/contexts'
+import { DISABLED_RED } from '../../util/colors'
 import {
   getFare,
   getFirstLegStartTime,
@@ -95,7 +95,7 @@ const ItinerarySummaryWrapper = styled.div`
 `
 
 const CanceledTripMessage = styled.div`
-  color: ${CANCELED_TRIP_RED};
+  color: ${DISABLED_RED};
 `
 
 const ITINERARY_ATTRIBUTES = [

--- a/lib/components/narrative/default/default-itinerary.js
+++ b/lib/components/narrative/default/default-itinerary.js
@@ -16,8 +16,8 @@ import coreUtils from '@opentripplanner/core-utils'
 import React from 'react'
 import styled from 'styled-components'
 
+import { CLOSED_OR_CANCELED_RED } from '../../util/colors'
 import { ComponentContext } from '../../../util/contexts'
-import { DISABLED_RED } from '../../util/colors'
 import {
   getFare,
   getFirstLegStartTime,
@@ -95,7 +95,7 @@ const ItinerarySummaryWrapper = styled.div`
 `
 
 const CanceledTripMessage = styled.div`
-  color: ${DISABLED_RED};
+  color: ${CLOSED_OR_CANCELED_RED};
 `
 
 const ITINERARY_ATTRIBUTES = [

--- a/lib/components/util/colors.ts
+++ b/lib/components/util/colors.ts
@@ -33,6 +33,10 @@ const GREY_ON_WHITE = grey[700]
  */
 const BLUE_ON_WHITE = blue[800]
 
+const CANCELED_TRIP_RED = red[700]
+
+const CLOSED_STOP_RED = red[700]
+
 const DARK_TEXT_GREY = '#333333'
 
 const DEFAULT_ROUTE_COLOR = grey[800]
@@ -49,6 +53,8 @@ export {
   grey,
   red,
   blue,
+  CANCELED_TRIP_RED,
+  CLOSED_STOP_RED,
   DARK_TEXT_GREY,
   DEFAULT_ROUTE_COLOR,
   ELEVATION_BLUE,

--- a/lib/components/util/colors.ts
+++ b/lib/components/util/colors.ts
@@ -33,9 +33,7 @@ const GREY_ON_WHITE = grey[700]
  */
 const BLUE_ON_WHITE = blue[800]
 
-const CANCELED_TRIP_RED = red[700]
-
-const CLOSED_STOP_RED = red[700]
+const DISABLED_RED = red[700]
 
 const DARK_TEXT_GREY = '#333333'
 
@@ -53,8 +51,7 @@ export {
   grey,
   red,
   blue,
-  CANCELED_TRIP_RED,
-  CLOSED_STOP_RED,
+  DISABLED_RED,
   DARK_TEXT_GREY,
   DEFAULT_ROUTE_COLOR,
   ELEVATION_BLUE,

--- a/lib/components/util/colors.ts
+++ b/lib/components/util/colors.ts
@@ -33,7 +33,7 @@ const GREY_ON_WHITE = grey[700]
  */
 const BLUE_ON_WHITE = blue[800]
 
-const DISABLED_RED = red[700]
+const CLOSED_OR_CANCELED_RED = red[700]
 
 const DARK_TEXT_GREY = '#333333'
 
@@ -51,7 +51,7 @@ export {
   grey,
   red,
   blue,
-  DISABLED_RED,
+  CLOSED_OR_CANCELED_RED,
   DARK_TEXT_GREY,
   DEFAULT_ROUTE_COLOR,
   ELEVATION_BLUE,

--- a/lib/components/viewers/nearby/nearby-view.tsx
+++ b/lib/components/viewers/nearby/nearby-view.tsx
@@ -28,6 +28,7 @@ import {
   NearbyFilterKey,
   NearbyFilters
 } from '../../../util/state-types'
+import { flattenStopClosures } from '../../../util/itinerary'
 import { GeocoderConfig, NearbyFilterConfig } from '../../../util/config-types'
 import { getCurrentServiceWeek } from '../../../util/current-service-week'
 import { grey } from '../../util/colors'
@@ -64,6 +65,7 @@ type ServiceWeek = { end: string; start: string }
 
 type Props = {
   activeNearbyFilters: NearbyFilters
+  closedStops?: Map<string, Set<string>>
   currentPosition?: CurrentPosition
   currentServiceWeek?: ServiceWeek
   defaultLatLon: LatLonObj | null
@@ -98,8 +100,13 @@ type Props = {
   zoomToPlace: ZoomToPlaceHandler
 }
 
-const getNearbyItem = (place: any, feeds?: any[]) => {
+const getNearbyItem = (
+  place: any,
+  closedStops?: Set<string>,
+  feeds?: any[]
+) => {
   const placeForFromTo = { ...place }
+  let closed = false
   if (place.__typename === 'Stop' && feeds) {
     const feedId = place.gtfsId.split(':')[0]
     const feed = feeds.find((f) => f.feedId === feedId)
@@ -108,6 +115,7 @@ const getNearbyItem = (place: any, feeds?: any[]) => {
       feedName && place.code
         ? `${place.name} (${feedName} ${place.code})`
         : place.name
+    closed = place.gtfsId && closedStops && closedStops.has(place.gtfsId)
   }
   const fromTo = (
     <FromToPicker
@@ -120,7 +128,7 @@ const getNearbyItem = (place: any, feeds?: any[]) => {
     case 'RentalVehicle':
       return <Vehicle fromToSlot={fromTo} vehicle={place} />
     case 'Stop':
-      return <Stop fromToSlot={fromTo} stopData={place} />
+      return <Stop closed={closed} fromToSlot={fromTo} stopData={place} />
     case 'VehicleParking':
       return <VehicleParking fromToSlot={fromTo} place={place} />
     case 'BikeRentalStation':
@@ -165,6 +173,7 @@ function getNearbyCoordsFromUrlOrLocationOrMapCenter(
 // eslint-disable-next-line complexity
 function NearbyView({
   activeNearbyFilters,
+  closedStops,
   currentPosition,
   currentServiceWeek,
   defaultLatLon,
@@ -197,6 +206,11 @@ function NearbyView({
   const [loading, setLoading] = useState(true)
   const [reversedPoint, setReversedPoint] = useState('')
   const [locationInputFocused, setLocationInputFocused] = useState(false)
+
+  const closedStopsSet = useMemo(
+    () => (closedStops ? flattenStopClosures(closedStops) : new Set<string>()),
+    [closedStops]
+  )
 
   const nearbyContainerRef = useRef<HTMLOListElement>(null)
   const finalNearbyCoords = useMemo(
@@ -374,6 +388,7 @@ function NearbyView({
         >
           {getNearbyItem(
             { ...n.place, distance: n.distance, nearbyRoutes },
+            closedStopsSet,
             feeds
           )}
         </div>
@@ -528,7 +543,7 @@ const mapStateToProps = (state: AppReduxState) => {
   const { config, location, transitIndex, ui } = state.otp
   const { map, nearbyView: nearbyViewConfig, routeViewer } = config
   const transitOperators = config?.transitOperators || []
-  const { nearbyView, nearbyViewCoords } = ui
+  const { nearbyView, nearbyViewCoords, stopClosures } = ui
   const { nearby } = transitIndex
   const { entityId } = state.router.location.query
   const { currentPosition, sessionSearches } = location
@@ -557,6 +572,7 @@ const mapStateToProps = (state: AppReduxState) => {
 
   return {
     activeNearbyFilters: filters,
+    closedStops: stopClosures.closedStops,
     currentPosition,
     currentServiceWeek,
     defaultLatLon,

--- a/lib/components/viewers/nearby/stop-card-header.tsx
+++ b/lib/components/viewers/nearby/stop-card-header.tsx
@@ -7,7 +7,7 @@ import React, { ComponentType } from 'react'
 import styled from 'styled-components'
 
 import { AppReduxState } from '../../../util/state-types'
-import { CLOSED_STOP_RED } from '../../util/colors'
+import { DISABLED_RED } from '../../util/colors'
 import { Icon, IconWithText } from '../../util/styledIcon'
 import { StopData } from '../../util/types'
 import Strong from '../../util/strong-text'
@@ -18,7 +18,7 @@ import DistanceDisplay from './distance-display'
 
 const ClosedStopContainer = styled.div`
   align-items: center;
-  color: ${CLOSED_STOP_RED};
+  color: ${DISABLED_RED};
   display: flex;
   gap: 5px;
 `

--- a/lib/components/viewers/nearby/stop-card-header.tsx
+++ b/lib/components/viewers/nearby/stop-card-header.tsx
@@ -1,10 +1,13 @@
 import { connect } from 'react-redux'
+import { ExclamationTriangle } from '@styled-icons/fa-solid'
 import { FormattedMessage, useIntl } from 'react-intl'
 import { Search } from '@styled-icons/fa-solid/Search'
 import { TransitOperator } from '@opentripplanner/types'
 import React, { ComponentType } from 'react'
+import styled from 'styled-components'
 
 import { AppReduxState } from '../../../util/state-types'
+import { CLOSED_STOP_RED } from '../../util/colors'
 import { Icon, IconWithText } from '../../util/styledIcon'
 import { StopData } from '../../util/types'
 import Strong from '../../util/strong-text'
@@ -13,11 +16,19 @@ import TransitOperatorLogos from '../../util/transit-operator-icons'
 import { ActionLink, CardBody, CardHeader, CardTitle } from './styled'
 import DistanceDisplay from './distance-display'
 
+const ClosedStopContainer = styled.div`
+  align-items: center;
+  color: ${CLOSED_STOP_RED};
+  display: flex;
+  gap: 5px;
+`
+
 type Props = {
   actionIcon: ComponentType
   actionParams?: Record<string, unknown>
   actionPath?: string
   actionText?: JSX.Element
+  closed?: boolean
   fromToSlot: JSX.Element
   onZoomClick?: () => void
   stopData: StopData & { distance?: number }
@@ -30,6 +41,7 @@ const StopCardHeader = ({
   actionParams,
   actionPath,
   actionText,
+  closed,
   fromToSlot,
   onZoomClick,
   stopData,
@@ -76,6 +88,12 @@ const StopCardHeader = ({
         <DistanceDisplay distance={stopData.distance} />
       </CardHeader>
       <CardBody>
+        {closed && (
+          <ClosedStopContainer>
+            <ExclamationTriangle size={15} />
+            <FormattedMessage id="common.closedStop" />
+          </ClosedStopContainer>
+        )}
         {(stopData.code || actionPath) && (
           // TODO: Clean up these conditionals -- perhaps grid one level higher?
           <div style={{ display: 'grid', height: 20 }}>

--- a/lib/components/viewers/nearby/stop-card-header.tsx
+++ b/lib/components/viewers/nearby/stop-card-header.tsx
@@ -7,7 +7,7 @@ import React, { ComponentType } from 'react'
 import styled from 'styled-components'
 
 import { AppReduxState } from '../../../util/state-types'
-import { DISABLED_RED } from '../../util/colors'
+import { CLOSED_OR_CANCELED_RED } from '../../util/colors'
 import { Icon, IconWithText } from '../../util/styledIcon'
 import { StopData } from '../../util/types'
 import Strong from '../../util/strong-text'
@@ -18,7 +18,7 @@ import DistanceDisplay from './distance-display'
 
 const ClosedStopContainer = styled.div`
   align-items: center;
-  color: ${DISABLED_RED};
+  color: ${CLOSED_OR_CANCELED_RED};
   display: flex;
   gap: 5px;
 `

--- a/lib/components/viewers/nearby/stop.tsx
+++ b/lib/components/viewers/nearby/stop.tsx
@@ -49,6 +49,7 @@ const ChildStopHeader = styled.div`
 `
 
 type Props = {
+  closed?: boolean
   fromToSlot: JSX.Element
   homeTimezone: string
   nearbyViewConfig?: NearbyViewConfig
@@ -136,6 +137,7 @@ const renderPatternRows = (
 }
 
 const Stop = ({
+  closed,
   fromToSlot,
   homeTimezone,
   nearbyViewConfig,
@@ -171,6 +173,7 @@ const Stop = ({
             <FormattedMessage id="components.StopViewer.viewSchedule" />
           ) : undefined
         }
+        closed={closed}
         fromToSlot={fromToSlot}
         stopData={stopData}
       />

--- a/lib/util/itinerary.tsx
+++ b/lib/util/itinerary.tsx
@@ -461,3 +461,12 @@ export function copyAndRemoveRouteModeOverrides(
     }))
   }
 }
+
+/** Take a Map<string, Set<string>> of routes and their closed stops
+ * and flatten to a Set<string> of just stop IDs
+ */
+export function flattenStopClosures(
+  map: Map<string, Set<string>>
+): Set<string> {
+  return new Set(map.values().flatMap((v) => v.values()))
+}

--- a/lib/util/itinerary.tsx
+++ b/lib/util/itinerary.tsx
@@ -468,5 +468,7 @@ export function copyAndRemoveRouteModeOverrides(
 export function flattenStopClosures(
   map: Map<string, Set<string>>
 ): Set<string> {
-  return new Set(map.values().flatMap((v) => v.values()))
+  return new Set(
+    Array.from(map.values()).flatMap((v) => Array.from(v.values()))
+  )
 }


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Show a warning in the nearby view card when a stop is closed.

<img width="490" height="250" alt="Screenshot 2026-08-31 at 3 16 59 PM" src="https://github.com/user-attachments/assets/953439dc-7914-4b12-a808-82d7e965db08" />

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [x] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [x] Are all languages supported (Internationalization/Localization)?
- [x] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

