### PR TITLE
Map Layer Default Icon

### DIFF
--- a/lib/components/map/connected-geojson-layer.tsx
+++ b/lib/components/map/connected-geojson-layer.tsx
@@ -9,6 +9,21 @@ import React, { useEffect, useState } from 'react'
 import * as mapActions from '../../actions/map'
 import { SetLocationHandler } from '../util/types'
 
+const DefaultMapIcon = (name: string, className?: string) => (
+  <svg
+    aria-labelledby="svg-title"
+    className={className}
+    fill="currentColor"
+    height="16"
+    viewBox="0 0 16 16"
+    width="16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title id="svg-title">{name}</title>
+    <path d="M8 16s6-5.686 6-10A6 6 0 0 0 2 6c0 4.314 6 10 6 10m0-7a3 3 0 1 1 0-6 3 3 0 0 1 0 6" />
+  </svg>
+)
+
 type Props = {
   setLocation: SetLocationHandler
   url: string
@@ -67,11 +82,15 @@ const GeoJSONOverlay = (props: Props) => {
             popupProps={{ offset: 10 }}
             position={[geometry.coordinates[1], geometry.coordinates[0]]}
           >
-            <img
-              alt={properties.Name}
-              className={properties.className}
-              src={properties.icon}
-            />
+            {properties.icon ? (
+              <img
+                alt={properties.Name}
+                className={properties.className}
+                src={properties.icon}
+              />
+            ) : (
+              DefaultMapIcon(properties.Name, properties.className)
+            )}
           </MarkerWithPopup>
         )
       })}


### PR DESCRIPTION
<!--Please provide a brief description of what this PR accomplishes and note if it should be considered/merged with any related PR(s)-->
**Description:**
Currently, geojson-based map layers require the geojson objects to include an `icon` property that points to a URL, which is used as the `src` attribute on an `img` tag. This PR introduces a default SVG to use when the `icon` property is not present on the geojson, allowing for simple map layers to be added that don't require publicly-hosted images.

This could also be extended to allow for multiple "default" icons using a known set of keys, similar to the way that we handle the icons in the mode selector buttons.

<!--Check the following are met before requesting a review. Leave unchecked if unapplicable-->
**PR Checklist:**
- [ ] Does the code follow accessibility standards (WCAG 2.1 AA Compliant)?
- [ ] Are all languages supported (Internationalization/Localization)?
- [ ] Are appropriate Typescript types implemented?

<!--(Optional) Before and after screenshots for visual changes:-->
<!--| Before | After |
    |--------|-------|
    |        |       | -->

