### PR TITLE
Fix Route Long Name Display Logic

### DIFF
--- a/lib/components/narrative/metro/route-block.tsx
+++ b/lib/components/narrative/metro/route-block.tsx
@@ -146,6 +146,9 @@ const RouteBlock = ({
   }
   const showModeIcon = leg.mode !== previousLegMode
 
+  const longNameExists =
+    leg.routeLongName || (typeof leg.route === 'object' && leg.route.longName)
+
   return (
     <>
       {showDivider && previousLegMode && (
@@ -170,7 +173,7 @@ const RouteBlock = ({
             })}
           </MultiWrapper>
         )}
-        {!hideLongName && (leg.routeLongName || leg.route?.longName) && (
+        {!hideLongName && longNameExists && (
           <MultiRouteLongName>
             <RouteLongName className="route-block-route-long-name" leg={leg} />
             {Object.entries(leg?.alternateRoutes || {})?.length > 0 && (

--- a/lib/components/narrative/metro/route-block.tsx
+++ b/lib/components/narrative/metro/route-block.tsx
@@ -170,7 +170,7 @@ const RouteBlock = ({
             })}
           </MultiWrapper>
         )}
-        {!hideLongName && leg.routeLongName && (
+        {!hideLongName && (leg.routeLongName || leg.route?.longName) && (
           <MultiRouteLongName>
             <RouteLongName className="route-block-route-long-name" leg={leg} />
             {Object.entries(leg?.alternateRoutes || {})?.length > 0 && (


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Currently, route long name information can be carried in one of two ways in an itinerary leg:
- Directly on the leg object (`leg.routeLongName`), or
- As part of the `route` object on the leg (`leg.route.longName`)

This can be seen [here in OTP-UI](https://github.com/opentripplanner/otp-ui/blob/master/packages/core-utils/src/itinerary.ts#L888)

When the `RouteLongName` component is conditionally rendered in `RouteBlock`, one of the conditions is that `leg.routeLongName` is truthy. This is not accommodating to the `route` object approach; the change here fixes that.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

